### PR TITLE
Renderer: create new CiModuleControl

### DIFF
--- a/lib/python/Components/Renderer/CiModuleControl.py
+++ b/lib/python/Components/Renderer/CiModuleControl.py
@@ -1,0 +1,57 @@
+from Renderer import Renderer
+from enigma import eDVBCI_UI, eDVBCIInterfaces, eLabel, iPlayableService
+from Components.VariableText import VariableText
+
+class CiModuleControl(Renderer, VariableText):
+	def __init__(self):
+		Renderer.__init__(self)
+		VariableText.__init__(self)
+		self.eDVBCIUIInstance = eDVBCI_UI.getInstance()
+		self.eDVBCIUIInstance and self.eDVBCIUIInstance.ciStateChanged.get().append(self.ciModuleStateChanged)
+		self.NUM_CI = eDVBCIInterfaces.getInstance() and eDVBCIInterfaces.getInstance().getNumOfSlots()
+		self.text = ""
+		self.allVisible = False
+
+	GUI_WIDGET = eLabel
+
+	def applySkin(self, desktop, parent):
+		attribs = self.skinAttributes[:]
+		for (attrib, value) in self.skinAttributes:
+			if attrib == "allVisible":
+				self.allVisible = value == "1"
+				attribs.remove((attrib,value))
+				break
+		self.skinAttributes = attribs
+		return Renderer.applySkin(self, desktop, parent)
+
+	def ciModuleStateChanged(self, slot):
+		self.changed(True)
+
+	def changed(self, what):
+		if what == True or what[0] == self.CHANGED_SPECIFIC and what[1] == iPlayableService.evStart:
+			string = ""
+			if self.NUM_CI and self.NUM_CI > 0:
+				if self.eDVBCIUIInstance:
+					for slot in range(self.NUM_CI):
+						add_num = True
+						if string:
+							string += " "
+						state = self.eDVBCIUIInstance.getState(slot)
+						if state != -1:
+							if state == 0:
+								if not self.allVisible:
+									string += ""
+									add_num = False
+								else:
+									string += "\c007?7?7?"
+							elif state == 1:
+								string += "\c00????00"
+							elif state == 2:
+								string += "\c0000??00"
+						else:
+							string += "\c00??2525"
+						if add_num:
+							string += "%d" % (slot + 1)
+					if string:
+						string = _("CI slot: ") + string
+			self.text = string

--- a/lib/python/Components/Renderer/Makefile.am
+++ b/lib/python/Components/Renderer/Makefile.am
@@ -2,5 +2,5 @@ installdir = $(pkglibdir)/python/Components/Renderer
 
 install_PYTHON = \
 	__init__.py Label.py Progress.py Listbox.py Renderer.py Pixmap.py \
-	FixedLabel.py PositionGauge.py Canvas.py Picon.py Pig.py \
+	FixedLabel.py PositionGauge.py Canvas.py CiModuleControl.py Picon.py Pig.py \
 	FrontpanelLed.py ChannelNumber.py VideoSize.py NextEpgInfo.py


### PR DESCRIPTION
-for change  state CI(+) modules
state 0 (no module) --> slot number(gray color)
state 1 (init module) --> slot number(yellow color)
state 2 (module ready) --> slot number(green color)
state -1 (error) --> slot number(red color)

-if state  0 and not self.allVisible(default)  text not show
please add allVisible="1" in skin attributes if this text show

example:
<widget source="session.CurrentService" render="CiModuleControl"
allVisible="0" position="760, 412" size="130,25" borderWidth="1"
zPosition="1" transparent="1" font="Regular;20"/>