### PR TITLE
RecordTimer: new logic show notify conflicts   in startup

### DIFF
--- a/RecordTimer.py
+++ b/RecordTimer.py
@@ -744,7 +744,6 @@ class RecordTimer(timer.Timer):
 		return False
 
 	def loadTimer(self):
-		# TODO: PATH!
 		if not Directories.fileExists(self.Filename):
 			return
 		try:
@@ -768,16 +767,20 @@ class RecordTimer(timer.Timer):
 
 		root = doc.getroot()
 
-		# put out a message when at least one timer overlaps
-		checkit = True
+		checkit = False
+		timer_text = ""
 		for timer in root.findall("timer"):
 			newTimer = createTimer(timer)
-			if (self.record(newTimer, ignoreTSC=True, dosave=False) is not None) and checkit:
-				from Tools.Notifications import AddPopup
-				from Screens.MessageBox import MessageBox
-				timer_text = _("\nTimer '%s' disabled!") % newTimer.name
-				AddPopup(_("Timer overlap in timers.xml detected!\nPlease recheck it!") + timer_text, type = MessageBox.TYPE_ERROR, timeout = 0, id = "TimerLoadFailed")
-				checkit = False # at moment it is enough when the message is displayed one time
+			conflict_list = self.record(newTimer, ignoreTSC=True, dosave=False, loadtimer=True)
+			if conflict_list:
+				checkit = True
+				if newTimer in conflict_list:
+					timer_text += _("\nTimer '%s' disabled!") % newTimer.name
+		if checkit:
+			from Tools.Notifications import AddPopup
+			from Screens.MessageBox import MessageBox
+			AddPopup(_("Timer overlap in timers.xml detected!\nPlease recheck it!") + timer_text, type = MessageBox.TYPE_ERROR, timeout = 0, id = "TimerLoadFailed")
+
 
 	def saveTimer(self):
 		#root_element = xml.etree.cElementTree.Element('timers')
@@ -921,8 +924,9 @@ class RecordTimer(timer.Timer):
 					return True
 		return False
 
-	def record(self, entry, ignoreTSC=False, dosave=True): # wird von loadTimer mit dosave=False aufgerufen
-		timersanitycheck = TimerSanityCheck(self.timer_list,entry)
+	def record(self, entry, ignoreTSC=False, dosave=True, loadtimer=False):
+		check_timer_list = self.timer_list[:]
+		timersanitycheck = TimerSanityCheck(check_timer_list,entry)
 		answer = None
 		if not timersanitycheck.check():
 			if not ignoreTSC:
@@ -931,9 +935,13 @@ class RecordTimer(timer.Timer):
 				return timersanitycheck.getSimulTimerList()
 			else:
 				print "[RecordTimer] ignore timer conflict..."
-				if not dosave:
-					entry.disabled = True
-					answer = timersanitycheck.getSimulTimerList()
+				if not dosave and loadtimer:
+					simulTimerList = timersanitycheck.getSimulTimerList()
+					if entry in simulTimerList:
+						entry.disabled = True
+						if entry in check_timer_list:
+							check_timer_list.remove(entry)
+					answer = simulTimerList
 		elif timersanitycheck.doubleCheck():
 			print "[RecordTimer] ignore double timer..."
 			return None


### PR DESCRIPTION
1)Disable the timer only if it is in conflict list
2)Remove this timer in from check  list

In the past this has led to disabling all timers
from the list after the first found conflict.