### PR TITLE
Fix CI info - thanks betacentauri

### DIFF
--- a/lib/mmi/mmi_ui.cpp
+++ b/lib/mmi/mmi_ui.cpp
@@ -114,10 +114,8 @@ int eMMI_UI::processMMIData(int slot_id, const unsigned char *tag, const void *d
 			memcpy(str, ((char*)d), textlen);
 			str[textlen] = '\0';
 			mmiScreenAddText(slot_id, pos++, (char*)convertDVBUTF8(str).c_str());
-			eDebugNoNewLineStart("[eMMI_UI] ");
-			while (textlen--)
-				eDebugNoNewLine("%c", *d++);
-			eDebugNoNewLine("\n");
+			eDebug("[eMMI_UI] %s", str);
+			d += textlen;
 		}
 		mmiScreenFinish(slot_id);
 		break;


### PR DESCRIPTION
CI info was not shown when debug log was disabled.
Seperating debug from program logic.