### PR TITLE
SystemInfo: add HasFullHDSkinSupport for some vu+ and dreambox recivers

### DIFF
--- a/lib/python/Components/SystemInfo.py
+++ b/lib/python/Components/SystemInfo.py
@@ -48,4 +48,4 @@ SystemInfo["3DMode"] = fileCheck("/proc/stb/fb/3dmode") or fileCheck("/proc/stb/
 SystemInfo["3DZNorm"] = fileCheck("/proc/stb/fb/znorm") or fileCheck("/proc/stb/fb/primary/zoffset")
 SystemInfo["Blindscan_t2_available"] = fileCheck("/proc/stb/info/vumodel")
 SystemInfo["RcTypeChangable"] = not(HardwareInfo().get_device_model().startswith('et8500') or HardwareInfo().get_device_model().startswith('et7')) and pathExists('/proc/stb/ir/rc/type')
-SystemInfo["HasFullHDSkinSupport"] = HardwareInfo().get_device_model() not in "et4000 et5000 sh1 hd500c hd1100 xp1000 vusolo vuduo vuuno vuultimo dm500hd dm800se dm800hd fusionhd fusionhdse"
+SystemInfo["HasFullHDSkinSupport"] = HardwareInfo().get_device_model() not in "et4000 et5000 sh1 hd500c hd1100 xp1000 vusolo fusionhd fusionhdse"


### PR DESCRIPTION
As you can read here: http://forums.openpli.org/topic/41404-vu-uno-and-full-hd-skins/
many receivers who support full hd skins are disabled in HasFullHDSkinSupport.
Therefore, I remove them from the list of the receiver that does not support it.

I do not have such receivers and therefore I expected that someone from openpli team will fix it, but it seems that nobody does not use full hd skins, and therefore not worried about it.