### PR TITLE
scan: do not abort searching t2 centre frequencies when other frequency flag is zero

### DIFF
--- a/lib/dvb/scan.cpp
+++ b/lib/dvb/scan.cpp
@@ -750,9 +750,6 @@ void eDVBScan::channelDone()
 							T2DeliverySystemDescriptor &d = (T2DeliverySystemDescriptor&)**desc;
 							t2transponder.set(d);
 
-							if(!d.getOtherFrequencyFlag())
-								break;
-
 							for (T2CellConstIterator cell = d.getCells()->begin();
 								cell != d.getCells()->end(); ++cell)
 							{


### PR DESCRIPTION
From the spec (ETSI EN 300 468 V1.15.1 (2016-03)):

other_frequency_flag: This 1-bit flag indicates whether other frequencies (non-TFS case) or other groups of frequencies (TFS case) are in use.
The value 0 (zero) indicates that the set of frequencies (non-TFS case) or the set of groups of frequencies (TFS case) included in the descriptor is complete,whereas the value 1 (one) indicates that the set is incomplete.

Thanks obi for the info.