### PR TITLE
fixed file descriptor not closed when no demuxer or ts recorder is av…

### DIFF
--- a/lib/service/servicedvbrecord.cpp
+++ b/lib/service/servicedvbrecord.cpp
@@ -310,6 +310,7 @@ int eDVBServiceRecord::doRecord()
 			eDebug("[eDVBServiceRecord] NO DEMUX available!");
 			m_error = errNoDemuxAvailable;
 			m_event((iRecordableService*)this, evRecordFailed);
+			::close(fd);
 			return errNoDemuxAvailable;
 		}
 		demux->createTSRecorder(m_record);
@@ -318,6 +319,7 @@ int eDVBServiceRecord::doRecord()
 			eDebug("[eDVBServiceRecord] no ts recorder available.");
 			m_error = errNoTsRecorderAvailable;
 			m_event((iRecordableService*)this, evRecordFailed);
+			::close(fd);
 			return errNoTsRecorderAvailable;
 		}
 		m_record->setTargetFD(fd);


### PR DESCRIPTION
cppcheck reported these as:
Summary: Possible null pointer dereference: bouquet
Message: Possible null pointer dereference: bouquet