### PR TITLE
sec: Use frequency limits from frontend info in canTune instead of de…

### DIFF
--- a/lib/dvb/frontend.h
+++ b/lib/dvb/frontend.h
@@ -161,6 +161,7 @@ public:
 	int openFrontend();
 	int closeFrontend(bool force=false, bool no_delayed=false);
 	const char *getDescription() const { return m_description; }
+	const dvb_frontend_info getFrontendInfo() const { return fe_info; }
 	bool is_simulate() const { return m_simulate; }
 	bool is_FBCTuner() { return m_fbc; }
 	bool getEnabled() { return m_enabled; }

--- a/lib/dvb/sec.cpp
+++ b/lib/dvb/sec.cpp
@@ -49,6 +49,7 @@ eDVBSatelliteEquipmentControl::eDVBSatelliteEquipmentControl(eSmartPtrList<eDVBR
 
 int eDVBSatelliteEquipmentControl::canTune(const eDVBFrontendParametersSatellite &sat, iDVBFrontend *fe, int slot_id, int *highest_score_lnb)
 {
+	const dvb_frontend_info fe_info = ((eDVBFrontend*)fe)->getFrontendInfo();
 	bool simulate = ((eDVBFrontend*)fe)->is_simulate();
 	bool direct_connected = m_not_linked_slot_mask & slot_id;
 	int score=0, satcount=0;
@@ -221,7 +222,7 @@ int eDVBSatelliteEquipmentControl::canTune(const eDVBFrontendParametersSatellite
 					int lof = sat.frequency > lnb_param.m_lof_threshold ?
 						lnb_param.m_lof_hi : lnb_param.m_lof_lo;
 					int tuner_freq = abs(sat.frequency - lof);
-					if (tuner_freq < 900000 || tuner_freq > 2200000)
+					if (tuner_freq < fe_info.frequency_min || tuner_freq > fe_info.frequency_max)
 						ret = 0;
 				}
 


### PR DESCRIPTION
…fault 900000 - 2200000

The eDVBSatelliteEquipmentControl::canTune uses hardcoded values for frequency limits.
Use the real frontend limits from fe_info instead of using hardcoded values.

Code based on https://github.com/openatv/enigma2/commits/multituner