### PR TITLE
frontend: Assume feSatellite when tuner is not multitype

### DIFF
--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -676,6 +676,9 @@ int eDVBFrontend::openFrontend()
 
 	m_multitype = m_delsys[SYS_DVBS] && (m_delsys[SYS_DVBT] || m_delsys[SYS_DVBC_ANNEX_A]);
 
+	if (!m_multitype)
+		m_type = feSatellite;
+
 	setTone(iDVBFrontend::toneOff);
 	setVoltage(iDVBFrontend::voltageOff);
 


### PR DESCRIPTION
In a loop-through environment there is a issue if the tuner with the main cable attached is not used as "master" tuner (preferred tuner).

Tuner A (0) - Unicable-LNB - loopcable to Tuner C - connected with C - E2 preferred tuner A
Tuner B (1) - Diseq switch - direct cable
Tuner C (2) - Unicable-LNB - loopcable to Tuner D - connected with D
Tuner D (3) - Unicable-LNB - cable to lnb

Preferred Tuner in E2 = Tuner A . All commands should only be send to lnb by tuner D which is connected to LNB.

When tuner is not multitype lets assume feSatellite as we used to.

More info: https://github.com/openmips/stbgui/commit/6cfcc0fb119d11844bd38e86b36f2c16cc64c755#commitcomment-18738154