### PR TITLE
ServiceMP3 enigma2 freeze bug when paused

### DIFF
--- a/lib/service/servicemp3.h
+++ b/lib/service/servicemp3.h
@@ -304,7 +304,6 @@ private:
 	bool m_is_live;
 	bool m_use_prefillbuffer;
 	bool m_paused;
-	bool m_seek_paused;
 	/* cuesheet load check */
 	bool m_cuesheet_loaded;
 	/* servicemMP3 chapter TOC support CVR */


### PR DESCRIPTION
 When media is paused and user tried to change the used audio track
 To the next avbl track enigma2 freeze stb freezed.
 mx3L found out that problem is solved if we start with flushseek,
 then change the track problem is solved.
 Then removed the unneeded pas to playing back to stop on audio
 track change when paused.

	modified:   lib/service/servicemp3.cpp
	modified:   lib/service/servicemp3.h