### PR TITLE
correct snr value for Si216x tuner

### DIFF
--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -979,6 +979,18 @@ void eDVBFrontend::calculateSignalQuality(int snr, int &signalquality, int &sign
 		default: break;
 		}
 	}
+	else if (!strcmp(m_description, "Si216x"))
+	{
+		eDVBFrontendParametersTerrestrial parm;
+		oparm.getDVBT(parm);
+		switch (parm.system)
+		{
+		case eDVBFrontendParametersTerrestrial::System_DVB_T:
+		case eDVBFrontendParametersTerrestrial::System_DVB_T2: 
+		case eDVBFrontendParametersTerrestrial::System_DVB_T_T2: ret = (int)((snr * 10) / 15); break;
+		default: break;
+		}
+	}
 
 	signalqualitydb = ret;
 	if (ret == 0x12345678) // no snr db calculation avail.. return untouched snr value..


### PR DESCRIPTION
-only DVB-T/T2 mode