### PR TITLE
scan.cpp: re add flag dxDontshow for all type scan

### DIFF
--- a/lib/dvb/scan.cpp
+++ b/lib/dvb/scan.cpp
@@ -1081,6 +1081,17 @@ void eDVBScan::insertInto(iDVBChannelList *db, bool backgroundscanresult)
 		bool clearCable=false;
 		std::set<unsigned int> scanned_sat_positions;
 
+		for (std::map<eServiceReferenceDVB, ePtr<eDVBService> >::const_iterator
+			service(m_new_services.begin()); service != m_new_services.end(); ++service)
+		{
+			ePtr<eDVBService> dvb_service;
+			if (!db->getService(service->first, dvb_service))
+			{
+				if (dvb_service->m_flags & eDVBService::dxDontshow)
+					service->second->m_flags |= eDVBService::dxDontshow;
+			}
+		}
+
 		std::list<ePtr<iDVBFrontendParameters> >::iterator it(m_ch_scanned.begin());
 		for (;it != m_ch_scanned.end(); ++it)
 		{


### PR DESCRIPTION
When old service is this flag and use option scanRemoveServices re add flag
for new scan service