### PR TITLE
refactored config manager function names to be shorted without loosin…

### DIFF
--- a/lib/base/nconfig.cpp
+++ b/lib/base/nconfig.cpp
@@ -17,20 +17,25 @@ eConfigManager *eConfigManager::getInstance()
 	return instance;
 }
 
-std::string eConfigManager::getConfigValue(const char *key)
+std::string eConfigManager::getString(const char *key, const char *defaultvalue)
 {
-	return instance ? instance->getConfig(key) : "";
+	return instance ? instance->getConfig(key) : defaultvalue;
 }
 
-int eConfigManager::getConfigIntValue(const char *key, int defaultvalue)
+std::string eConfigManager::getString(const std::string &key, const char *defaultvalue /*= ""*/)
 {
-	std::string value = getConfigValue(key);
+	return getString(key.c_str());
+}
+
+int eConfigManager::getInt(const char *key, int defaultvalue)
+{
+	std::string value = getString(key);
 	return (value != "") ? atoi(value.c_str()) : defaultvalue;
 }
 
-bool eConfigManager::getConfigBoolValue(const char *key, bool defaultvalue)
+bool eConfigManager::getBool(const char *key, bool defaultvalue)
 {
-	std::string value = getConfigValue(key);
+	std::string value = getString(key);
 	if (value == "True" || value == "true") return true;
 	if (value == "False" || value == "false") return false;
 	return defaultvalue;

--- a/lib/base/nconfig.h
+++ b/lib/base/nconfig.h
@@ -16,9 +16,10 @@ public:
 	eConfigManager();
 	virtual ~eConfigManager();
 
-	static std::string getConfigValue(const char *key);
-	static int getConfigIntValue(const char *key, int defaultvalue = 0);
-	static bool getConfigBoolValue(const char *key, bool defaultvalue = false);
+	static std::string getString(const char *key, const char *defaultvalue = "");
+	static std::string getString(const std::string &key, const char *defaultvalue = "");
+	static int getInt(const char *key, int defaultvalue = 0);
+	static bool getBool(const char *key, bool defaultvalue = false);
 };
 
 #endif /* __lib_base_nconfig_h_ */

--- a/lib/driver/hdmi_cec.cpp
+++ b/lib/driver/hdmi_cec.cpp
@@ -236,7 +236,7 @@ void eHdmiCEC::hdmiEvent(int what)
 			}
 		}
 #endif
-		bool hdmicec_enabled = eConfigManager::getConfigBoolValue("config.hdmicec.enabled", false);
+		bool hdmicec_enabled = eConfigManager::getBool("config.hdmicec.enabled", false);
 		if (hasdata && hdmicec_enabled)
 		{
 			bool keypressed = false;
@@ -248,7 +248,7 @@ void eHdmiCEC::hdmiEvent(int what)
 				eDebugNoNewLine(" %02X", rxmessage.data[i]);
 			}
 			eDebugNoNewLine("\n");
-			bool hdmicec_report_active_menu = eConfigManager::getConfigBoolValue("config.hdmicec.report_active_menu", false);
+			bool hdmicec_report_active_menu = eConfigManager::getBool("config.hdmicec.report_active_menu", false);
 			if (hdmicec_report_active_menu)
 			{
 				switch (rxmessage.data[0])

--- a/lib/dvb/cablescan.cpp
+++ b/lib/dvb/cablescan.cpp
@@ -345,8 +345,7 @@ void eCableScan::createBouquets()
 	}
 	bouquetFilename = replace_all(providerName, " ", "");
 
-	bool multibouquet = eConfigManager::getConfigBoolValue("config.usage.multibouquet");
-
+	bool multibouquet = eConfigManager::getBool("config.usage.multibouquet");
 	if (multibouquet)
 	{
 		std::string bouquetname = "userbouquet." + bouquetFilename + ".tv";

--- a/lib/dvb/db.cpp
+++ b/lib/dvb/db.cpp
@@ -199,7 +199,7 @@ bool eDVBService::isCrypted()
 int eDVBService::isPlayable(const eServiceReference &ref, const eServiceReference &ignore, bool simulate)
 {
 	ePtr<eDVBResourceManager> res_mgr;
-	bool remote_fallback_enabled = eConfigManager::getConfigBoolValue("config.usage.remote_fallback_enabled", false);
+	bool remote_fallback_enabled = eConfigManager::getBool("config.usage.remote_fallback_enabled", false);
 
 	if (eDVBResourceManager::getInstance(res_mgr))
 		eDebug("[eDVBService] isPlayble... no res manager!!");

--- a/lib/dvb/fastscan.cpp
+++ b/lib/dvb/fastscan.cpp
@@ -619,7 +619,7 @@ void eFastScan::parseResult()
 		}
 	}
 
