### PR TITLE
DVDplayer plugin not always went away when a dvd is removed.

### DIFF
--- a/lib/python/Plugins/Extensions/DVDPlayer/plugin.py
+++ b/lib/python/Plugins/Extensions/DVDPlayer/plugin.py
@@ -28,10 +28,10 @@ def filescan_open(list, session, **kwargs):
 	from Screens import DVD
 	if len(list) == 1 and list[0].mimetype == "video/x-dvd":
 		cd = harddiskmanager.getCD()
-		if cd and (os.path.exists(os.path.join(harddiskmanager.getAutofsMountpoint(harddiskmanager.getCD()), "VIDEO_TS"))
-				or os.path.exists(os.path.join(harddiskmanager.getAutofsMountpoint(harddiskmanager.getCD()), "video_ts"))):
-			print "[DVDplayer] found device /dev/%s", " mount path ", harddiskmanager.getAutofsMountpoint(harddiskmanager.getCD())
-			session.open(DVD.DVDPlayer, dvd_device="/dev/%s" %(harddiskmanager.getAutofsMountpoint(harddiskmanager.getCD())))
+		if cd and (os.path.exists(os.path.join(harddiskmanager.getAutofsMountpoint(cd), "VIDEO_TS"))
+				or os.path.exists(os.path.join(harddiskmanager.getAutofsMountpoint(cd), "video_ts"))):
+			print "[DVDplayer] found device /dev/%s", " mount path ", harddiskmanager.getAutofsMountpoint(cd)
+			session.open(DVD.DVDPlayer, dvd_device="/dev/%s" %(harddiskmanager.getAutofsMountpoint(cd)))
 			return
 	else:
 		dvd_filelist = []
@@ -77,11 +77,11 @@ def onPartitionChange(action, partition):
 def menu(menuid, **kwargs):
 	if menuid == "mainmenu":
 		global detected_DVD
-		if detected_DVD == None or detected_DVD == True:
+		if detected_DVD:
 			cd = harddiskmanager.getCD()
-			if cd and (os.path.exists(os.path.join(harddiskmanager.getAutofsMountpoint(harddiskmanager.getCD()), "VIDEO_TS"))
-					or os.path.exists(os.path.join(harddiskmanager.getAutofsMountpoint(harddiskmanager.getCD()), "video_ts"))):
-				print "[DVDplayer] Mountpoint is present and is", harddiskmanager.getAutofsMountpoint(harddiskmanager.getCD())
+			if cd and (os.path.exists(os.path.join(harddiskmanager.getAutofsMountpoint(cd), "VIDEO_TS"))
+					or os.path.exists(os.path.join(harddiskmanager.getAutofsMountpoint(cd), "video_ts"))):
+				print "[DVDplayer] Mountpoint is present and is", harddiskmanager.getAutofsMountpoint(cd)
 				detected_DVD = True
 			else:
 				detected_DVD = False

--- a/lib/python/Plugins/Extensions/DVDPlayer/plugin.py
+++ b/lib/python/Plugins/Extensions/DVDPlayer/plugin.py
@@ -27,11 +27,12 @@ def DVDOverlay(*args, **kwargs):
 def filescan_open(list, session, **kwargs):
 	from Screens import DVD
 	if len(list) == 1 and list[0].mimetype == "video/x-dvd":
-		splitted = list[0].path.split('/')
-		if len(splitted) > 2:
-			if splitted[1] == 'media' and (splitted[2].startswith('sr') or splitted[2] == 'dvd'):
-				session.open(DVD.DVDPlayer, dvd_device="/dev/%s" %(splitted[2]))
-				return
+		cd = harddiskmanager.getCD()
+		if cd and (os.path.exists(os.path.join(harddiskmanager.getAutofsMountpoint(harddiskmanager.getCD()), "VIDEO_TS"))
+				or os.path.exists(os.path.join(harddiskmanager.getAutofsMountpoint(harddiskmanager.getCD()), "video_ts"))):
+			print "[DVDplayer] found device /dev/%s", " mount path ", harddiskmanager.getAutofsMountpoint(harddiskmanager.getCD())
+			session.open(DVD.DVDPlayer, dvd_device="/dev/%s" %(harddiskmanager.getAutofsMountpoint(harddiskmanager.getCD())))
+			return
 	else:
 		dvd_filelist = []
 		for x in list:
