### PR TITLE
Fix readTerrestrials broken with 4a2fd0ee

### DIFF
--- a/lib/dvb/db.cpp
+++ b/lib/dvb/db.cpp
@@ -1457,7 +1457,7 @@ PyObject *eDVBDB::readTerrestrials(ePyObject ter_list, ePyObject tp_dict)
 
 					if (dest)
 					{
-						tmp = strtol((const char*)attr->name, &end_ptr, 10);
+						tmp = strtol((const char*)attr->children->content, &end_ptr, 10);
 						if (!*end_ptr)
 						{
 							*dest = tmp;


### PR DESCRIPTION
Fix readTerrestrials by parsing attribute value not the name