### PR TITLE
servicedvbstream: start stream when state is not idle

### DIFF
--- a/lib/service/servicedvbstream.cpp
+++ b/lib/service/servicedvbstream.cpp
@@ -27,7 +27,7 @@ void eDVBServiceStream::serviceEvent(int event)
 	{
 	case eDVBServicePMTHandler::eventTuned:
 	{
-		eDebug("[eDVBServiceStream] tuned..");
+		eDebug("[eDVBServiceStream] tuned.. m_state %d m_want_record %d", m_state, m_want_record);
 		m_tuned = 1;
 
 			/* start feeding EIT updates */
@@ -45,7 +45,7 @@ void eDVBServiceStream::serviceEvent(int event)
 				m_event_handler.start(m_demux, sid);
 		}
 
-		if (m_state == stateRecording && m_want_record)
+		if (m_state > stateIdle && m_want_record)
 			doRecord();
 		break;
 	}
@@ -84,7 +84,7 @@ int eDVBServiceStream::start(const char *serviceref, int fd)
 
 RESULT eDVBServiceStream::stop()
 {
-	eDebug("[eDVBServiceStream] stop streaming");
+	eDebug("[eDVBServiceStream] stop streaming m_state %d", m_state);
 
 	if (m_state == stateRecording)
 	{
@@ -124,11 +124,15 @@ int eDVBServiceStream::doRecord()
 	int err = doPrepare();
 	if (err)
 	{
+		eDebug("[eDVBServiceStream] doPrerare err %d", err);
 		return err;
 	}
 
 	if (!m_tuned)
+	{
+		eDebug("[eDVBServiceStream] try it again when we are tuned in");
 		return 0; /* try it again when we are tuned in */
+	}
 
 	if (!m_record && m_tuned)
 	{


### PR DESCRIPTION
When we are using flag dxNoDVB (4, dont use PMT for this service, use cached pids) we cannot start a stream because the events arriving in stream are not in the "expected" order.

The m_state is not stateRecording but state statePrepared. Simply checking if m_state is higher than stateIdle (stateIdle < statePrepared < stateRecording) it works.

Additionally add few more eDebug in order to aid when debugging.