### PR TITLE
Unpause gst after media settings are known.

### DIFF
--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -416,6 +416,7 @@ eServiceMP3::eServiceMP3(eServiceReference ref):
 	m_paused = false;
 	m_seek_paused = false;
 	m_cuesheet_loaded = false; /* cuesheet CVR */
+	m_user_paused = false;
 #if GST_VERSION_MAJOR >= 1
 	m_use_chapter_entries = false; /* TOC chapter support CVR */
 	m_last_seek_pos = 0; /* CVR last seek position */
@@ -750,7 +751,7 @@ RESULT eServiceMP3::start()
 	{
 		eDebug("[eServiceMP3] starting pipeline");
 		GstStateChangeReturn ret;
-		ret = gst_element_set_state (m_gst_playbin, GST_STATE_PLAYING);
+		ret = gst_element_set_state (m_gst_playbin, GST_STATE_PAUSED);
 
 		switch(ret)
 		{
@@ -1747,6 +1748,7 @@ void eServiceMP3::gstBusCall(GstMessage *msg)
 				{
 					if ( m_sourceinfo.is_streaming && m_streamingsrc_timeout )
 						m_streamingsrc_timeout->stop();
+					m_user_paused = false;
 					m_paused = false;
 					if (m_seek_paused)
 					{
@@ -1758,6 +1760,7 @@ void eServiceMP3::gstBusCall(GstMessage *msg)
 				}	break;
 				case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
 				{
+					m_user_paused = true;
 					m_paused = true;
 				}	break;
 				case GST_STATE_CHANGE_PAUSED_TO_READY:
@@ -2030,6 +2033,8 @@ void eServiceMP3::gstBusCall(GstMessage *msg)
 				if (m_errorInfo.missing_codec.find("video/") == 0 || (m_errorInfo.missing_codec.find("audio/") == 0 && m_audioStreams.empty()))
 					m_event((iPlayableService*)this, evUser+12);
 			}
+			if(!m_user_paused)
+				gst_element_set_state (m_gst_playbin, GST_STATE_PLAYING);
 			break;
 		}
 		case GST_MESSAGE_ELEMENT:

--- a/lib/service/servicemp3.h
+++ b/lib/service/servicemp3.h
@@ -303,6 +303,7 @@ private:
 	bool m_seek_paused;
 	/* cuesheet load check */
 	bool m_cuesheet_loaded;
+	bool m_user_paused;
 	/* servicemMP3 chapter TOC support CVR */
 #if GST_VERSION_MAJOR >= 1
 	bool m_use_chapter_entries;


### PR DESCRIPTION
 Recently a change caused for a lot off media video to run before
 All audio settings where known and done. That caused sync issues.
 Now gst will only pass to play if all settings are known and done

	modified:   lib/service/servicemp3.cpp
	modified:   lib/service/servicemp3.h