### PR TITLE
InfoBarSubtitleSupport: fix GSOD when iSubtitleOutput is not implemented

### DIFF
--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -3194,7 +3194,7 @@ class InfoBarSubtitleSupport(object):
 	def __updatedInfo(self):
 		if not self.selected_subtitle:
 			subtitle = self.getCurrentServiceSubtitle()
-			cachedsubtitle = subtitle.getCachedSubtitle()
+			cachedsubtitle = subtitle and subtitle.getCachedSubtitle()
 			if cachedsubtitle:
 				self.enableSubtitle(cachedsubtitle)
 


### PR DESCRIPTION
I'm implementing custom service and currently don't have iSubtitlesOutput done, so I'm getting crash. 
I think we shouldn't assume that iSubtitlesOutput is always available, which is done in this simple patch.