### PR TITLE
Renderer/CiModuleControl: not show state -1(error)

### DIFF
--- a/lib/python/Components/Renderer/CiModuleControl.py
+++ b/lib/python/Components/Renderer/CiModuleControl.py
@@ -49,7 +49,11 @@ class CiModuleControl(Renderer, VariableText):
 							elif state == 2:
 								string += "\c0000??00"
 						else:
-							string += "\c00??2525"
+							if not self.allVisible:
+								string += ""
+								add_num = False
+							else:
+								string += "\c00??2525"
 						if add_num:
 							string += "%d" % (slot + 1)
 					if string:


### PR DESCRIPTION
-strange response to formuler1, if there is no CI module answer
-1(error)