### PR TITLE
servicedvbstream: When service flagged dxNoDVB stream cache pids

### DIFF
--- a/lib/service/servicedvbstream.cpp
+++ b/lib/service/servicedvbstream.cpp
@@ -154,6 +154,12 @@ int eDVBServiceStream::doRecord()
 
 	eDebug("[eDVBServiceStream] start streaming...");
 
+	if (recordCachedPids())
+	{
+		eDebug("[eDVBServiceStream] streaming pids from cache.");
+		return 0;
+	}
+
 	eDVBServicePMTHandler::program program;
 	if (m_service_handler.getProgramInfo(program))
 	{
@@ -261,44 +267,104 @@ int eDVBServiceStream::doRecord()
 		/* include TDT pid, really low bandwidth, should not hurt anyone */
 		pids_to_record.insert(0x14);
 
-			/* find out which pids are NEW and which pids are obsolete.. */
-		std::set<int> new_pids, obsolete_pids;
-
-		std::set_difference(pids_to_record.begin(), pids_to_record.end(),
-				m_pids_active.begin(), m_pids_active.end(),
-				std::inserter(new_pids, new_pids.begin()));
-
-		std::set_difference(
-				m_pids_active.begin(), m_pids_active.end(),
-				pids_to_record.begin(), pids_to_record.end(),
-				std::inserter(obsolete_pids, obsolete_pids.begin())
-				);
-
-		for (std::set<int>::iterator i(new_pids.begin()); i != new_pids.end(); ++i)
-		{
-			eDebug("[eDVBServiceStream] ADD PID: %04x", *i);
-			m_record->addPID(*i);
-		}
-
-		for (std::set<int>::iterator i(obsolete_pids.begin()); i != obsolete_pids.end(); ++i)
-		{
-			eDebug("[eDVBServiceStream] REMOVED PID: %04x", *i);
-			m_record->removePID(*i);
-		}
-
-		if (timing_pid != -1)
-			m_record->setTimingPID(timing_pid, timing_pid_type, timing_stream_type);
-
-		m_pids_active = pids_to_record;
-
-		if (m_state != stateRecording)
-		{
-			m_record->start();
-			m_state = stateRecording;
-		}
+		recordPids(pids_to_record, timing_pid, timing_stream_type, timing_pid_type);
 	}
 
 	return 0;
+}
+
+bool eDVBServiceStream::recordCachedPids()
+{
+	eServiceReferenceDVB ref = m_ref.getParentServiceReference();
+	ePtr<eDVBResourceManager> res_mgr;
+	std::set<int> pids_to_record;
+	if (!ref.valid())
+		ref = m_ref;
+	if (!eDVBResourceManager::getInstance(res_mgr))
+	{
+		ePtr<iDVBChannelList> db;
+		if (!res_mgr->getChannelList(db))
+		{
+			ePtr<eDVBService> service;
+			if (!db->getService(ref, service) && !service->usePMT())
+			{
+				// cached pids
+				for (int x = 0; x < eDVBService::cacheMax; ++x)
+				{
+					int entry = service->getCacheEntry((eDVBService::cacheID)x);
+					if (entry != -1)
+					{
+						if (eDVBService::cSUBTITLE == (eDVBService::cacheID)x)
+						{
+							entry = (entry&0xFFFF0000)>>16;
+						}
+						pids_to_record.insert(entry);
+					}
+				}
+			}
+		}
+	}
+
+	// check if cached pids found
+	if (!pids_to_record.size())
+	{
+		eDebug("[eDVBServiceStream] no cached pids found");
+		return false;
+	}
+
+	pids_to_record.insert(0); // PAT
+
+	if (m_stream_eit)
+	{
+		pids_to_record.insert(0x12);
+	}
+
+	/* include TDT pid, really low bandwidth, should not hurt anyone */
+	pids_to_record.insert(0x14);
+
+	recordPids(pids_to_record, -1, -1, iDVBTSRecorder::none);
+
+	return true;
+}
+
+void eDVBServiceStream::recordPids(std::set<int> pids_to_record, int timing_pid,
+	int timing_stream_type, iDVBTSRecorder::timing_pid_type timing_pid_type)
+{
+	/* find out which pids are NEW and which pids are obsolete.. */
+	std::set<int> new_pids, obsolete_pids;
+
+	std::set_difference(pids_to_record.begin(), pids_to_record.end(),
+			m_pids_active.begin(), m_pids_active.end(),
+			std::inserter(new_pids, new_pids.begin()));
+
+	std::set_difference(
+			m_pids_active.begin(), m_pids_active.end(),
+			pids_to_record.begin(), pids_to_record.end(),
+			std::inserter(obsolete_pids, obsolete_pids.begin())
+			);
+
+	for (std::set<int>::iterator i(new_pids.begin()); i != new_pids.end(); ++i)
+	{
+		eDebug("[eDVBServiceStream] ADD PID: %04x", *i);
+		m_record->addPID(*i);
+	}
+
+	for (std::set<int>::iterator i(obsolete_pids.begin()); i != obsolete_pids.end(); ++i)
+	{
+		eDebug("[eDVBServiceStream] REMOVED PID: %04x", *i);
+		m_record->removePID(*i);
+	}
+
+	if (timing_pid != -1)
+		m_record->setTimingPID(timing_pid, timing_pid_type, timing_stream_type);
+
+	m_pids_active = pids_to_record;
+
+	if (m_state != stateRecording)
+	{
+		m_record->start();
+		m_state = stateRecording;
+	}
 }
 
 void eDVBServiceStream::recordEvent(int event)

--- a/lib/service/servicedvbstream.h
+++ b/lib/service/servicedvbstream.h
@@ -48,6 +48,9 @@ private:
 
 	virtual void streamStopped() {}
 	virtual void tuneFailed() {}
+
+	void recordPids(std::set<int> pids_to_record, int timing_pid, int timing_stream_type, iDVBTSRecorder::timing_pid_type timing_pid_type);
+	bool recordCachedPids();
 };
 
 #endif


### PR DESCRIPTION
When we are using flag dxNoDVB (4, dont use PMT for this service, use cached pids) the streamservicedvb doesn't read any Cached data, it always try to get PID from DVB Sections.
But since there is no ProgramInfo, we cannot proceed, we get error "getting program info failed".

This commit streams cached pids when flag dxNoDVB is in use.