### PR TITLE
Use lidvbsi++ t2 descriptor

### DIFF
--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -196,6 +196,49 @@ void eDVBFrontendParametersTerrestrial::set(const TerrestrialDeliverySystemDescr
 		guard_interval, hierarchy, modulation);
 }
 
+void eDVBFrontendParametersTerrestrial::set(const T2DeliverySystemDescriptor &descriptor)
+{
+	switch (descriptor.getBandwidth())
+	{
+		case 0: bandwidth = 8000000; break;
+		case 1: bandwidth = 7000000; break;
+		case 2: bandwidth = 6000000; break;
+		case 3: bandwidth = 5000000; break;
+		case 4: bandwidth = 1712000; break;
+		case 5: bandwidth = 10000000; break;
+		default: bandwidth = 0; break;
+	}
+	switch (descriptor.getTransmissionMode())
+	{
+		case 0: transmission_mode = TransmissionMode_2k; break;
+		case 1: transmission_mode = TransmissionMode_8k; break;
+		case 2: transmission_mode = TransmissionMode_4k; break;
+		case 3: transmission_mode = TransmissionMode_1k; break;
+		case 4: transmission_mode = TransmissionMode_16k; break;
+		case 5: transmission_mode = TransmissionMode_32k; break;
+		default: transmission_mode = TransmissionMode_Auto; break;
+	}
+	switch (descriptor.getGuardInterval())
+	{
+		case 0: guard_interval = GuardInterval_1_32; break;
+		case 1: guard_interval = GuardInterval_1_16; break;
+		case 2: guard_interval = GuardInterval_1_8; break;
+		case 3: guard_interval = GuardInterval_1_4; break;
+		case 4: guard_interval = GuardInterval_1_128; break;
+		case 5: guard_interval = GuardInterval_19_128; break;
+		case 6: guard_interval = GuardInterval_19_256; break;
+		case 7: guard_interval = GuardInterval_Auto; break;
+	}
+	plp_id = descriptor.getPlpId();
+	code_rate_HP = code_rate_LP = FEC_Auto;
+	hierarchy = Hierarchy_Auto;
+	modulation = Modulation_Auto;
+	inversion = Inversion_Unknown;
+	system = System_DVB_T2;
+	eDebug("[eDVBFrontendParametersTerrestrial] T2 bw %d, tm_mode %d, guard %d, plp_id %d",
+		bandwidth, transmission_mode, guard_interval, plp_id);
+}
+
 eDVBFrontendParameters::eDVBFrontendParameters()
 	:m_type(-1), m_flags(0)
 {

--- a/lib/dvb/frontendparms.h
+++ b/lib/dvb/frontendparms.h
@@ -6,6 +6,7 @@
 #include <dvbsi++/satellite_delivery_system_descriptor.h>
 #include <dvbsi++/cable_delivery_system_descriptor.h>
 #include <dvbsi++/terrestrial_delivery_system_descriptor.h>
+#include <dvbsi++/t2_delivery_system_descriptor.h>
 
 #include <lib/python/swig.h>
 #include <lib/dvb/idvb.h>
@@ -87,6 +88,7 @@ struct eDVBFrontendParametersTerrestrial
 {
 #ifndef SWIG
 	void set(const TerrestrialDeliverySystemDescriptor  &);
+	void set(const T2DeliverySystemDescriptor &);
 #endif
 	enum {
 		Bandwidth_8MHz, Bandwidth_7MHz, Bandwidth_6MHz, Bandwidth_Auto, Bandwidth_5MHz, Bandwidth_1_712MHz, Bandwidth_10MHz

--- a/lib/dvb/scan.cpp
+++ b/lib/dvb/scan.cpp
@@ -4,6 +4,7 @@
 #include <dvbsi++/service_descriptor.h>
 #include <dvbsi++/satellite_delivery_system_descriptor.h>
 #include <dvbsi++/terrestrial_delivery_system_descriptor.h>
+#include <dvbsi++/t2_delivery_system_descriptor.h>
 #include <dvbsi++/cable_delivery_system_descriptor.h>
 #include <dvbsi++/ca_identifier_descriptor.h>
 #include <dvbsi++/registration_descriptor.h>
@@ -744,95 +745,25 @@ void eDVBScan::channelDone()
 						ExtensionDescriptor &d = (ExtensionDescriptor&)**desc;
 						switch (d.getExtensionTag())
 						{
-						case 0x04: /* T2_delivery_system_descriptor */
-							if (d.getLength() > 4)
+						case T2_DELIVERY_SYSTEM_DESCRIPTOR:
+							T2 = true;
+							T2DeliverySystemDescriptor &d = (T2DeliverySystemDescriptor&)**desc;
+							t2transponder.set(d);
+
+							if(!d.getOtherFrequencyFlag())
+								break;
+
+							for (T2CellConstIterator cell = d.getCells()->begin();
+								cell != d.getCells()->end(); ++cell)
 							{
-								T2 = true;
-								t2transponder.system = eDVBFrontendParametersTerrestrial::System_DVB_T2;
-								t2transponder.plp_id = (int)d.getSelectorBytes()->at(0);
-								t2transponder.code_rate_HP = t2transponder.code_rate_LP = eDVBFrontendParametersTerrestrial::FEC_Auto;
-								t2transponder.hierarchy = eDVBFrontendParametersTerrestrial::Hierarchy_Auto;
-								t2transponder.modulation = eDVBFrontendParametersTerrestrial::Modulation_Auto;
-								t2transponder.inversion = eDVBFrontendParametersTerrestrial::Inversion_Unknown;
-								switch ((d.getSelectorBytes()->at(3) >> 2) & 0xf)
+								for (T2FrequencyConstIterator freq = (*cell)->getCentreFrequencies()->begin();
+									freq != (*cell)->getCentreFrequencies()->end(); ++freq)
 								{
-								case 0:
-									t2transponder.bandwidth = 8000000;
-									break;
-								case 1:
-									t2transponder.bandwidth = 7000000;
-									break;
-								case 2:
-									t2transponder.bandwidth = 6000000;
-									break;
-								case 3:
-									t2transponder.bandwidth = 5000000;
-									break;
-								case 4:
-									t2transponder.bandwidth = 1712000;
-									break;
-								case 5:
-									t2transponder.bandwidth = 10000000;
-									break;
-								default:
-									t2transponder.bandwidth = 0;
-									break;
+									t2transponder.frequency = (*freq) * 10;
+									ePtr<eDVBFrontendParameters> feparm = new eDVBFrontendParameters;
+									feparm->setDVBT(t2transponder);
+									addChannelToScan(feparm);
 								}
-								switch ((d.getSelectorBytes()->at(4) >> 5) & 0x7)
-								{
-								case 0:
-									t2transponder.guard_interval = eDVBFrontendParametersTerrestrial::GuardInterval_1_32;
-									break;
-								case 1:
-									t2transponder.guard_interval = eDVBFrontendParametersTerrestrial::GuardInterval_1_16;
-									break;
-								case 2:
-									t2transponder.guard_interval = eDVBFrontendParametersTerrestrial::GuardInterval_1_8;
-									break;
-								case 3:
-									t2transponder.guard_interval = eDVBFrontendParametersTerrestrial::GuardInterval_1_4;
-									break;
-								case 4:
-									t2transponder.guard_interval = eDVBFrontendParametersTerrestrial::GuardInterval_1_128;
-									break;
-								case 5:
-									t2transponder.guard_interval = eDVBFrontendParametersTerrestrial::GuardInterval_19_128;
-									break;
-								case 6:
-									t2transponder.guard_interval = eDVBFrontendParametersTerrestrial::GuardInterval_19_256;
-									break;
-								case 7:
-									t2transponder.guard_interval = eDVBFrontendParametersTerrestrial::GuardInterval_Auto;
-									break;
-								}
-								switch ((d.getSelectorBytes()->at(4) >> 2) & 0x7)
-								{
-								case 0:
-									t2transponder.transmission_mode = eDVBFrontendParametersTerrestrial::TransmissionMode_2k;
-									break;
-								case 1:
-									t2transponder.transmission_mode = eDVBFrontendParametersTerrestrial::TransmissionMode_8k;
-									break;
-								case 2:
-									t2transponder.transmission_mode = eDVBFrontendParametersTerrestrial::TransmissionMode_4k;
-									break;
-								case 3:
-									t2transponder.transmission_mode = eDVBFrontendParametersTerrestrial::TransmissionMode_1k;
-									break;
-								case 4:
-									t2transponder.transmission_mode = eDVBFrontendParametersTerrestrial::TransmissionMode_16k;
-									break;
-								case 5:
-									t2transponder.transmission_mode = eDVBFrontendParametersTerrestrial::TransmissionMode_32k;
-									break;
-								default:
-									t2transponder.transmission_mode = eDVBFrontendParametersTerrestrial::TransmissionMode_Auto;
-									break;
-								}
-							}
-							if (d.getLength() > 6)
-							{
-								/* TODO: parse centre_frequency(s) */
 							}
 						}
 						break;


### PR DESCRIPTION
Enigma2 was parsing partially manually the t2 descriptor (Eg missing centre frequencies parsing).

The latest version of libdvbsi++ introduces the t2 delivery system descriptor.

Use latest libdvbsi++ with centre frequency parsing support.