### PR TITLE
epgcache: allow query from all services

### DIFF
--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -2629,12 +2629,6 @@ PyObject *eEPGCache::lookupEvent(ePyObject list, ePyObject convertFunc)
 				stime = ::time(0);
 
 			eServiceReference ref(handleGroup(eServiceReference(PyString_AS_STRING(service))));
-			if (ref.type != eServiceReference::idDVB && ref.type != eServiceReference::idServiceMP3)
-			{
-				eDebug("[eEPGCache] service reference for epg query is not valid");
-				continue;
-			}
-
 			// redirect subservice querys to parent service
 			eServiceReferenceDVB &dvb_ref = (eServiceReferenceDVB&)ref;
 			if (dvb_ref.getParentTransportStreamID().get()) // linkage subservice


### PR DESCRIPTION
EPG Cache can be queried using other services, insteand of naming all of them, simply remove the check allowing all services to query epg cache from now on.

More info: http://forums.openpli.org/topic/41198-serviceapp-gstplayer-and-exteplayer3/page-4