### PR TITLE
For filesrc media unpause gst after media settings are known.

### DIFF
--- a/lib/service/servicemp3.h
+++ b/lib/service/servicemp3.h
@@ -303,8 +303,10 @@ private:
 	bool m_seek_paused;
 	/* cuesheet load check */
 	bool m_cuesheet_loaded;
+	bool m_file_source;
 	/* servicemMP3 chapter TOC support CVR */
 #if GST_VERSION_MAJOR >= 1
+	bool m_user_paused;
 	bool m_use_chapter_entries;
 	/* last used seek position gst-1 only */
 	gint64 m_last_seek_pos;


### PR DESCRIPTION
 Recently this pause sequence behaviour has been changed.
 Cause it could cause deadlock by some live streams.
 The result was that again by some media the video runned audio not
 or only after a couple off minuts playing the audio came by dts streams
 mostly out off sync by a half fragment.
 Now it's only for filesrc media that the gstreamer is set to playing ,
 after all settings are known.

	modified:   lib/service/servicemp3.cpp
	modified:   lib/service/servicemp3.h