### PR TITLE
remove unneeded struct type specifier from sizeof.

### DIFF
--- a/lib/driver/rc.cpp
+++ b/lib/driver/rc.cpp
@@ -94,7 +94,7 @@ void eRCInputEventDriver::keyPressed(int)
 	struct input_event ev;
 	while (1)
 	{
-		if (read(handle, &ev, sizeof(struct input_event))!=sizeof(struct input_event))
+		if (read(handle, &ev, sizeof(input_event))!=sizeof(input_event))
 			break;
 		if (enabled && !input->islocked())
 			for (std::list<eRCDevice*>::iterator i(listeners.begin()); i!=listeners.end(); ++i)

--- a/lib/dvb/decoder.cpp
+++ b/lib/dvb/decoder.cpp
@@ -1201,7 +1201,7 @@ RESULT eTSMPEGDecoder::showSinglePic(const char *filename)
 				unsigned char iframe[s.st_size];
 				unsigned char stuffing[8192];
 				int streamtype;
-				memset(stuffing, 0, 8192);
+				memset(stuffing, 0, sizeof(stuffing));
 				read(f, iframe, s.st_size);
 				if (iframe[0] == 0x00 && iframe[1] == 0x00 && iframe[2] == 0x00 && iframe[3] == 0x01 && (iframe[4] & 0x0f) == 0x07)
 					streamtype = VIDEO_STREAMTYPE_MPEG4_H264;

--- a/lib/dvb/demux.cpp
+++ b/lib/dvb/demux.cpp
@@ -496,7 +496,7 @@ int eDVBRecordFileThread::AsyncIO::poll()
 
 int eDVBRecordFileThread::AsyncIO::start(int fd, off_t offset, size_t nbytes, void* buffer)
 {
-	memset(&aio, 0, sizeof(struct aiocb)); // Documentation says "zero it before call".
+	memset(&aio, 0, sizeof(aiocb)); // Documentation says "zero it before call".
 	aio.aio_fildes = fd;
 	aio.aio_nbytes = nbytes;
 	aio.aio_offset = offset;   // Offset can be omitted with O_APPEND

--- a/lib/dvb/demux.h
+++ b/lib/dvb/demux.h
@@ -111,7 +111,7 @@ protected:
 		unsigned char* buffer;
 		AsyncIO()
 		{
-			memset(&aio, 0, sizeof(struct aiocb));
+			memset(&aio, 0, sizeof(aiocb));
 			buffer = NULL;
 		}
 		int wait();

--- a/lib/service/servicedvd.cpp
+++ b/lib/service/servicedvd.cpp
@@ -363,7 +363,7 @@ void eServiceDVD::gotMessage(int /*what*/)
 				m_event(this, evUser + 8); // chapterUpdated
 			if ( info.pos_title != last_info.pos_title )
 				m_event(this, evUser + 9); // titleUpdated
-			memcpy(&last_info, &info, sizeof(struct ddvd_time));
+			memcpy(&last_info, &info, sizeof(last_info));
 			break;
 		}
 		case DDVD_SHOWOSD_TITLESTRING:
@@ -1055,7 +1055,7 @@ void eServiceDVD::loadCuesheet()
 		if (fread(&where, sizeof(where), 1, f))
 			if (fread(&what, sizeof(what), 1, f))
 				if (ntohl(what) == 3)
-					if (fread(&m_resume_info, sizeof(struct ddvd_resume), 1, f))
+					if (fread(&m_resume_info, sizeof(m_resume_info), 1, f))
 						if (fread(&what, sizeof(what), 1, f))
 							if (ntohl(what) == 4)
 								m_cue_pts = be64toh(where);
@@ -1166,7 +1166,7 @@ void eServiceDVD::saveCuesheet()
 		what = htonl(3);
 		fwrite(&what, sizeof(what), 1, f);
 
-		fwrite(&resume_info, sizeof(struct ddvd_resume), 1, f);
+		fwrite(&resume_info, sizeof(resume_info), 1, f);
 		what = htonl(4);
 		fwrite(&what, sizeof(what), 1, f);
 


### PR DESCRIPTION
This seems to be a leftover from back in the days when everything was
written in C.