### PR TITLE
Fix GCC6 abs wrap around on unsigned integers

### DIFF
--- a/lib/dvb/Makefile.inc
+++ b/lib/dvb/Makefile.inc
@@ -39,6 +39,7 @@ endif
 
 dvbincludedir = $(pkgincludedir)/lib/dvb
 dvbinclude_HEADERS = \
+	dvb/absdiff.h \
 	dvb/cablescan.h \
 	dvb/cahandler.h \
 	dvb/crc32.h \

--- a/lib/dvb/absdiff.h
+++ b/lib/dvb/absdiff.h
@@ -1,0 +1,9 @@
+#ifndef __ABSDIFF__
+#define __ABSDIFF__
+
+static inline unsigned int absdiff(unsigned int a, unsigned int b)
+{
+	return a < b ? (b - a) : (a - b);
+}
+
+#endif // __ABSDIFF__

--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -43,6 +43,11 @@
 		}
 #endif
 
+static inline unsigned int absdiff(unsigned int a, unsigned int b)
+{
+	return a < b ? (b - a) : (a - b);
+}
+
 void eDVBDiseqcCommand::setCommandString(const char *str)
 {
 	if (!str)
@@ -343,8 +348,8 @@ RESULT eDVBFrontendParameters::calculateDifference(const iDVBFrontendParameters 
 				diff = 1<<27;
 			else
 			{
-				diff = abs(sat.frequency - osat.frequency);
-				diff += abs(sat.symbol_rate - osat.symbol_rate);
+				diff = absdiff(sat.frequency, osat.frequency);
+				diff += absdiff(sat.symbol_rate, osat.symbol_rate);
 			}
 			return 0;
 		}
@@ -362,8 +367,8 @@ RESULT eDVBFrontendParameters::calculateDifference(const iDVBFrontendParameters 
 				diff = 1 << 27;
 			else
 			{
-				diff = abs(cable.frequency - ocable.frequency);
-				diff += abs(cable.symbol_rate - ocable.symbol_rate);
+				diff = absdiff(cable.frequency, ocable.frequency);
+				diff += absdiff(cable.symbol_rate, ocable.symbol_rate);
 			}
 			return 0;
 		}
@@ -405,7 +410,7 @@ RESULT eDVBFrontendParameters::calculateDifference(const iDVBFrontendParameters 
 			else if (oterrestrial.system != terrestrial.system)
 				diff = 1 << 30;
 			else
-				diff = abs(terrestrial.frequency - oterrestrial.frequency) / 1000;
+				diff = absdiff(terrestrial.frequency, oterrestrial.frequency) / 1000;
 			return 0;
 		}
 		case iDVBFrontend::feATSC:
@@ -420,7 +425,7 @@ RESULT eDVBFrontendParameters::calculateDifference(const iDVBFrontendParameters 
 				diff = 1 << 29;
 			else
 			{
-				diff = abs(atsc.frequency - oatsc.frequency);
+				diff = absdiff(atsc.frequency, oatsc.frequency);
 			}
 			return 0;
 		}

--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -12,6 +12,8 @@
 
 #include <sstream>
 
+#include "absdiff.h"
+
 #ifndef I2C_SLAVE_FORCE
 #define I2C_SLAVE_FORCE	0x0706
 #endif
@@ -42,11 +44,6 @@
 			eDebugNoNewLine(x); \
 		}
 #endif
