### PR TITLE
Reorganize saveServicelist for dvb-s/s2

### DIFF
--- a/lib/dvb/db.cpp
+++ b/lib/dvb/db.cpp
@@ -629,27 +629,18 @@ void eDVBDB::saveServicelist(const char *file)
 		ch.m_frontendParameters->getFlags(flags);
 		if (!ch.m_frontendParameters->getDVBS(sat))
 		{
+			fprintf(f, "\ts %d:%d:%d:%d:%d:%d:%d",
+				sat.frequency, sat.symbol_rate,
+				sat.polarisation, sat.fec,
+				sat.orbital_position > 1800 ? sat.orbital_position - 3600 : sat.orbital_position,
+				sat.inversion, flags);
+
 			if (sat.system == eDVBFrontendParametersSatellite::System_DVB_S2)
 			{
-				fprintf(f, "\ts %d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d\n",
-					sat.frequency, sat.symbol_rate,
-					sat.polarisation, sat.fec,
-					sat.orbital_position > 1800 ? sat.orbital_position - 3600 : sat.orbital_position,
-					sat.inversion,
-					flags,
-					sat.system,
-					sat.modulation,
-					sat.rolloff,
-					sat.pilot);
+				fprintf(f, ":%d:%d:%d:%d",
+					sat.system, sat.modulation, sat.rolloff, sat.pilot);
 			}
-			else
-			{
-				fprintf(f, "\ts %d:%d:%d:%d:%d:%d:%d\n",
-					sat.frequency, sat.symbol_rate,
-					sat.polarisation, sat.fec,
-					sat.orbital_position > 1800 ? sat.orbital_position - 3600 : sat.orbital_position,
-					sat.inversion, flags);
-			}
+			fprintf(f, "\n");
 		}
 		else if (!ch.m_frontendParameters->getDVBT(ter))
 		{


### PR DESCRIPTION
The dvb-s2 are just extra fields in lamedb over dvb-s.
So start saving dvb-s fields append s2 fields when system is s2.
When mis/pls patch accepted it will add three more extra columns over s2.

Based on https://github.com/athoik/enigma2/commit/22835b93a4c79ef27416d6d51919e1efc5c9b307
