### PR TITLE
Mediaplayer: create mediaplayer.extraHeaders

### DIFF
--- a/lib/python/Plugins/Extensions/MediaPlayer/settings.py
+++ b/lib/python/Plugins/Extensions/MediaPlayer/settings.py
@@ -3,7 +3,7 @@ from Screens.HelpMenu import HelpableScreen
 from Components.FileList import FileList
 from Components.Sources.StaticText import StaticText
 from Components.MediaPlayer import PlayList
-from Components.config import config, getConfigListEntry, ConfigSubsection, configfile, ConfigText, ConfigYesNo, ConfigDirectory
+from Components.config import config, getConfigListEntry, ConfigSubsection, configfile, ConfigText, ConfigYesNo, ConfigDirectory, NoSave
 from Components.ConfigList import ConfigListScreen
 from Components.ActionMap import ActionMap
 
@@ -17,6 +17,7 @@ config.mediaplayer.alternateUserAgent = ConfigText(default="")
 config.mediaplayer.sortPlaylists = ConfigYesNo(default=False)
 config.mediaplayer.alwaysHideInfoBar = ConfigYesNo(default=True)
 config.mediaplayer.onMainMenu = ConfigYesNo(default=False)
+config.mediaplayer.extraHeaders = NoSave(ConfigText(default=""))
 
 class DirectoryBrowser(Screen, HelpableScreen):
 


### PR DESCRIPTION
Without creating mediaplayer.extraHeaders we cannot use extraHeaders on bouquets

More Info: http://forums.openpli.org/topic/29501-gstreamer-10/page-91#entry510627