### PR TITLE
Overscanwizard work's for all stb's.

### DIFF
--- a/lib/python/Plugins/SystemPlugins/OSDPositionSetup/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/OSDPositionSetup/plugin.py
@@ -35,9 +35,6 @@ def startup(reason, **kwargs):
 	setConfiguredPosition()
 
 def Plugins(**kwargs):
-	from os import path
-	if path.exists("/proc/stb/fb/dst_left"):
-		from Plugins.Plugin import PluginDescriptor
-		return [PluginDescriptor(name = "Overscan Wizard", description = "", where = PluginDescriptor.WHERE_SESSIONSTART, fnc = startup),
-			PluginDescriptor(name = "Overscan Wizard", description = _("Wizard to arrange the overscan"), where = PluginDescriptor.WHERE_MENU, fnc = startSetup)]
-	return []
+	from Plugins.Plugin import PluginDescriptor
+	return [PluginDescriptor(name = "Overscan Wizard", description = "", where = PluginDescriptor.WHERE_SESSIONSTART, fnc = startup),
+		PluginDescriptor(name = "Overscan Wizard", description = _("Wizard to arrange the overscan"), where = PluginDescriptor.WHERE_MENU, fnc = startSetup)]

--- a/lib/python/Screens/StartWizard.py
+++ b/lib/python/Screens/StartWizard.py
@@ -37,5 +37,6 @@ class StartWizard(WizardLanguage, Rc):
 		configfile.save()
 
 wizardManager.registerWizard(LanguageWizard, config.misc.languageselected.value, priority = 5)
-wizardManager.registerWizard(OverscanWizard, config.misc.do_overscanwizard.value, priority = 10)
+if OverscanWizard is not None:
+	wizardManager.registerWizard(OverscanWizard, config.misc.do_overscanwizard.value, priority = 10)
 wizardManager.registerWizard(StartWizard, config.misc.firstrun.value, priority = 20)


### PR DESCRIPTION
 The overscanwizard is a ussefull tool and does now work
 on all stb's . Even if stb does not support position setup self.
 It's is a nice add for user to adjust the tv self.
 Plugin is for next-master only.
 Plugin if installed always showed in system menu
 Start wizard protection should the plugin not be installed.
 The last is from Taapat.

	modified:   lib/python/Plugins/SystemPlugins/OSDPositionSetup/plugin.py
	modified:   lib/python/Screens/StartWizard.py