### PR TITLE
Enigma2 freeze on track change while paused and a/v sink issues

### DIFF
--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -1569,18 +1569,12 @@ RESULT eServiceMP3::selectTrack(unsigned int i)
 		if (ppos < 0)
 			ppos = 0;
 	}
-
-	int ret = selectAudioStream(i);
-	if (!ret)
+	if (validposition)
 	{
-		if (validposition)
-		{
-			/* flush */
-			seekTo(ppos);
-		}
+		/* flush */
+		seekTo(ppos);
 	}
-
-	return ret;
+	return selectAudioStream(i);
 }
 
 int eServiceMP3::selectAudioStream(int i)

--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -1812,13 +1812,7 @@ void eServiceMP3::gstBusCall(GstMessage *msg)
 				case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
 				{
 					m_paused = false;
-					if (m_seek_paused)
-					{
-						m_seek_paused = false;
-						gst_element_set_state(m_gst_playbin, GST_STATE_PAUSED);
-					}
-					else
-						m_event((iPlayableService*)this, evGstreamerPlayStarted);
+					m_event((iPlayableService*)this, evGstreamerPlayStarted);
 				}	break;
 				case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
 				{
@@ -2081,6 +2075,12 @@ void eServiceMP3::gstBusCall(GstMessage *msg)
 				m_subtitleStreams.push_back(subs);
 			}
 			m_event((iPlayableService*)this, evUpdatedInfo);
+
+			if (m_seek_paused)
+			{
+				m_seek_paused = false;
+				gst_element_set_state(m_gst_playbin, GST_STATE_PAUSED);
+			}
 
 			if ( m_errorInfo.missing_codec != "" )
 			{


### PR DESCRIPTION
When user paused the file media, then changed the audio track to the next avbl track e2 freezed.
- solved by patch mx3L first flush then change audio-track.

- a/v sync issues do occur at wild when performing actions when in paused state.
at wild I mean sometimes well sometimes not.
Introduced on commit https://github.com/OpenPLi/enigma2/commit/738e628e619e05c9df8df5007c5d8bafe68dc48d
But this action is well needed to have e2 state change while performing several action when paused.
The sync issue occurred cause we proceeded back to pause before the previous state change to playing to have the e2 state updated was completed. 
The relocation off the back to pause routine to the place when the previous state change was really completed solve this a/v sync issues. That is after message_async_done we are working async.