### PR TITLE
[TimerSanityCheck] fix real  receiving reference for alternative service

### DIFF
--- a/lib/python/Components/TimerSanityCheck.py
+++ b/lib/python/Components/TimerSanityCheck.py
@@ -1,7 +1,7 @@
 import NavigationInstance
 from time import localtime, mktime, gmtime
 from ServiceReference import ServiceReference
-from enigma import iServiceInformation, eServiceCenter, eServiceReference
+from enigma import iServiceInformation, eServiceCenter, eServiceReference, getBestPlayableServiceReference
 from timer import TimerEntry
 import RecordTimer
 from time import time, localtime
@@ -187,7 +187,10 @@ class TimerSanityCheck:
 			if event[1] == self.bflag:
 				tunerType = []
 				ref = timer.service_ref and timer.service_ref.ref
-				fakeRecService = NavigationInstance.instance.recordService(timer.service_ref, True)
+				timer_ref = timer.service_ref
+				if ref and ref.flags & eServiceReference.isGroup and timer.isRunning():
+					timer_ref = getBestPlayableServiceReference(timer.service_ref.ref, eServiceReference())
+				fakeRecService = NavigationInstance.instance.recordService(timer_ref, True)
 				if fakeRecService:
 					fakeRecResult = fakeRecService.start(True)
 				else:


### PR DESCRIPTION
-when timer ref is alternative and timer running, e.g. two service in
alternative list, need method getBestPlayableServiceReference(False)