@@ -67,24 +68,26 @@ def onPartitionChange(action, partition):
 	if partition != harddiskmanager.getCD():
 		global detected_DVD
 		if action == 'remove':
-			print "[@] DVD removed"
+			print "[DVDplayer] DVD removed"
 			detected_DVD = False
 		elif action == 'add':
-			print "[@] DVD Inserted"
+			print "[DVDplayer] DVD Inserted"
 			detected_DVD = None
 
 def menu(menuid, **kwargs):
 	if menuid == "mainmenu":
 		global detected_DVD
-		if detected_DVD is None:
+		if detected_DVD == None or detected_DVD == True:
 			cd = harddiskmanager.getCD()
-			if cd and os.path.exists(os.path.join(harddiskmanager.getAutofsMountpoint(harddiskmanager.getCD()), "VIDEO_TS")):
+			if cd and (os.path.exists(os.path.join(harddiskmanager.getAutofsMountpoint(harddiskmanager.getCD()), "VIDEO_TS"))
+					or os.path.exists(os.path.join(harddiskmanager.getAutofsMountpoint(harddiskmanager.getCD()), "video_ts"))):
+				print "[DVDplayer] Mountpoint is present and is", harddiskmanager.getAutofsMountpoint(harddiskmanager.getCD())
 				detected_DVD = True
 			else:
 				detected_DVD = False
 			if onPartitionChange not in harddiskmanager.on_partition_list_change:
 				harddiskmanager.on_partition_list_change.append(onPartitionChange)
-		if detected_DVD:
+		if detected_DVD == True:
 			return [(_("DVD player"), play, "dvd_player", 46)]
 	return []
 

--- a/lib/python/Plugins/Extensions/DVDPlayer/plugin.py
+++ b/lib/python/Plugins/Extensions/DVDPlayer/plugin.py
@@ -77,7 +77,7 @@ def onPartitionChange(action, partition):
 def menu(menuid, **kwargs):
 	if menuid == "mainmenu":
 		global detected_DVD
-		if detected_DVD:
+		if detected_DVD is None or detected_DVD:
 			cd = harddiskmanager.getCD()
 			if cd and (os.path.exists(os.path.join(harddiskmanager.getAutofsMountpoint(cd), "VIDEO_TS"))
 					or os.path.exists(os.path.join(harddiskmanager.getAutofsMountpoint(cd), "video_ts"))):
@@ -87,7 +87,7 @@ def menu(menuid, **kwargs):
 				detected_DVD = False
 			if onPartitionChange not in harddiskmanager.on_partition_list_change:
 				harddiskmanager.on_partition_list_change.append(onPartitionChange)
-		if detected_DVD == True:
+		if detected_DVD:
 			return [(_("DVD player"), play, "dvd_player", 46)]
 	return []
 

--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -237,9 +237,11 @@ def buildMovieLocationList(bookmarks):
 		else:
 			bookmarks.append((p.tabbedDescription(), d))
 		inlist.append(d)
-	for d in last_selected_dest:
-		if d not in inlist:
-			bookmarks.append((d,d))
+# The last selected destination becomes invalid or just an empty map
+# if the concerned media (usb hdd,usb stick,cd,dvd) is removed.
+#	for d in last_selected_dest:
+#		if d not in inlist:
+#			bookmarks.append((d,d))
 
 class MovieBrowserConfiguration(ConfigListScreen,Screen):
 	skin = """

--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -237,11 +237,6 @@ def buildMovieLocationList(bookmarks):
 		else:
 			bookmarks.append((p.tabbedDescription(), d))
 		inlist.append(d)
-# The last selected destination becomes invalid or just an empty map
-# if the concerned media (usb hdd,usb stick,cd,dvd) is removed.
-#	for d in last_selected_dest:
-#		if d not in inlist:
-#			bookmarks.append((d,d))
 
 class MovieBrowserConfiguration(ConfigListScreen,Screen):
 	skin = """


### PR DESCRIPTION
 The menu item in mainmenu DVD-player. Not always went away,  up on removal
 off dvd from reader. Now it does.  Changed the hard targetting to /media/sr
 to the real detected mountpoint.

	modified:   lib/python/Plugins/Extensions/DVDPlayer/plugin.py