### PR TITLE
Add option enable/disable conflict detection for each timer

### DIFF
--- a/RecordTimer.py
+++ b/RecordTimer.py
@@ -134,7 +134,7 @@ class RecordTimerEntry(timer.TimerEntry, object):
 			RecordTimerEntry.staticGotRecordEvent(None, iRecordableService.evEnd)
 #################################################################
 
-	def __init__(self, serviceref, begin, end, name, description, eit, disabled = False, justplay = False, afterEvent = AFTEREVENT.AUTO, checkOldTimers = False, dirname = None, tags = None, descramble = True, record_ecm = False, always_zap = False, zap_wakeup = "always", rename_repeat = True):
+	def __init__(self, serviceref, begin, end, name, description, eit, disabled = False, justplay = False, afterEvent = AFTEREVENT.AUTO, checkOldTimers = False, dirname = None, tags = None, descramble = True, record_ecm = False, always_zap = False, zap_wakeup = "always", rename_repeat = True, conflict_detection = True):
 		timer.TimerEntry.__init__(self, int(begin), int(end))
 
 		if checkOldTimers == True:
@@ -170,6 +170,7 @@ class RecordTimerEntry(timer.TimerEntry, object):
 		self.descramble = descramble
 		self.record_ecm = record_ecm
 		self.rename_repeat = rename_repeat
+		self.conflict_detection = conflict_detection
 		self.setAdvancedPriorityFrontend = None
 		if SystemInfo["DVB-T_priority_tuner_available"] or SystemInfo["DVB-C_priority_tuner_available"] or SystemInfo["DVB-S_priority_tuner_available"]:
 			rec_ref = self.service_ref and self.service_ref.ref
@@ -644,6 +645,7 @@ def createTimer(xml):
 	justplay = long(xml.get("justplay") or "0")
 	always_zap = long(xml.get("always_zap") or "0")
 	zap_wakeup = str(xml.get("zap_wakeup") or "always")
+	conflict_detection = long(xml.get("conflict_detection") or "1")
 	afterevent = str(xml.get("afterevent") or "nothing")
 	afterevent = {
 		"nothing": AFTEREVENT.NONE,
@@ -671,7 +673,7 @@ def createTimer(xml):
 
 	name = xml.get("name").encode("utf-8")
 	#filename = xml.get("filename").encode("utf-8")
-	entry = RecordTimerEntry(serviceref, begin, end, name, description, eit, disabled, justplay, afterevent, dirname = location, tags = tags, descramble = descramble, record_ecm = record_ecm, always_zap = always_zap, zap_wakeup = zap_wakeup, rename_repeat = rename_repeat)
+	entry = RecordTimerEntry(serviceref, begin, end, name, description, eit, disabled, justplay, afterevent, dirname = location, tags = tags, descramble = descramble, record_ecm = record_ecm, always_zap = always_zap, zap_wakeup = zap_wakeup, rename_repeat = rename_repeat, conflict_detection = conflict_detection)
 	entry.repeated = int(repeated)
 
 	for l in xml.findall("log"):
@@ -839,6 +841,7 @@ class RecordTimer(timer.Timer):
 			list.append(' always_zap="' + str(int(timer.always_zap)) + '"')
 			list.append(' zap_wakeup="' + str(timer.zap_wakeup) + '"')
 			list.append(' rename_repeat="' + str(int(timer.rename_repeat)) + '"')
+			list.append(' conflict_detection="' + str(int(timer.conflict_detection)) + '"')
 			list.append(' descramble="' + str(int(timer.descramble)) + '"')
 			list.append(' record_ecm="' + str(int(timer.record_ecm)) + '"')
 			list.append('>\n')

--- a/lib/python/Components/TimerSanityCheck.py
+++ b/lib/python/Components/TimerSanityCheck.py
@@ -24,6 +24,8 @@ class TimerSanityCheck:
 		if self.newtimer is None:
 			self.simultimer = []
 		else:
+			if not self.newtimer.conflict_detection:
+				return True
 			self.simultimer = [ self.newtimer ]
 		return self.checkTimerlist()
 
@@ -94,6 +96,8 @@ class TimerSanityCheck:
 		idx = 0
 		for timer in self.timerlist:
 			if (timer != self.newtimer) and (not timer.disabled):
+				if not timer.conflict_detection:
+					continue
 				if timer.repeated:
 					rflags = timer.repeated
 					rflags = ((rflags & 0x7F)>> 3)|((rflags & 0x07)<<4)

--- a/lib/python/Screens/TimerEntry.py
+++ b/lib/python/Screens/TimerEntry.py
@@ -60,6 +60,7 @@ class TimerEntry(Screen, ConfigListScreen):
 			always_zap = self.timer.always_zap
 			zap_wakeup = self.timer.zap_wakeup
 			rename_repeat = self.timer.rename_repeat
+			conflict_detection = self.timer.conflict_detection
 
 			afterevent = {
 				AFTEREVENT.NONE: "nothing",
@@ -130,6 +131,8 @@ class TimerEntry(Screen, ConfigListScreen):
 
 			self.timerentry_repeated = ConfigSelection(default = repeated, choices = [("weekly", _("weekly")), ("daily", _("daily")), ("weekdays", _("Mon-Fri")), ("user", _("user defined"))])
 			self.timerentry_renamerepeat = ConfigYesNo(default = rename_repeat)
+
+			self.timerentry_conflictdetection = ConfigYesNo(default = conflict_detection) 
 
 			self.timerentry_date = ConfigDateTime(default = self.timer.begin, formatstring = _("%d.%B %Y"), increment = 86400)
 			self.timerentry_starttime = ConfigClock(default = self.timer.begin)
@@ -213,6 +216,9 @@ class TimerEntry(Screen, ConfigListScreen):
 		self.entryEndTime = getConfigListEntry(_("End time"), self.timerentry_endtime)
 		if self.timerentry_justplay.value != "zap" or self.timerentry_showendtime.value:
 			self.list.append(self.entryEndTime)
+
+		self.conflictDetectionEntry = getConfigListEntry(_("Enable timer conflict detection"), self.timerentry_conflictdetection)
+		self.list.append(self.conflictDetectionEntry)
 
 		self.channelEntry = getConfigListEntry(_("Channel"), self.timerentry_service)
 		self.list.append(self.channelEntry)
@@ -372,6 +378,7 @@ class TimerEntry(Screen, ConfigListScreen):
 		self.timer.always_zap = self.timerentry_justplay.value == "zap+record"
 		self.timer.zap_wakeup = self.timerentry_zapwakeup.value
 		self.timer.rename_repeat = self.timerentry_renamerepeat.value
+		self.timer.conflict_detection = self.timerentry_conflictdetection.value
 		if self.timerentry_justplay.value == "zap":
 			if not self.timerentry_showendtime.value:
 				self.timerentry_endtime.value = self.timerentry_starttime.value


### PR DESCRIPTION
TODO:
-add to the conflict warning screen a quick option that can exclude a
selected timer from the check before going back to the timer entry.