### PR TITLE
pmtparse: fix VC-1 codec in getProgramInfo

### DIFF
--- a/lib/dvb/pmtparse.cpp
+++ b/lib/dvb/pmtparse.cpp
@@ -302,6 +302,7 @@ int eDVBPMTParser::getProgramInfo(program &program)
 											video.type = videoStream::vtVC1_SM; // simple main
 										isvideo = 1;
 									}
+									break;
 								}
 								case 0x48455643: /*HEVC */
 									isvideo = 1;


### PR DESCRIPTION
Add forgotten break in https://github.com/OpenPLi/enigma2/commit/1f43fca4ab0e078eb11b3f9455690a8f36ccfe7a
Thx for report nikolasi
This fix VC-1 sound on blu-ray.