### PR TITLE
ScanSetup: initialize terrestrial nims regions when compatible

### DIFF
--- a/lib/python/Screens/ScanSetup.py
+++ b/lib/python/Screens/ScanSetup.py
@@ -1059,7 +1059,7 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 
 		self.terrestrial_nims_regions = []
 		for slot in nimmanager.nim_slots:
-			if slot.isCompatible("DVB-T"):
+			if slot.canBeCompatible("DVB-T"):
 				self.terrestrial_nims_regions.append(self.getTerrestrialRegionsList(slot.slot))
 			else:
 				self.terrestrial_nims_regions.append(None)


### PR DESCRIPTION
Always initialize terrestrial nims regions when tuner can be compatible with DVB-T.

That commit fixes the following crash on multituner devices.

<100836.332>   File "/usr/lib/enigma2/python/Plugins/SystemPlugins/Satfinder/plugin.py", line 33, in __init__
<100836.334>     ScanSetup.__init__(self, session)
<100836.334>   File "/usr/lib/enigma2/python/Screens/ScanSetup.py", line 591, in __init__
<100836.335>   File "/usr/lib/enigma2/python/Plugins/SystemPlugins/Satfinder/plugin.py", line 220, in createConfig
<100836.338>     ScanSetup.createConfig(self, self.frontendData)
<100836.339>   File "/usr/lib/enigma2/python/Screens/ScanSetup.py", line 1145, in createConfig
<100836.340>   File "/usr/lib/enigma2/python/Screens/ScanSetup.py", line 1473, in predefinedTerrTranspondersList
<100836.341> AttributeError: 'NoneType' object has no attribute 'value'