-
-static inline unsigned int absdiff(unsigned int a, unsigned int b)
-{
-	return a < b ? (b - a) : (a - b);
-}
 
 void eDVBDiseqcCommand::setCommandString(const char *str)
 {

--- a/lib/dvb/sec.cpp
+++ b/lib/dvb/sec.cpp
@@ -223,7 +223,7 @@ int eDVBSatelliteEquipmentControl::canTune(const eDVBFrontendParametersSatellite
 				{
 					int lof = sat.frequency > lnb_param.m_lof_threshold ?
 						lnb_param.m_lof_hi : lnb_param.m_lof_lo;
-					int tuner_freq = absdiff(sat.frequency, lof);
+					unsigned int tuner_freq = absdiff(sat.frequency, lof);
 					if (tuner_freq < fe_info.frequency_min || tuner_freq > fe_info.frequency_max)
 						ret = 0;
 				}

--- a/lib/dvb/sec.cpp
+++ b/lib/dvb/sec.cpp
@@ -15,6 +15,11 @@
 #define eSecDebug(arg...)
 #endif
 
+static inline unsigned int absdiff(unsigned int a, unsigned int b)
+{
+	return a < b ? (b - a) : (a - b);
+}
+
 DEFINE_REF(eDVBSatelliteEquipmentControl);
 
 eDVBSatelliteEquipmentControl *eDVBSatelliteEquipmentControl::instance;
@@ -221,7 +226,7 @@ int eDVBSatelliteEquipmentControl::canTune(const eDVBFrontendParametersSatellite
 				{
 					int lof = sat.frequency > lnb_param.m_lof_threshold ?
 						lnb_param.m_lof_hi : lnb_param.m_lof_lo;
-					int tuner_freq = abs(sat.frequency - lof);
+					int tuner_freq = absdiff(sat.frequency, lof);
 					if (tuner_freq < fe_info.frequency_min || tuner_freq > fe_info.frequency_max)
 						ret = 0;
 				}
@@ -392,8 +397,7 @@ RESULT eDVBSatelliteEquipmentControl::prepare(iDVBFrontend &frontend, const eDVB
 			if(!is_unicable)
 			{
 				// calc Frequency
-				int local= abs(sat.frequency
-					- lof);
+				int local = absdiff(sat.frequency, lof);
 				frequency = ((((local * 2) / 125) + 1) / 2) * 125;
 				frontend.setData(eDVBFrontend::FREQ_OFFSET, sat.frequency - frequency);
 
@@ -417,8 +421,7 @@ RESULT eDVBSatelliteEquipmentControl::prepare(iDVBFrontend &frontend, const eDVB
 			}
 			else
 			{
-				int tmp1 = abs(sat.frequency
-						-lof)
+				int tmp1 = absdiff(sat.frequency, lof)
 						+ lnb_param.SatCRvco
 						- 1400000
 						+ lnb_param.guard_offset;

--- a/lib/dvb/sec.cpp
+++ b/lib/dvb/sec.cpp
@@ -7,6 +7,8 @@
 
 #include <lib/base/eerror.h>
 
+#include "absdiff.h"
+
 #define SEC_DEBUG
 
 #ifdef SEC_DEBUG
@@ -14,11 +16,6 @@
 #else
 #define eSecDebug(arg...)
 #endif
-
-static inline unsigned int absdiff(unsigned int a, unsigned int b)
-{
-	return a < b ? (b - a) : (a - b);
-}
 
 DEFINE_REF(eDVBSatelliteEquipmentControl);
 

--- a/lib/gdi/fb.cpp
+++ b/lib/gdi/fb.cpp
@@ -151,7 +151,8 @@ int fbClass::SetMode(int nxRes, int nyRes, int nbpp)
 
 	ioctl(fbFd, FBIOGET_VSCREENINFO, &screeninfo);
 
-	if ((screeninfo.xres!=nxRes) || (screeninfo.yres!=nyRes) || (screeninfo.bits_per_pixel!=nbpp))
+	if ((screeninfo.xres != (unsigned int)nxRes) || (screeninfo.yres != (unsigned int)nyRes) ||
+		(screeninfo.bits_per_pixel != (unsigned int)nbpp))
 	{
 		eDebug("[fb] SetMode failed: wanted: %dx%dx%d, got %dx%dx%d",
 			nxRes, nyRes, nbpp,

--- a/lib/gdi/fblcd.cpp
+++ b/lib/gdi/fblcd.cpp
@@ -144,7 +144,8 @@ int eFbLCD::setMode(int nxRes, int nyRes, int nbpp)
 
 	ioctl(lcdfd, FBIOGET_VSCREENINFO, &m_screeninfo);
 
-	if ((m_screeninfo.xres != nxRes) && (m_screeninfo.yres != nyRes) && (m_screeninfo.bits_per_pixel != nbpp))
+	if ((m_screeninfo.xres != (unsigned int)nxRes) && (m_screeninfo.yres != (unsigned int)nyRes) &&
+		(m_screeninfo.bits_per_pixel != (unsigned int)nbpp))
 	{
 		eDebug("[eFbLCD] SetMode failed: wanted: %dx%dx%d, got %dx%dx%d",
 			nxRes, nyRes, nbpp,


### PR DESCRIPTION
GCC6 used the behaviour on ::abs as in std::abs.

https://gcc.gnu.org/gcc-6/porting_to.html

Calling abs using GCC6 on unsigned values will produce results like
abs(1-2) = 4.29497e+09 (UINT_MAX), so we are getting the desired
wrap around as defined by the standard.

Introduce the absdiff that will return the absolute difference without
wraping around unsigned integers.