### PR TITLE
InfoBarTimeshiftState: access secondInfoBar screens only in standard InfoBar

### DIFF
--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -1688,8 +1688,9 @@ class InfoBarTimeshiftState(InfoBarPVRState):
 		InfoBarPVRState.__init__(self, screen=TimeshiftState, force_show=True)
 		self.timeshiftLiveScreen = self.session.instantiateDialog(TimeshiftLive)
 		self.onHide.append(self.timeshiftLiveScreen.hide)
-		self.secondInfoBarScreen and self.secondInfoBarScreen.onShow.append(self.timeshiftLiveScreen.hide)
-		self.secondInfoBarScreenSimple and self.secondInfoBarScreenSimple.onShow.append(self.timeshiftLiveScreen.hide)
+		if isStandardInfoBar(self):
+			self.secondInfoBarScreen and self.secondInfoBarScreen.onShow.append(self.timeshiftLiveScreen.hide)
+			self.secondInfoBarScreenSimple and self.secondInfoBarScreenSimple.onShow.append(self.timeshiftLiveScreen.hide)
 		self.timeshiftLiveScreen.hide()
 		self.__hideTimer = eTimer()
 		self.__hideTimer.callback.append(self.__hideTimeshiftState)
@@ -1697,10 +1698,11 @@ class InfoBarTimeshiftState(InfoBarPVRState):
 
 	def _mayShow(self):
 		if self.timeshiftEnabled():
-			if self.secondInfoBarScreen and self.secondInfoBarScreen.shown:
-				self.secondInfoBarScreen.hide()
-			if self.secondInfoBarScreenSimple and self.secondInfoBarScreenSimple.shown:
-				self.secondInfoBarScreenSimple.hide()
+			if isStandardInfoBar(self):
+				if self.secondInfoBarScreen and self.secondInfoBarScreen.shown:
+					self.secondInfoBarScreen.hide()
+				if self.secondInfoBarScreenSimple and self.secondInfoBarScreenSimple.shown:
+					self.secondInfoBarScreenSimple.hide()
 			if self.timeshiftActivated():
 				self.pvrStateDialog.show()
 				self.timeshiftLiveScreen.hide()


### PR DESCRIPTION
When we have non-standard InfoBar like SubservicesQuickZap which
inherits InfoBarTimeshiftState, secondInfoBar screens are not defined in
InfoBarBase which results in GS.

To fix this, we have to make sure to don't access secondInfoBar screens,
when non-standard InfoBar is in use.

To make it complete here is part of crashlog:
```
<262361.450> action ->  InfobarRedButtonActions activateRedButton
<262364.267> action ->  InfobarShowHideActions toggleShow
<262365.535> action ->  InfobarSubserviceSelectionActions subserviceSelection
<262367.971> action ->  WizardActions up
<262368.174> action ->  DirectionActions upUp
<262368.177> unknown action DirectionActions/upUp! typo in keymap?
<262368.344> action ->  WizardActions up
<262368.543> action ->  DirectionActions upUp
<262368.546> unknown action DirectionActions/upUp! typo in keymap?
<262369.020> action ->  WizardActions ok
<262369.466> [SKIN] Parsing embedded skin <embedded-in-'Screensaver'>
<262369.985> Traceback (most recent call last):
<262369.991>   File "/usr/lib/enigma2/python/mytest.py", line 200, in processDelay
<262370.000>     callback(*retval)
<262370.005>   File "/usr/lib/enigma2/python/Screens/InfoBarGenerics.py", line 2703, in subserviceSelected
<262370.083>     self.session.open(SubservicesQuickzap, service[2])
<262370.086>   File "/usr/lib/enigma2/python/mytest.py", line 289, in open
<262370.096>     dlg = self.current_dialog = self.instantiateDialog(screen, *arguments, **kwargs)
<262370.101>   File "/usr/lib/enigma2/python/mytest.py", line 232, in instantiateDialog
<262370.108>     return self.doInstantiateDialog(screen, arguments, kwargs, self.desktop)
<262370.113>   File "/usr/lib/enigma2/python/mytest.py", line 249, in doInstantiateDialog
<262370.121>     dlg = screen(self, *arguments, **kwargs)
<262370.124>   File "/usr/lib/enigma2/python/Screens/SubservicesQuickzap.py", line 24, in __init__
<262370.130>     x.__init__(self)
<262370.133>   File "/usr/lib/enigma2/python/Screens/InfoBarGenerics.py", line 1656, in __init__
<262370.164>     self.secondInfoBarScreen and self.secondInfoBarScreen.onShow.append(self.timeshiftLiveScreen.hide)
<262370.171> AttributeError: 'SubservicesQuickzap' object has no attribute 'secondInfoBarScreen'
```