### PR TITLE
By some dvd's resume does work.

### DIFF
--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -2856,8 +2856,7 @@ class InfoBarCueSheetSupport:
 		print "new service started! trying to download cuts!"
 		self.downloadCuesheet()
 
-		service = self.session.nav.getCurrentlyPlayingServiceOrGroup()
-		if self.ENABLE_RESUME_SUPPORT and not(service and service.toString().startswith("4369:")): #when resume support and not a DVD
+		if self.ENABLE_RESUME_SUPPORT:
 			for (pts, what) in self.cut_list:
 				if what == self.CUT_TYPE_LAST:
 					last = pts

--- a/lib/service/servicedvd.cpp
+++ b/lib/service/servicedvd.cpp
@@ -1099,7 +1099,14 @@ void eServiceDVD::saveCuesheet()
 			}
 		}
 		eDebug("[eServiceDVD] saveCuesheet filename=%s",filename);
-		f = fopen(filename, "wb");
+		/* CVR it does not make sense to keep a resume file with position 0 */
+		if (m_cue_pts == 0)
+		{
+			if (::access(filename, F_OK) == 0)
+				remove(filename);
+		}
+		else
+			f = fopen(filename, "wb");
 	}
 
 	if (f)

--- a/lib/service/servicedvd.cpp
+++ b/lib/service/servicedvd.cpp
@@ -1098,7 +1098,6 @@ void eServiceDVD::saveCuesheet()
 				strcpy(filename, "/home/root/dvd-untitled.cuts");
 			}
 		}
-		eDebug("[eServiceDVD] saveCuesheet filename=%s",filename);
 		/* CVR it does not make sense to keep a resume file with position 0 */
 		if (m_cue_pts == 0)
 		{
@@ -1106,7 +1105,10 @@ void eServiceDVD::saveCuesheet()
 				remove(filename);
 		}
 		else
+		{
+			eDebug("[eServiceDVD] saveCuesheet filename=%s",filename);
 			f = fopen(filename, "wb");
+		}
 	}
 
 	if (f)


### PR DESCRIPTION
 Restore the abilyty to resume by dvd.By some dvd's it does work.
 By other dvd's not.

 When there is no resume postion or it is 0 ,
 No need to save a resume.cuts file or keep one with 0.

	modified:   lib/python/Screens/InfoBarGenerics.py
	modified:   lib/service/servicedvd.cpp