-	bool multibouquet = eConfigManager::getConfigBoolValue("config.usage.multibouquet");
+	bool multibouquet = eConfigManager::getBool("config.usage.multibouquet");
 
 	if (multibouquet)
 	{

--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -2123,7 +2123,7 @@ RESULT eDVBFrontend::tune(const iDVBFrontendParameters &where)
 		char configStr[255];
 		snprintf(configStr, 255, "config.Nims.%d.terrestrial_5V", m_slotid);
 		m_sec_sequence.push_back( eSecCommand(eSecCommand::START_TUNE_TIMEOUT, timeout) );
-		if (eConfigManager::getConfigBoolValue(configStr))
+		if (eConfigManager::getBool(configStr))
 			m_sec_sequence.push_back( eSecCommand(eSecCommand::SET_VOLTAGE, iDVBFrontend::voltage13) );
 		else
 			m_sec_sequence.push_back( eSecCommand(eSecCommand::SET_VOLTAGE, iDVBFrontend::voltageOff) );

--- a/lib/dvb/pmt.cpp
+++ b/lib/dvb/pmt.cpp
@@ -399,16 +399,16 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 
 		std::string configvalue;
 		std::vector<std::string> autoaudio_languages;
-		configvalue = eConfigManager::getConfigValue("config.autolanguage.audio_autoselect1");
+		configvalue = eConfigManager::getString("config.autolanguage.audio_autoselect1");
 		if (configvalue != "" && configvalue != "None")
 			autoaudio_languages.push_back(configvalue);
-		configvalue = eConfigManager::getConfigValue("config.autolanguage.audio_autoselect2");
+		configvalue = eConfigManager::getString("config.autolanguage.audio_autoselect2");
 		if (configvalue != "" && configvalue != "None")
 			autoaudio_languages.push_back(configvalue);
-		configvalue = eConfigManager::getConfigValue("config.autolanguage.audio_autoselect3");
+		configvalue = eConfigManager::getString("config.autolanguage.audio_autoselect3");
 		if (configvalue != "" && configvalue != "None")
 			autoaudio_languages.push_back(configvalue);
-		configvalue = eConfigManager::getConfigValue("config.autolanguage.audio_autoselect4");
+		configvalue = eConfigManager::getString("config.autolanguage.audio_autoselect4");
 		if (configvalue != "" && configvalue != "None")
 			autoaudio_languages.push_back(configvalue);
 
@@ -419,16 +419,16 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 		int autosub_level =4;
 
 		std::vector<std::string> autosub_languages;
-		configvalue = eConfigManager::getConfigValue("config.autolanguage.subtitle_autoselect1");
+		configvalue = eConfigManager::getString("config.autolanguage.subtitle_autoselect1");
 		if (configvalue != "" && configvalue != "None")
 			autosub_languages.push_back(configvalue);
-		configvalue = eConfigManager::getConfigValue("config.autolanguage.subtitle_autoselect2");
+		configvalue = eConfigManager::getString("config.autolanguage.subtitle_autoselect2");
 		if (configvalue != "" && configvalue != "None")
 			autosub_languages.push_back(configvalue);
-		configvalue = eConfigManager::getConfigValue("config.autolanguage.subtitle_autoselect3");
+		configvalue = eConfigManager::getString("config.autolanguage.subtitle_autoselect3");
 		if (configvalue != "" && configvalue != "None")
 			autosub_languages.push_back(configvalue);
-		configvalue = eConfigManager::getConfigValue("config.autolanguage.subtitle_autoselect4");
+		configvalue = eConfigManager::getString("config.autolanguage.subtitle_autoselect4");
 		if (configvalue != "" && configvalue != "None")
 			autosub_languages.push_back(configvalue);
 
@@ -527,9 +527,9 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 			}
 		}
 
-		bool defaultac3 = eConfigManager::getConfigBoolValue("config.autolanguage.audio_defaultac3");
-		bool defaultddp = eConfigManager::getConfigBoolValue("config.autolanguage.audio_defaultddp");
-		bool useaudio_cache = eConfigManager::getConfigBoolValue("config.autolanguage.audio_usecache");
+		bool defaultac3 = eConfigManager::getBool("config.autolanguage.audio_defaultac3");
+		bool defaultddp = eConfigManager::getBool("config.autolanguage.audio_defaultddp");
+		bool useaudio_cache = eConfigManager::getBool("config.autolanguage.audio_usecache");
 
 		if (useaudio_cache && audio_cached != -1)
 			program.defaultAudioStream = audio_cached;
@@ -553,10 +553,10 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 				program.defaultAudioStream = first_non_mpeg;
 		}
 
