### PR TITLE
ServiceMP3 enigma2 freeze bug when paused.

### DIFF
--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -884,6 +884,13 @@ RESULT eServiceMP3::getLength(pts_t &pts)
 RESULT eServiceMP3::seekToImpl(pts_t to)
 {
 		/* convert pts to nanoseconds */
+	if (m_paused)
+	{
+		m_paused = false;
+		m_seek_paused = true;
+		gst_element_set_state(m_gst_playbin, GST_STATE_PLAYING);
+	}
+
 #if GST_VERSION_MAJOR < 1
 	gint64 time_nanoseconds = to * 11111LL;
 	if (!gst_element_seek (m_gst_playbin, m_currentTrickRatio, GST_FORMAT_TIME, (GstSeekFlags)(GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_KEY_UNIT),
@@ -898,12 +905,6 @@ RESULT eServiceMP3::seekToImpl(pts_t to)
 	{
 		eDebug("[eServiceMP3] seekTo failed");
 		return -1;
-	}
-
-	if (m_paused)
-	{
-		m_seek_paused = true;
-		gst_element_set_state(m_gst_playbin, GST_STATE_PLAYING);
 	}
 
 	return 0;
@@ -1569,18 +1570,12 @@ RESULT eServiceMP3::selectTrack(unsigned int i)
 		if (ppos < 0)
 			ppos = 0;
 	}
-
-	int ret = selectAudioStream(i);
-	if (!ret)
+	if (validposition)
 	{
-		if (validposition)
-		{
-			/* flush */
-			seekTo(ppos);
-		}
+		/* flush */
+		seekTo(ppos);
 	}
-
-	return ret;
+	return selectAudioStream(i);
 }
 
 int eServiceMP3::selectAudioStream(int i)
@@ -1817,14 +1812,16 @@ void eServiceMP3::gstBusCall(GstMessage *msg)
 				}	break;
 				case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
 				{
-					m_paused = false;
 					if (m_seek_paused)
 					{
 						m_seek_paused = false;
-						gst_element_set_state(m_gst_playbin, GST_STATE_PAUSED);
+						pause();
 					}
 					else
+					{
+						m_paused = false;
 						m_event((iPlayableService*)this, evGstreamerPlayStarted);
+					}
 				}	break;
 				case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
 				{


### PR DESCRIPTION
 First changed sequence when changing audio track.
 First flush will be done then the trach change.
 Then relocation off the pas to playing before seekflush is done.
 This avoids a/v sync issues.

	modified:   lib/service/servicemp3.cpp