### PR TITLE
eDVBService: Introduce new cacheID for data PID

### DIFF
--- a/lib/dvb/idvb.h
+++ b/lib/dvb/idvb.h
@@ -275,7 +275,8 @@ public:
 	{
 		cVPID, cMPEGAPID, cTPID, cPCRPID, cAC3PID,
 		cVTYPE, cACHANNEL, cAC3DELAY, cPCMDELAY,
-		cSUBTITLE, cAACHEAPID=12, cDDPPID, cAACAPID, cacheMax
+		cSUBTITLE, cAACHEAPID=12, cDDPPID, cAACAPID,
+		cDATAPID, cacheMax
 	};
 
 	int getCacheEntry(cacheID);


### PR DESCRIPTION
Introduce new cacheID entry to enumeration (cDATAPID - 15) that can be used to store a special PID containing data (eg T2-MI PID).
Once we have the cDATAPID cache filled it will be used to insert that PID in streaming, so another process can do something usefull with those data.