### PR TITLE
skin_default: fix title position in MenuSort

### DIFF
--- a/data/skin_default.xml
+++ b/data/skin_default.xml
@@ -543,8 +543,8 @@ self.autoResize()
 		<widget name="key_green" position="140,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" transparent="1"/>
 		<widget name="key_yellow" position="280,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#a08500" transparent="1"/>
 		<widget name="key_blue" position="420,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#18188b" transparent="1"/>
-		<widget source="title" render="Label" position="10,10" size="360,35" font="Regular;23"/>
-		<widget source="menu" render="Listbox" position="10,55" size="360,225" scrollbarMode="showOnDemand">
+		<widget source="title" render="Label" position="10,45" size="540,35" font="Regular;23"/>
+		<widget source="menu" render="Listbox" position="10,80" size="360,225" scrollbarMode="showOnDemand">
 			<convert type="StringList"/>
 		</widget>
 	</screen>


### PR DESCRIPTION
Move title below the buttons, rather than above the buttons.