### PR TITLE
Fix conflict timers (step 1)

### DIFF
--- a/lib/python/Components/TimerList.py
+++ b/lib/python/Components/TimerList.py
@@ -48,7 +48,7 @@ class TimerList(HTMLComponent, GUIComponent, object):
 		else:
 			text = repeatedtext + ((" %s ... %s (%d " + _("mins") + ")") % (begin[1], FuzzyTime(timer.end)[1], (timer.end - timer.begin) / 60))
 		icon = None
-		if not processed:
+		if not processed and not timer.disabled:
 			if timer.state == TimerEntry.StateWaiting:
 				state = _("waiting")
 				icon = self.iconWait


### PR DESCRIPTION
see this
http://forums.openpli.org/topic/23062-timer-bug/?view=findpost&p=499669

step 1:
If timer.disabled --> timer.state == TimerEntry.StateEnded
don't show icon "Done"