### PR TITLE
servicemp3: Always initialize pointer to NULL before pass to gst_tag_list_get_string

### DIFF
--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -1295,7 +1295,7 @@ std::string eServiceMP3::getInfoString(int w)
 	}
 	if ( !tag )
 		return "";
-	gchar *value;
+	gchar *value = NULL;
 	if (m_stream_tags && gst_tag_list_get_string(m_stream_tags, tag, &value))
 	{
 		std::string res = value;


### PR DESCRIPTION
More info: http://forums.openpli.org/topic/29501-gstreamer-10/page-93