-		bool allow_hearingimpaired = eConfigManager::getConfigBoolValue("config.autolanguage.subtitle_hearingimpaired");
-		bool default_hearingimpaired = eConfigManager::getConfigBoolValue("config.autolanguage.subtitle_defaultimpaired");
-		bool defaultdvb = eConfigManager::getConfigBoolValue("config.autolanguage.subtitle_defaultdvb");
-		int equallanguagemask = eConfigManager::getConfigIntValue("config.autolanguage.equal_languages");
+		bool allow_hearingimpaired = eConfigManager::getBool("config.autolanguage.subtitle_hearingimpaired");
+		bool default_hearingimpaired = eConfigManager::getBool("config.autolanguage.subtitle_defaultimpaired");
+		bool defaultdvb = eConfigManager::getBool("config.autolanguage.subtitle_defaultdvb");
+		int equallanguagemask = eConfigManager::getInt("config.autolanguage.equal_languages");
 
 		if (defaultdvb)
 		{
@@ -846,7 +846,7 @@ int eDVBServicePMTHandler::tuneExt(eServiceReferenceDVB &ref, int use_decode_dem
 			if (ref.path.empty())
 			{
 				m_dvb_scan = new eDVBScan(m_channel, true, false);
-				if (!eConfigManager::getConfigBoolValue("config.misc.disable_background_scan"))
+				if (!eConfigManager::getBool("config.misc.disable_background_scan"))
 				{
 					/*
 					 * not starting a dvb scan triggers what appears to be a
@@ -878,7 +878,7 @@ int eDVBServicePMTHandler::tuneExt(eServiceReferenceDVB &ref, int use_decode_dem
 
 			if (m_service_type == offline)
 			{
-				m_pvr_channel->setOfflineDecodeMode(eConfigManager::getConfigIntValue("config.recording.offline_decode_delay"));
+				m_pvr_channel->setOfflineDecodeMode(eConfigManager::getInt("config.recording.offline_decode_delay"));
 			}
 		}
 	}

--- a/lib/dvb/streamserver.cpp
+++ b/lib/dvb/streamserver.cpp
@@ -72,7 +72,7 @@ void eStreamClient::notifier(int what)
 	if (request.substr(0, 5) == "GET /")
 	{
 		size_t pos;
-		if (eConfigManager::getConfigBoolValue("config.streaming.authentication"))
+		if (eConfigManager::getBool("config.streaming.authentication"))
 		{
 			bool authenticated = false;
 			if ((pos = request.find("Authorization: Basic ")) != std::string::npos)

--- a/lib/dvb/subtitle.cpp
+++ b/lib/dvb/subtitle.cpp
@@ -51,7 +51,7 @@ static int extract_pts(pts_t &pts, uint8_t *pkt)
 
 void eDVBSubtitleParser::subtitle_process_line(subtitle_region *region, subtitle_region_object *object, int line, uint8_t *data, int len)
 {
-	bool subcentered = eConfigManager::getConfigBoolValue("config.subtitles.dvb_subtitles_centered");
+	bool subcentered = eConfigManager::getBool("config.subtitles.dvb_subtitles_centered");
 	int x = subcentered ? (region->width - len) /2 : object->object_horizontal_position;
 	int y = object->object_vertical_position + line;
 	if (x + len > region->width)
@@ -1033,8 +1033,8 @@ void eDVBSubtitleParser::subtitle_redraw(int page_id)
 					break;
 			}
 
-			int bcktrans = eConfigManager::getConfigIntValue("config.subtitles.dvb_subtitles_backtrans");
-			bool yellow = eConfigManager::getConfigBoolValue("config.subtitles.dvb_subtitles_yellow");
+			int bcktrans = eConfigManager::getInt("config.subtitles.dvb_subtitles_backtrans");
+			bool yellow = eConfigManager::getBool("config.subtitles.dvb_subtitles_yellow");
 
 			for (int i=0; i<clut_size; ++i)
 			{

--- a/lib/dvb_ci/dvbci.cpp
+++ b/lib/dvb_ci/dvbci.cpp
@@ -350,7 +350,7 @@ static bool canDescrambleMultipleServices(int slotid)
 {
 	char configStr[255];
 	snprintf(configStr, 255, "config.ci.%d.canDescrambleMultipleServices", slotid);
-	std::string str = eConfigManager::getConfigValue(configStr);
+	std::string str = eConfigManager::getString(configStr);
 	if ( str == "auto" )
 	{
 		std::string appname = eDVBCI_UI::getInstance()->getAppName(slotid);

--- a/lib/gui/esubtitle.cpp
+++ b/lib/gui/esubtitle.cpp
@@ -31,11 +31,11 @@ void eSubtitleWidget::setPage(const eDVBTeletextSubtitlePage &p)
 	if (elements)
 	{
 		int width = size().width() - startX * 2;
-		bool original_position = eConfigManager::getConfigBoolValue("config.subtitles.ttx_subtitle_original_position");
-		bool rewrap = eConfigManager::getConfigBoolValue("config.subtitles.subtitle_rewrap");
+		bool original_position = eConfigManager::getBool("config.subtitles.ttx_subtitle_original_position");
+		bool rewrap = eConfigManager::getBool("config.subtitles.subtitle_rewrap");
 		gRGB color;
 		bool original_colors = false;
-		switch (eConfigManager::getConfigIntValue("config.subtitles.ttx_subtitle_colors", 1))
+		switch (eConfigManager::getInt("config.subtitles.ttx_subtitle_colors", 1))
 		{
 			case 0: /* use original teletext colors */
 				color = newpage.m_elements[0].m_color;
@@ -54,7 +54,7 @@ void eSubtitleWidget::setPage(const eDVBTeletextSubtitlePage &p)
 		{
 			int height = size().height() / 3;
 
-			int lowerborder = eConfigManager::getConfigIntValue("config.subtitles.subtitle_position", 50);
+			int lowerborder = eConfigManager::getInt("config.subtitles.subtitle_position", 50);
 			int line = newpage.m_elements[0].m_source_line;
 			/* create a new page with just one text element */
 			m_page.m_elements.push_back(eDVBTeletextSubtitlePageElement(color, "", 0));
@@ -124,13 +124,13 @@ void eSubtitleWidget::setPage(const eDVBSubtitlePage &p)
 	invalidate(m_visible_region); // invalidate old visible regions
 	m_visible_region.rects.clear();
 	int line = 0;
-	int original_position = eConfigManager::getConfigIntValue("config.subtitles.dvb_subtitles_original_position");
+	int original_position = eConfigManager::getInt("config.subtitles.dvb_subtitles_original_position");
 	for (std::list<eDVBSubtitleRegion>::iterator it(m_dvb_page.m_regions.begin()); it != m_dvb_page.m_regions.end(); ++it)
 	{
 		if (original_position)
 		{
 			int lines = m_dvb_page.m_regions.size();
-			int lowerborder = eConfigManager::getConfigIntValue("config.subtitles.subtitle_position", -1);
+			int lowerborder = eConfigManager::getInt("config.subtitles.subtitle_position", -1);
 			if (lowerborder >= 0)
 			{
 				if (original_position == 1)
@@ -163,9 +163,9 @@ void eSubtitleWidget::setPage(const ePangoSubtitlePage &p)
 	invalidate(m_visible_region); // invalidate old visible regions
 	m_visible_region.rects.clear();
 
-	rewrap_enabled = eConfigManager::getConfigBoolValue("config.subtitles.subtitle_rewrap");
-	colourise_dialogs_enabled = eConfigManager::getConfigBoolValue("config.subtitles.colourise_dialogs");
-	lowerborder = eConfigManager::getConfigIntValue("config.subtitles.subtitle_position", 50);
+	rewrap_enabled = eConfigManager::getBool("config.subtitles.subtitle_rewrap");
+	colourise_dialogs_enabled = eConfigManager::getBool("config.subtitles.colourise_dialogs");
+	lowerborder = eConfigManager::getInt("config.subtitles.subtitle_position", 50);
 
 	elements = m_pango_page.m_elements.size();
 
@@ -174,7 +174,7 @@ void eSubtitleWidget::setPage(const ePangoSubtitlePage &p)
 		size_t ix, colourise_dialogs_current = 0;
 		std::vector<std::string> colourise_dialogs_colours;
 		std::string replacement;
-		bool alignment_center = eConfigManager::getConfigValue("config.subtitles.subtitle_alignment") == "center";
+		bool alignment_center = eConfigManager::getString("config.subtitles.subtitle_alignment") == "center";
 
 		if(colourise_dialogs_enabled)
 		{
@@ -276,7 +276,7 @@ int eSubtitleWidget::event(int event, void *data, void *data2)
 		std::string alignmentValue;
 
 		int rt_halignment_flag;
-		alignmentValue = eConfigManager::getConfigValue("config.subtitles.subtitle_alignment");
+		alignmentValue = eConfigManager::getString("config.subtitles.subtitle_alignment");
 		if (alignmentValue == "right")
 			rt_halignment_flag = gPainter::RT_HALIGN_RIGHT;
 		else if (alignmentValue == "left")
@@ -284,8 +284,8 @@ int eSubtitleWidget::event(int event, void *data, void *data2)
 		else
 			rt_halignment_flag = gPainter::RT_HALIGN_CENTER;
 
-		int borderwidth = eConfigManager::getConfigIntValue("config.subtitles.subtitle_borderwidth", 2) * getDesktop(0)->size().width()/1280;
-		int fontsize = eConfigManager::getConfigIntValue("config.subtitles.subtitle_fontsize", 34) * getDesktop(0)->size().width()/1280;
+		int borderwidth = eConfigManager::getInt("config.subtitles.subtitle_borderwidth", 2) * getDesktop(0)->size().width()/1280;
+		int fontsize = eConfigManager::getInt("config.subtitles.subtitle_fontsize", 34) * getDesktop(0)->size().width()/1280;
 
 		if (m_pixmap)
 		{
@@ -306,7 +306,7 @@ int eSubtitleWidget::event(int event, void *data, void *data2)
 				if (!element.m_text.empty())
 				{
 					eRect &area = element.m_area;
-					if (eConfigManager::getConfigBoolValue("config.subtitles.showbackground"))
+					if (eConfigManager::getBool("config.subtitles.showbackground"))
 					{
 						eTextPara *para = new eTextPara(area);
 						para->setFont(subtitleStyles[Subtitle_TTX].font);
@@ -320,7 +320,7 @@ int eSubtitleWidget::event(int event, void *data, void *data2)
 						else
 							bbox.setLeft(area.left() + area.width() / 2 - bboxWidth / 2 - borderwidth);
 						bbox.setWidth(bboxWidth + borderwidth * 2);
-						if (eConfigManager::getConfigBoolValue("config.subtitles.ttx_subtitle_original_position"))
+						if (eConfigManager::getBool("config.subtitles.ttx_subtitle_original_position"))
 							bbox.setHeight(area.height());
 						else
 						{
@@ -358,7 +358,7 @@ int eSubtitleWidget::event(int event, void *data, void *data2)
 				text = replace_all(text, "&lt", "<");
 				text = replace_all(text, "&gt", ">");
 
-				if (eConfigManager::getConfigBoolValue("config.subtitles.pango_subtitle_fontswitch"))
+				if (eConfigManager::getBool("config.subtitles.pango_subtitle_fontswitch"))
 				{
 					if (text.find("<i>") != std::string::npos || text.find("</i>") != std::string::npos)
 						if (text.find("<b>") != std::string::npos || text.find("</b>") != std::string::npos)
@@ -368,7 +368,7 @@ int eSubtitleWidget::event(int event, void *data, void *data2)
 					else if (text.find("<b>") != std::string::npos || text.find("</b>") != std::string::npos)
 						face = Subtitle_Bold;
 				}
-				int subtitleColors = eConfigManager::getConfigIntValue("config.subtitles.pango_subtitle_colors", 1);
+				int subtitleColors = eConfigManager::getInt("config.subtitles.pango_subtitle_colors", 1);
 				if (!subtitleColors)
 					{
 						text = replace_all(text, "<i>", gRGB(255,255,0));
@@ -392,7 +392,7 @@ int eSubtitleWidget::event(int event, void *data, void *data2)
 				subtitleStyles[face].font->pointSize=fontsize;
 				painter.setFont(subtitleStyles[face].font);
 				eRect &area = element.m_area;
-				if (eConfigManager::getConfigBoolValue("config.subtitles.showbackground"))
+				if (eConfigManager::getBool("config.subtitles.showbackground"))
 				{
 					eTextPara *para = new eTextPara(area);
 					para->setFont(subtitleStyles[face].font);

--- a/lib/python/pythonconfig.cpp
+++ b/lib/python/pythonconfig.cpp
@@ -12,7 +12,7 @@ void ePythonConfigQuery::setQueryFunc(ePyObject queryFunc)
 		Py_INCREF(m_queryFunc);
 }
 
-RESULT ePythonConfigQuery::getConfigValue(const char *key, std::string &value)
+RESULT ePythonConfigQuery::getString(const char *key, std::string &value)
 {
 	if (key && PyCallable_Check(m_queryFunc))
 	{
@@ -37,6 +37,6 @@ RESULT ePythonConfigQuery::getConfigValue(const char *key, std::string &value)
 std::string ePythonConfigQuery::getConfig(const char *key)
 {
 	std::string value;
-	getConfigValue(key, value);
+	getString(key, value);
 	return value;
 }

--- a/lib/python/pythonconfig.h
+++ b/lib/python/pythonconfig.h
@@ -8,7 +8,7 @@ class ePythonConfigQuery : public eConfigManager
 {
 	static ePyObject m_queryFunc;
 #ifndef SWIG
-	RESULT getConfigValue(const char *key, std::string &value);
+	RESULT getString(const char *key, std::string &value);
 	std::string getConfig(const char *key);
 #endif
 public:

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -1178,7 +1178,7 @@ void eDVBServicePlay::serviceEvent(int event)
 		updateEpgCacheNowNext();
 
 		/* default behaviour is to start an eit reader, and wait for now/next info, unless this is disabled */
-		if (eConfigManager::getConfigBoolValue("config.usage.show_eit_nownext", true))
+		if (eConfigManager::getBool("config.usage.show_eit_nownext", true))
 		{
 			ePtr<iDVBDemux> m_demux;
 			if (!m_service_handler.getDataDemux(m_demux))
@@ -1368,7 +1368,7 @@ RESULT eDVBServicePlay::start()
 		 * streams are considered to be descrambled by default;
 		 * user can indicate a stream is scrambled, by using servicetype id + 0x100
 		 */
-		bool config_descramble_client = eConfigManager::getConfigBoolValue("config.streaming.descramble_client", false);
+		bool config_descramble_client = eConfigManager::getBool("config.streaming.descramble_client", false);
 
 		scrambled = (m_reference.type == eServiceFactoryDVB::id + 0x100);
 
@@ -1725,7 +1725,7 @@ RESULT eDVBServicePlay::timeshift(ePtr<iTimeshiftService> &ptr)
 		if (!m_timeshift_enabled)
 		{
 			/* query config path */
-			std::string tspath = eConfigManager::getConfigValue("config.usage.timeshift_path");
+			std::string tspath = eConfigManager::getString("config.usage.timeshift_path");
 			if(tspath == "")
 			{
 				eDebug("[eDVBServicePlay] timeshift could not query ts path from config");
@@ -2294,8 +2294,8 @@ bool eDVBServiceBase::tryFallbackTuner(eServiceReferenceDVB &service, bool &is_s
 	int system;
 	size_t index;
 
-	bool remote_fallback_enabled = eConfigManager::getConfigBoolValue("config.usage.remote_fallback_enabled", false);
-	std::string remote_fallback_url = eConfigManager::getConfigValue("config.usage.remote_fallback");
+	bool remote_fallback_enabled = eConfigManager::getBool("config.usage.remote_fallback_enabled", false);
+	std::string remote_fallback_url = eConfigManager::getString("config.usage.remote_fallback");
 
 	if(is_stream || is_pvr || simulate ||
 			!remote_fallback_enabled || (remote_fallback_url.length() == 0) ||
@@ -2420,7 +2420,7 @@ RESULT eDVBServicePlay::startTimeshift()
 	if (!m_record)
 		return -3;
 
-	std::string tspath = eConfigManager::getConfigValue("config.usage.timeshift_path");
+	std::string tspath = eConfigManager::getString("config.usage.timeshift_path");
 	if (tspath == "")
 	{
 		eDebug("[eDVBServicePlay] could not query timeshift path");
@@ -2890,12 +2890,12 @@ void eDVBServicePlay::updateDecoder(bool sendSeekableStateChanged)
 		else
 		{
 			std::string value;
-			bool showRadioBackground = eConfigManager::getConfigBoolValue("config.misc.showradiopic", true);
+			bool showRadioBackground = eConfigManager::getBool("config.misc.showradiopic", true);
 			std::string radio_pic;
 			if (showRadioBackground)
-				radio_pic = eConfigManager::getConfigValue("config.misc.radiopic");
+				radio_pic = eConfigManager::getString("config.misc.radiopic");
 			else
-				radio_pic = eConfigManager::getConfigValue("config.misc.blackradiopic");
+				radio_pic = eConfigManager::getString("config.misc.blackradiopic");
 			m_decoder->setRadioPic(radio_pic);
 		}
 
@@ -3177,7 +3177,7 @@ RESULT eDVBServicePlay::getCachedSubtitle(struct SubtitleTrack &track)
 		eDVBServicePMTHandler &h = m_timeshift_active ? m_service_handler_timeshift : m_service_handler;
 		if (!h.getProgramInfo(program))
 		{
-			bool usecache = eConfigManager::getConfigBoolValue("config.autolanguage.subtitle_usecache");
+			bool usecache = eConfigManager::getBool("config.autolanguage.subtitle_usecache");
 			int stream=program.defaultSubtitleStream;
 			int tmp = m_dvb_service->getCacheEntry(eDVBService::cSUBTITLE);
 
@@ -3315,12 +3315,12 @@ void eDVBServicePlay::newSubtitlePage(const eDVBTeletextSubtitlePage &page)
 		if (m_is_pvr || m_timeshift_enabled)
 		{
 			eDebug("[eDVBServicePlay] Subtitle in recording/timeshift");
-			subtitledelay = eConfigManager::getConfigIntValue("config.subtitles.subtitle_noPTSrecordingdelay", 315000);
+			subtitledelay = eConfigManager::getInt("config.subtitles.subtitle_noPTSrecordingdelay", 315000);
 		}
 		else
 		{
 			/* check the setting for subtitle delay in live playback, either with pts, or without pts */
-			subtitledelay = eConfigManager::getConfigIntValue("config.subtitles.subtitle_bad_timing_delay", 0);
+			subtitledelay = eConfigManager::getInt("config.subtitles.subtitle_bad_timing_delay", 0);
 		}
 
 		// eDebug("[eDVBServicePlay] Subtitle get  TTX have_pts=%d pvr=%d timeshift=%d page.pts=%lld pts=%lld delay=%d", page.m_have_pts, m_is_pvr, m_timeshift_enabled, page.m_pts, pts, subtitledelay);
@@ -3406,7 +3406,7 @@ void eDVBServicePlay::newDVBSubtitlePage(const eDVBSubtitlePage &p)
 		if ( abs(pos-p.m_show_time)>1800000 && (m_is_pvr || m_timeshift_enabled))
 		{
 			eDebug("[eDVBServicePlay] Subtitle without PTS and recording");
-			int subtitledelay = eConfigManager::getConfigIntValue("config.subtitles.subtitle_noPTSrecordingdelay", 315000);
+			int subtitledelay = eConfigManager::getInt("config.subtitles.subtitle_noPTSrecordingdelay", 315000);
 
 			eDVBSubtitlePage tmppage;
 			tmppage = p;
@@ -3415,7 +3415,7 @@ void eDVBServicePlay::newDVBSubtitlePage(const eDVBSubtitlePage &p)
 		}
 		else
 		{
-			int subtitledelay = eConfigManager::getConfigIntValue("config.subtitles.subtitle_bad_timing_delay", 0);
+			int subtitledelay = eConfigManager::getInt("config.subtitles.subtitle_bad_timing_delay", 0);
 			if (subtitledelay != 0)
 			{
 				eDVBSubtitlePage tmppage;
@@ -3456,7 +3456,7 @@ void eDVBServicePlay::setAC3Delay(int delay)
 		m_dvb_service->setCacheEntry(eDVBService::cAC3DELAY, delay ? delay : -1);
 	if (m_decoder)
 	{
-		m_decoder->setAC3Delay(delay + eConfigManager::getConfigIntValue("config.av.generalAC3delay"));
+		m_decoder->setAC3Delay(delay + eConfigManager::getInt("config.av.generalAC3delay"));
 	}
 }
 
@@ -3466,7 +3466,7 @@ void eDVBServicePlay::setPCMDelay(int delay)
 		m_dvb_service->setCacheEntry(eDVBService::cPCMDELAY, delay ? delay : -1);
 	if (m_decoder)
 	{
-		m_decoder->setPCMDelay(delay + eConfigManager::getConfigIntValue("config.av.generalPCMdelay"));
+		m_decoder->setPCMDelay(delay + eConfigManager::getInt("config.av.generalPCMdelay"));
 	}
 }
 

--- a/lib/service/servicedvbrecord.cpp
+++ b/lib/service/servicedvbrecord.cpp
@@ -241,7 +241,7 @@ int eDVBServiceRecord::doPrepare()
 				* streams are considered to be descrambled by default;
 				* user can indicate a stream is scrambled, by using servicetype id + 0x100
 				*/
-				bool config_descramble_client = eConfigManager::getConfigBoolValue("config.streaming.descramble_client", false);
+				bool config_descramble_client = eConfigManager::getBool("config.streaming.descramble_client", false);
 
 				m_descramble = (m_ref.type == eServiceFactoryDVB::id + 0x100);
 

--- a/lib/service/servicedvbstream.cpp
+++ b/lib/service/servicedvbstream.cpp
@@ -107,13 +107,13 @@ int eDVBServiceStream::doPrepare()
 		/* allocate a ts recorder if we don't already have one. */
 	if (m_state == stateIdle)
 	{
-		m_stream_ecm = eConfigManager::getConfigBoolValue("config.streaming.stream_ecm");
-		m_stream_eit = eConfigManager::getConfigBoolValue("config.streaming.stream_eit");
-		m_stream_ait = eConfigManager::getConfigBoolValue("config.streaming.stream_ait");
+		m_stream_ecm = eConfigManager::getBool("config.streaming.stream_ecm");
+		m_stream_eit = eConfigManager::getBool("config.streaming.stream_eit");
+		m_stream_ait = eConfigManager::getBool("config.streaming.stream_ait");
 		m_pids_active.clear();
 		m_state = statePrepared;
 		eDVBServicePMTHandler::serviceType servicetype = m_stream_ecm ? eDVBServicePMTHandler::scrambled_streamserver : eDVBServicePMTHandler::streamserver;
-		bool descramble = eConfigManager::getConfigBoolValue("config.streaming.descramble", true);
+		bool descramble = eConfigManager::getBool("config.streaming.descramble", true);
 		return m_service_handler.tune(m_ref, 0, 0, 0, NULL, servicetype, descramble);
 	}
 	return 0;

--- a/lib/service/servicedvd.cpp
+++ b/lib/service/servicedvd.cpp
@@ -183,7 +183,7 @@ eServiceDVD::eServiceDVD(eServiceReference ref):
 	ddvd_set_dvd_path(m_ddvdconfig, ref.path.c_str());
 	ddvd_set_ac3thru(m_ddvdconfig, 0);
 
-	std::string ddvd_language = eConfigManager::getConfigValue("config.osd.language");
+	std::string ddvd_language = eConfigManager::getString("config.osd.language");
 	if (ddvd_language != "")
 		ddvd_set_language(m_ddvdconfig, (ddvd_language.substr(0, 2)).c_str());
 

--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -507,13 +507,8 @@ eServiceMP3::eServiceMP3(eServiceReference ref):
 		CONNECT(m_streamingsrc_timeout->timeout, eServiceMP3::sourceTimeout);
 
 		std::string config_str;
-		if (eConfigManager::getConfigBoolValue("config.mediaplayer.useAlternateUserAgent"))
-		{
-			m_useragent = eConfigManager::getConfigValue("config.mediaplayer.alternateUserAgent");
-		}
-		if (m_useragent.empty())
-			m_useragent = "Enigma2 Mediaplayer";
-		m_extra_headers = eConfigManager::getConfigValue("config.mediaplayer.extraHeaders");
+		m_useragent = eConfigManager::getString("config.mediaplayer.alternateUserAgent", "Enigma2 Mediaplayer");
+		m_extra_headers = eConfigManager::getString("config.mediaplayer.extraHeaders");
 		if ( m_ref.getData(7) & BUFFERING_ENABLED )
 		{
 			m_use_prefillbuffer = true;
@@ -2463,8 +2458,8 @@ void eServiceMP3::pullSubtitle(GstBuffer *buffer)
 		{
 			if ( subType < stVOB )
 			{
-				int delay = eConfigManager::getConfigIntValue("config.subtitles.pango_subtitles_delay");
-				int subtitle_fps = eConfigManager::getConfigIntValue("config.subtitles.pango_subtitles_fps");
+				int delay = eConfigManager::getInt("config.subtitles.pango_subtitles_delay");
+				int subtitle_fps = eConfigManager::getInt("config.subtitles.pango_subtitles_fps");
 
 				double convert_fps = 1.0;
 				if (subtitle_fps > 1 && m_framerate > 0)
@@ -2644,7 +2639,7 @@ RESULT eServiceMP3::disableSubtitles()
 RESULT eServiceMP3::getCachedSubtitle(struct SubtitleTrack &track)
 {
 
-	bool autoturnon = eConfigManager::getConfigBoolValue("config.subtitles.pango_autoturnon", true);
+	bool autoturnon = eConfigManager::getBool("config.subtitles.pango_autoturnon", true);
 	if (!autoturnon)
 		return -1;
 
@@ -2792,7 +2787,7 @@ void eServiceMP3::setAC3Delay(int delay)
 		 */
 		if (videoSink)
 		{
-			config_delay_int += eConfigManager::getConfigIntValue("config.av.generalAC3delay");
+			config_delay_int += eConfigManager::getInt("config.av.generalAC3delay");
 		}
 		else
 		{
@@ -2823,7 +2818,7 @@ void eServiceMP3::setPCMDelay(int delay)
 		 */
 		if (videoSink)
 		{
-			config_delay_int += eConfigManager::getConfigIntValue("config.av.generalPCMdelay");
+			config_delay_int += eConfigManager::getInt("config.av.generalPCMdelay");
 		}
 		else
 		{

--- a/lib/service/servicemp3record.cpp
+++ b/lib/service/servicemp3record.cpp
@@ -26,7 +26,6 @@ eServiceMP3Record::eServiceMP3Record(const eServiceReference &ref):
 	CONNECT(m_pump.recv_msg, eServiceMP3Record::gstPoll);
 	CONNECT(m_streamingsrc_timeout->timeout, eServiceMP3Record::sourceTimeout);
 
-	std::string config_str;
 	if (eConfigManager::getConfigBoolValue("config.mediaplayer.useAlternateUserAgent"))
 	{
 		m_useragent = eConfigManager::getConfigValue("config.mediaplayer.alternateUserAgent");

--- a/main/bsod.cpp
+++ b/main/bsod.cpp
@@ -69,7 +69,7 @@ static void addToLogbuffer(int level, const std::string &log)
 
 static const std::string getConfigString(const std::string &key, const std::string &defaultValue)
 {
-	std::string value = eConfigManager::getConfigValue(key.c_str());
+	std::string value = eConfigManager::getString(key);
 
 	//we get at least the default value if python is still alive
 	if (!value.empty())


### PR DESCRIPTION
…g there explicit naming. While I was at it I teached the getString (the old getConfigValue)
function how to handle a default value. This simplified a use case in the
mp3 service.