### PR TITLE
CA: When descramling iterate demuxes in ascending order

### DIFF
--- a/lib/dvb/dvb.cpp
+++ b/lib/dvb/dvb.cpp
@@ -977,7 +977,7 @@ RESULT eDVBResourceManager::allocateDemux(eDVBRegisteredFrontend *fe, ePtr<eDVBA
 					}
 				}
 			}
-			if (fe)
+			if (fe || (cap & iDVBChannel::capDecode))
 			{
 				++i;
 			}


### PR DESCRIPTION
We missed that on commit 4c12411