### PR TITLE
fixed incorrect use of pointer to temporary object.

### DIFF
--- a/main/bsod.cpp
+++ b/main/bsod.cpp
@@ -140,13 +140,13 @@ void bsodFatal(const char *component)
 	}
 
 	FILE *f;
-	const char* crashlog_name;
+	std::string crashlog_name;
 	std::ostringstream os;
 	os << "/media/hdd/enigma2_crash_";
 	os << time(0);
 	os << ".log";
-	crashlog_name = os.str().c_str();
-	f = fopen(crashlog_name, "wb");
+	crashlog_name = os.str();
+	f = fopen(crashlog_name.c_str(), "wb");
 
 	if (f == NULL)
 	{
@@ -155,14 +155,14 @@ void bsodFatal(const char *component)
 		 * all night long may damage the flash. Also, usually the first
 		 * crash log is the most interesting one. */
 		crashlog_name = "/home/root/enigma2_crash.log";
-		if ((access(crashlog_name, F_OK) == 0) ||
-		    ((f = fopen(crashlog_name, "wb")) == NULL))
+		if ((access(crashlog_name.c_str(), F_OK) == 0) ||
+		    ((f = fopen(crashlog_name.c_str(), "wb")) == NULL))
 		{
 			/* Re-write the same file in /tmp/ because it's expected to
 			 * be in RAM. So the first crash log will end up in /home
 			 * and the last in /tmp */
 			crashlog_name = "/tmp/enigma2_crash.log";
-			f = fopen(crashlog_name, "wb");
+			f = fopen(crashlog_name.c_str(), "wb");
 		}
 	}
 


### PR DESCRIPTION
cppcheck reported as:
Summary: Dangerous usage of c_str(). The value returned by c_str() is invalid after this call.
Message: Dangerous usage of c_str(). The c_str() return value is only valid until its string is deleted.