### PR TITLE
add Megasat Unicable II LNB Diavolo

### DIFF
--- a/data/unicable.xml
+++ b/data/unicable.xml
@@ -79,6 +79,14 @@ unicable (version)
 		<manufacturer name="Kreiling">
 			<product name="KR1440" scr1="1680" scr2="1420" scr3="2040" scr4="1210"/>
 		</manufacturer>
+		<manufacturer name="Megasat">
+			<product name="Unicable II LNB Diavolo"
+				scr1 ="1210" scr2= "1420" scr3= "1680" scr4= "2040" scr5= "1005" scr6= "1050" scr7= "1095" scr8= "1140"/>
+<!-- uncomment this once EN50607 AKA JESS is available in OpenPLI
+					scr9 ="1260" scr10="1305" scr11="1350" scr12="1475" scr13="1520" scr14="1565" scr15="1610" scr16="1725"
+					scr17="1770" scr18="1815" scr19="1860" scr20="1905" scr21="1950" scr22="1995" scr23="2085" scr24="2130" format="EN50607"/>
+-->
+		</manufacturer>
 		<manufacturer name="Radix">
 			<product name="Unicable LNB" scr1="1680" scr2="1420" scr3="2040" scr4="1210"/>
 		</manufacturer>


### PR DESCRIPTION
I have one of the missing LNBs and even though I can setup it via "user defined" option, it's much easier to simply select correct one from list of predefined ones.