### PR TITLE
Possibility to set custom pid for parsing epg data

### DIFF
--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -405,10 +405,10 @@ eEPGCache::eEPGCache()
 		while (!pid_file.eof())
 		{
 			getline(pid_file, line);
-			if (line[0] == '#' ||
-				line.empty() ||
-				sscanf(line.c_str(), "%i %i %i %i", &op, &tsid, &onid, &eitpid) != 4) continue;
-			if (op < 0) op += 3600;
+			if (line[0] == '#' || sscanf(line.c_str(), "%i %i %i %i", &op, &tsid, &onid, &eitpid) != 4)
+				continue;
+			if (op < 0)
+				op += 3600;
 			if (eitpid != 0)
 			{
 				sprintf (optsidonid, "%x%04x%04x", op, tsid, onid);

--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -398,6 +398,7 @@ eEPGCache::eEPGCache()
 	std::ifstream pid_file ("/etc/enigma2/epgpids.custom");
 	if (pid_file.is_open())
 	{
+		eDebug("[eEPGCache] Found custom pidfile, parsing...");
 		std::string line;
 		char nstsidonid[12];
 		int ns, tsid, onid, eitpid;
@@ -410,11 +411,13 @@ eEPGCache::eEPGCache()
 			if (ns < 0) ns += 3600;
 			if (eitpid != 0)
 			{
-				sprintf (nstsidonid, "%04x%04x%04x", ns, tsid, onid);
+				sprintf (nstsidonid, "%x%04x%04x", ns, tsid, onid);
 				customeitpid[std::string(nstsidonid)] = eitpid;
+				eDebug("[eEPGCache] %s --> %#x", nstsidonid, eitpid);
 			}
 		}
 		pid_file.close();
+		eDebug("[eEPGCache] Done");
 	}
 
 	ePtr<eDVBResourceManager> res_mgr;
@@ -1601,7 +1604,7 @@ void eEPGCache::channel_data::startEPG()
 	int tsid = chid.transport_stream_id.get();
 	int onid = chid.original_network_id.get();
 	char nstsidonid[8];
-	sprintf (nstsidonid,"%08x", ns);
+	sprintf (nstsidonid,"%x", ns);
 	nstsidonid [strlen(nstsidonid) - 4] = '\0';
 	sprintf (nstsidonid, "%s%04x%04x", nstsidonid, tsid, onid);
 	std::map<std::string,int>::iterator it = cache->customeitpid.find(std::string(nstsidonid));

--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -398,22 +398,22 @@ eEPGCache::eEPGCache()
 	std::ifstream pid_file ("/etc/enigma2/epgpids.custom");
 	if (pid_file.is_open())
 	{
-		eDebug("[eEPGCache] Found custom pidfile, parsing...");
+		eDebug("[eEPGCache] Custom pidfile found, parsing...");
 		std::string line;
-		char nstsidonid[12];
-		int ns, tsid, onid, eitpid;
+		char optsidonid[12];
+		int op, tsid, onid, eitpid;
 		while (!pid_file.eof())
 		{
-			std::getline(pid_file,line);
+			getline(pid_file, line);
 			if (line[0] == '#' ||
 				line.empty() ||
-				sscanf(line.c_str(), "%i %i %i %i", &ns, &tsid, &onid, &eitpid) != 4) continue;
-			if (ns < 0) ns += 3600;
+				sscanf(line.c_str(), "%i %i %i %i", &op, &tsid, &onid, &eitpid) != 4) continue;
+			if (op < 0) op += 3600;
 			if (eitpid != 0)
 			{
-				sprintf (nstsidonid, "%x%04x%04x", ns, tsid, onid);
-				customeitpid[std::string(nstsidonid)] = eitpid;
-				eDebug("[eEPGCache] %s --> %#x", nstsidonid, eitpid);
+				sprintf (optsidonid, "%x%04x%04x", op, tsid, onid);
+				customeitpids[std::string(optsidonid)] = eitpid;
+				eDebug("[eEPGCache] %s --> %#x", optsidonid, eitpid);
 			}
 		}
 		pid_file.close();
@@ -1600,15 +1600,12 @@ void eEPGCache::channel_data::startEPG()
 	mask.flags = eDVBSectionFilterMask::rfCRC;
 
 	eDVBChannelID chid = channel->getChannelID();
-	int ns = chid.dvbnamespace.get();
-	int tsid = chid.transport_stream_id.get();
-	int onid = chid.original_network_id.get();
-	char nstsidonid[8];
-	sprintf (nstsidonid,"%x", ns);
-	nstsidonid [strlen(nstsidonid) - 4] = '\0';
-	sprintf (nstsidonid, "%s%04x%04x", nstsidonid, tsid, onid);
-	std::map<std::string,int>::iterator it = cache->customeitpid.find(std::string(nstsidonid));
-	if (it != cache->customeitpid.end())
+	char optsidonid[8];
+	sprintf (optsidonid, "%x", chid.dvbnamespace.get());
+	optsidonid [strlen(optsidonid) - 4] = '\0';
+	sprintf (optsidonid, "%s%04x%04x", optsidonid, chid.transport_stream_id.get(), chid.original_network_id.get());
+	std::map<std::string,int>::iterator it = cache->customeitpids.find(std::string(optsidonid));
+	if (it != cache->customeitpids.end())
 	{
 		mask.pid = it->second;
 		eDebug("[eEPGCache] Using non standart pid %#x", mask.pid);

--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -1574,6 +1574,35 @@ void eEPGCache::channel_data::startEPG()
 	mask.pid = 0x12;
 	mask.flags = eDVBSectionFilterMask::rfCRC;
 
+	std::ifstream pid_file ("/etc/enigma2/epgpids.custom");
+	if (pid_file.is_open())
+	{
+		std::string line;
+		eDVBChannelID chid = channel->getChannelID();
+		int ns = chid.dvbnamespace.get();
+		int tsid = chid.transport_stream_id.get();
+		int onid = chid.original_network_id.get();
+		int a, b, c, d;
+		char dvbns [8];
+		sprintf (dvbns,"%x", ns);
+		dvbns [strlen(dvbns) - 4] = '\0';
+		sscanf (dvbns,"%x", &ns);
+		while (!pid_file.eof())
+		{
+			std::getline(pid_file,line);
+			if (line[0] == '#' ||
+				line.empty() ||
+				sscanf(line.c_str(), "%i %i %i %i", &a, &b, &c, &d) != 4) continue;
+			if (a < 0) a += 3600;
+			if (a == ns && b == tsid && c == onid && d != 0)
+			{
+				mask.pid = d;
+				eDebug("[eEPGCache] Using non standart pid %#x", mask.pid);
+				break;
+			}
+		}
+		pid_file.close();
+	}
 	if (eEPGCache::getInstance()->getEpgSources() & eEPGCache::NOWNEXT)
 	{
 		mask.data[0] = 0x4E;

--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -395,6 +395,28 @@ eEPGCache::eEPGCache()
 	         onid_blacklist.insert(onid_blacklist.end(),1,tmp_onid);
 	onid_file.close();
 
+	std::ifstream pid_file ("/etc/enigma2/epgpids.custom");
+	if (pid_file.is_open())
+	{
+		std::string line;
+		char nstsidonid[12];
+		int ns, tsid, onid, eitpid;
+		while (!pid_file.eof())
+		{
+			std::getline(pid_file,line);
+			if (line[0] == '#' ||
+				line.empty() ||
+				sscanf(line.c_str(), "%i %i %i %i", &ns, &tsid, &onid, &eitpid) != 4) continue;
+			if (ns < 0) ns += 3600;
+			if (eitpid != 0)
+			{
+				sprintf (nstsidonid, "%04x%04x%04x", ns, tsid, onid);
+				customeitpid[std::string(nstsidonid)] = eitpid;
+			}
+		}
+		pid_file.close();
+	}
+
 	ePtr<eDVBResourceManager> res_mgr;
 	eDVBResourceManager::getInstance(res_mgr);
 	if (!res_mgr)
@@ -1574,35 +1596,21 @@ void eEPGCache::channel_data::startEPG()
 	mask.pid = 0x12;
 	mask.flags = eDVBSectionFilterMask::rfCRC;
 
-	std::ifstream pid_file ("/etc/enigma2/epgpids.custom");
-	if (pid_file.is_open())
+	eDVBChannelID chid = channel->getChannelID();
+	int ns = chid.dvbnamespace.get();
+	int tsid = chid.transport_stream_id.get();
+	int onid = chid.original_network_id.get();
+	char nstsidonid[8];
+	sprintf (nstsidonid,"%08x", ns);
+	nstsidonid [strlen(nstsidonid) - 4] = '\0';
+	sprintf (nstsidonid, "%s%04x%04x", nstsidonid, tsid, onid);
+	std::map<std::string,int>::iterator it = cache->customeitpid.find(std::string(nstsidonid));
+	if (it != cache->customeitpid.end())
 	{
-		std::string line;
-		eDVBChannelID chid = channel->getChannelID();
-		int ns = chid.dvbnamespace.get();
-		int tsid = chid.transport_stream_id.get();
-		int onid = chid.original_network_id.get();
-		int a, b, c, d;
-		char dvbns [8];
-		sprintf (dvbns,"%x", ns);
-		dvbns [strlen(dvbns) - 4] = '\0';
-		sscanf (dvbns,"%x", &ns);
-		while (!pid_file.eof())
-		{
-			std::getline(pid_file,line);
-			if (line[0] == '#' ||
-				line.empty() ||
-				sscanf(line.c_str(), "%i %i %i %i", &a, &b, &c, &d) != 4) continue;
-			if (a < 0) a += 3600;
-			if (a == ns && b == tsid && c == onid && d != 0)
-			{
-				mask.pid = d;
-				eDebug("[eEPGCache] Using non standart pid %#x", mask.pid);
-				break;
-			}
-		}
-		pid_file.close();
+		mask.pid = it->second;
+		eDebug("[eEPGCache] Using non standart pid %#x", mask.pid);
 	}
+	
 	if (eEPGCache::getInstance()->getEpgSources() & eEPGCache::NOWNEXT)
 	{
 		mask.data[0] = 0x4E;

--- a/lib/dvb/epgcache.h
+++ b/lib/dvb/epgcache.h
@@ -258,6 +258,7 @@ private:
 	unsigned int historySeconds;
 
 	std::vector<int> onid_blacklist;
+	std::map<std::string,int> customeitpid;
 	eventCache eventDB;
 	updateMap channelLastUpdated;
 	std::string m_filename;

--- a/lib/dvb/epgcache.h
+++ b/lib/dvb/epgcache.h
@@ -258,7 +258,7 @@ private:
 	unsigned int historySeconds;
 
 	std::vector<int> onid_blacklist;
-	std::map<std::string,int> customeitpid;
+	std::map<std::string,int> customeitpids;
 	eventCache eventDB;
 	updateMap channelLastUpdated;
 	std::string m_filename;


### PR DESCRIPTION
This is very useful if a transponder epg be filed in 2 or more different pids or use non stardart one.
For example, the platform Dolce sent epg data on Romanian language on PID 0x12 and Bulgarian and Serbian on PID 0x12b. If create reader for PID 0x12b, some events are Romanian language, others are Bulgarian because of PID 0x12 no information about the language of epg data.
Usage:
Create a file "/etc/enigma2/epgpids.cusom" and fill in the format

Orbital position | TSID | ONID | Custom pid to use

The values ​​can be decimal or hexadecimal (0x ...), and combined
For orbital position using integers where 1 means 0,1 ° (19,2°E -> 192)
For orbital position can be used as negative numbers (0,8°W -> -8 or 3592)

examples:
390 17 28 299 # 39°E 12688V, epgpid to use: 299
0x186 0x11 0x1c 0x12b # Same, but in hexadecimal format
390 17 28 0x12b # Or combined