### PR TITLE
E2 state update during paused whitout gst play/paused state change

### DIFF
--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -412,7 +412,6 @@ eServiceMP3::eServiceMP3(eServiceReference ref):
 	m_is_live = false;
 	m_use_prefillbuffer = false;
 	m_paused = false;
-	m_seek_paused = false;
 	m_cuesheet_loaded = false; /* cuesheet CVR */
 #if GST_VERSION_MAJOR >= 1
 	m_use_chapter_entries = false; /* TOC chapter support CVR */
@@ -902,8 +901,7 @@ RESULT eServiceMP3::seekToImpl(pts_t to)
 
 	if (m_paused)
 	{
-		m_seek_paused = true;
-		gst_element_set_state(m_gst_playbin, GST_STATE_PLAYING);
+		m_event((iPlayableService*)this, evUpdatedInfo);
 	}
 
 	return 0;
@@ -1131,7 +1129,7 @@ RESULT eServiceMP3::getPlayPosition(pts_t &pts)
 	if ((pos = get_pts_pcrscr()) > 0)
 		pos *= 11111LL;
 #else
-	if (audioSink || videoSink)
+	if ((audioSink || videoSink) && !m_paused)
 	{
 		g_signal_emit_by_name(audioSink ? audioSink : videoSink, "get-decoder-time", &pos);
 		if (!GST_CLOCK_TIME_IS_VALID(pos)) return -1;
@@ -2074,13 +2072,8 @@ void eServiceMP3::gstBusCall(GstMessage *msg)
 				g_free(g_codec);
 				m_subtitleStreams.push_back(subs);
 			}
-			m_event((iPlayableService*)this, evUpdatedInfo);
 
-			if (m_seek_paused)
-			{
-				m_seek_paused = false;
-				gst_element_set_state(m_gst_playbin, GST_STATE_PAUSED);
-			}
+			m_event((iPlayableService*)this, evUpdatedInfo);
 
 			if ( m_errorInfo.missing_codec != "" )
 			{

--- a/lib/service/servicemp3.h
+++ b/lib/service/servicemp3.h
@@ -304,7 +304,6 @@ private:
 	bool m_is_live;
 	bool m_use_prefillbuffer;
 	bool m_paused;
-	bool m_seek_paused;
 	/* cuesheet load check */
 	bool m_cuesheet_loaded;
 	/* servicemMP3 chapter TOC support CVR */


### PR DESCRIPTION
 If media is set to paused, and user changed audio track or
 jumped between chapters. E2 needs to be updated to have the new pts.
 However since we are paused the ioctl getplayposition will be
 the one which was present when we paused the media. For that before
 we just unpaused the media and repaused the media this to have the
 new position.
 That is not required if we are paused and do a change the new position
 is known since there is always a SeekTo done. For that during paused,
 the new and consecutive play positions update must come from gstreamer
 as long the media is paused. During paused state the new play position
 after a change does now come from a gst_element_query_position.
 This avoids an unneeded set to play back to pause and avoids all a/v sync issues.
 During paused we will after a change just pas a evUpdatedInfo after a seek to.
 Then you can see for exmaple you're actions on the media bar.

	modified:   lib/service/servicemp3.cpp
	modified:   lib/service/servicemp3.h