### PR TITLE
DVD player plugin possible gsod error.

### DIFF
--- a/lib/python/Plugins/Extensions/DVDPlayer/plugin.py
+++ b/lib/python/Plugins/Extensions/DVDPlayer/plugin.py
@@ -12,7 +12,11 @@ def main(session, **kwargs):
 
 def play(session, **kwargs):
 	from Screens import DVD
-	session.open(DVD.DVDPlayer, dvd_device=harddiskmanager.getAutofsMountpoint(harddiskmanager.getCD()))
+	if (os.path.exists(os.path.join(harddiskmanager.getAutofsMountpoint(harddiskmanager.getCD()), "VIDEO_TS"))
+			or os.path.exists(os.path.join(harddiskmanager.getAutofsMountpoint(harddiskmanager.getCD()), "video_ts"))):
+		session.open(DVD.DVDPlayer, dvd_device=harddiskmanager.getAutofsMountpoint(harddiskmanager.getCD()))
+	else:
+		return
 
 def DVDPlayer(*args, **kwargs):
 	# for backward compatibility with plugins that do "from DVDPlayer.plugin import DVDPlayer"


### PR DESCRIPTION
 When this plugin is used, in main menu item DVDplayer shows up.
 When You exit the dvd player. Remain in mainmenu and removed the dvd.
 Clicked ok, A non existend dvd tried to play
.
	modified:   lib/python/Plugins/Extensions/DVDPlayer/plugin.py