### PR TITLE
Components Language: add os.environ["LANGUAGE"]

### DIFF
--- a/lib/python/Components/Language.py
+++ b/lib/python/Components/Language.py
@@ -81,6 +81,7 @@ class Language:
 				pass
 		# HACK: sometimes python 2.7 reverts to the LC_TIME environment value, so make sure it has the correct value
 		os.environ["LC_TIME"] = self.getLanguage() + '.UTF-8'
+		os.environ["LANGUAGE"] = self.getLanguage()[:2]
 		os.environ["GST_SUBTITLE_ENCODING"] = self.getGStreamerSubtitleEncoding()
 
 	def activateLanguageIndex(self, index):


### PR DESCRIPTION
-it solves a strange problem with the installation of the native language
for some plugins, e.g. PartnerBox