### PR TITLE
DVB-S sat config: set default nothing connected

### DIFF
--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -1557,7 +1557,7 @@ def InitNimManager(nimmgr):
 			if len(nimmgr.canConnectTo(x)) > 0:
 				config_mode_choices.append(("loopthrough", _("loopthrough to")))
 			nim.advanced = ConfigNothing()
-			tmp = ConfigSelection(config_mode_choices, "simple")
+			tmp = ConfigSelection(config_mode_choices, "nothing")
 			tmp.slot_id = x
 			tmp.addNotifier(configModeChanged, initial_call = False)
 			nim.configMode = tmp


### PR DESCRIPTION
-this solves the problem empty list of satellites

gma2/python/Plugins/SystemPlugins/Satfinder/plugin.py",
line 101, in createSetup
if len(nimmanager.getTransponders(int(self.tuning_sat.value))) < 1: #
Only offer 'predefined transponder' if some transponders exist
ValueError: invalid literal for int() with base 10: ''