### PR TITLE
epgcache: change deprecated UnknownDescriptor to Descriptor

### DIFF
--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -3511,7 +3511,7 @@ void eEPGCache::PMTready(eDVBServicePMTHandler *pmthandler)
 								break;
 							case 0x90:
 							{
-								UnknownDescriptor *descr = (UnknownDescriptor*)*desc;
+								Descriptor *descr = (Descriptor*)*desc;
 								int descr_len = descr->getLength();
 								if (descr_len == 4)
 								{


### PR DESCRIPTION
UnknownDescriptor was deprecated almost 10 years ago
http://git.opendreambox.org/?p=obi/libdvbsi%2B%2B.git;a=commit;h=7f4127edb2658dc4c0634f5016e872ebd2a7b240.

Change UnknownDescriptor to Descriptor to prevent deprecated declaration warning.

../../git/lib/dvb/epgcache.cpp: In member function 'void eEPGCache::PMTready(eDVBServicePMTHandler*)':
../../git/lib/dvb/epgcache.cpp:3514:28: warning: 'UnknownDescriptor' is deprecated [-Wdeprecated-declarations]
         UnknownDescriptor *descr = (UnknownDescriptor*)*desc;