### PR TITLE
Fix title translation parsing in InputBox and LocationBox

### DIFF
--- a/lib/python/Screens/InputBox.py
+++ b/lib/python/Screens/InputBox.py
@@ -9,12 +9,14 @@ from Tools.Notifications import AddPopup
 from time import time
 
 class InputBox(Screen):
-	def __init__(self, session, title = "", windowTitle = "Input", useableChars = None, **kwargs):
+	def __init__(self, session, title = "", windowTitle = None, useableChars = None, **kwargs):
 		Screen.__init__(self, session)
 
 		self["text"] = Label(title)
 		self["input"] = Input(**kwargs)
-		self.onShown.append(boundFunction(self.setTitle, _(windowTitle)))
+		if windowTitle is None:
+			windowTitle = _("Input")
+		self.onShown.append(boundFunction(self.setTitle, windowTitle))
 		if useableChars is not None:
 			self["input"].setUseableChars(useableChars)
 

--- a/lib/python/Screens/LocationBox.py
+++ b/lib/python/Screens/LocationBox.py
@@ -50,7 +50,7 @@ class LocationBox(Screen, NumericalTextInput, HelpableScreen):
 			<widget name="key_blue" position="405,415" zPosition="2" size="135,40" halign="center" valign="center" font="Regular;22" transparent="1" shadowColor="black" shadowOffset="-1,-1" />
 		</screen>"""
 
-	def __init__(self, session, text = "", filename = "", currDir = None, bookmarks = None, userMode = False, windowTitle = "Select location", minFree = None, autoAdd = False, editDir = False, inhibitDirs = [], inhibitMounts = []):
+	def __init__(self, session, text = "", filename = "", currDir = None, bookmarks = None, userMode = False, windowTitle = None, minFree = None, autoAdd = False, editDir = False, inhibitDirs = [], inhibitMounts = []):
 		# Init parents
 		Screen.__init__(self, session)
 		NumericalTextInput.__init__(self, handleTimeout = False)
@@ -165,8 +165,10 @@ class LocationBox(Screen, NumericalTextInput, HelpableScreen):
 		})
 
 		# Run some functions when shown
+		if windowTitle is None:
+			windowTitle = _("Select location")
 		self.onShown.extend((
-			boundFunction(self.setTitle, _(windowTitle)),
+			boundFunction(self.setTitle, windowTitle),
 			self.updateTarget,
 			self.showHideRename,
 		))


### PR DESCRIPTION
We can not use the gettext in function parameter, so the default title translation does not work and gettext should be used twice. Use gettext only once, when set the text. This allows also always specify the text that will be parsed when creating pot file.