### PR TITLE
decoder: use audio only on primary decoder if external pip mode not used

### DIFF
--- a/lib/dvb/decoder.cpp
+++ b/lib/dvb/decoder.cpp
@@ -845,7 +845,7 @@ int eTSMPEGDecoder::setState()
 	}
 	if (m_changed & changeAudio)
 	{
-		if ((m_apid >= 0) && (m_apid < 0x1FFF) && !noaudio && (m_decoder == 0 || m_pip_mode == "external"))
+		if ((m_apid >= 0) && (m_apid < 0x1FFF) && !noaudio && (m_decoder == 0 || eConfigManager::getConfigValue("config.av.pip_mode") == "external"))
 		{
 			m_audio = new eDVBAudio(m_demux, m_decoder);
 			if (m_audio->startPid(m_apid, m_atype))
@@ -968,8 +968,6 @@ eTSMPEGDecoder::eTSMPEGDecoder(eDVBDemux *demux, int decoder)
 		m_vpid(-1), m_vtype(-1), m_apid(-1), m_atype(-1), m_pcrpid(-1), m_textpid(-1),
 		m_changed(0), m_decoder(decoder), m_video_clip_fd(-1), m_showSinglePicTimer(eTimer::create(eApp))
 {
-	m_pip_mode = eConfigManager::getConfigValue("config.av.pip_mode");
-
 	if (m_demux)
 	{
 		m_demux->connectEvent(slot(*this, &eTSMPEGDecoder::demux_event), m_demux_event_conn);

--- a/lib/dvb/decoder.cpp
+++ b/lib/dvb/decoder.cpp
@@ -1,6 +1,7 @@
 #include <lib/base/cfile.h>
 #include <lib/base/ebase.h>
 #include <lib/base/eerror.h>
+#include <lib/base/nconfig.h>
 #include <lib/base/wrappers.h>
 #include <lib/dvb/decoder.h>
 #include <lib/components/tuxtxtapp.h>
@@ -844,7 +845,7 @@ int eTSMPEGDecoder::setState()
 	}
 	if (m_changed & changeAudio)
 	{
-		if ((m_apid >= 0) && (m_apid < 0x1FFF) && !noaudio)
+		if ((m_apid >= 0) && (m_apid < 0x1FFF) && !noaudio && (m_decoder == 0 || m_pip_mode == "external"))
 		{
 			m_audio = new eDVBAudio(m_demux, m_decoder);
 			if (m_audio->startPid(m_apid, m_atype))
@@ -967,6 +968,8 @@ eTSMPEGDecoder::eTSMPEGDecoder(eDVBDemux *demux, int decoder)
 		m_vpid(-1), m_vtype(-1), m_apid(-1), m_atype(-1), m_pcrpid(-1), m_textpid(-1),
 		m_changed(0), m_decoder(decoder), m_video_clip_fd(-1), m_showSinglePicTimer(eTimer::create(eApp))
 {
+	m_pip_mode = eConfigManager::getConfigValue("config.av.pip_mode");
+
 	if (m_demux)
 	{
 		m_demux->connectEvent(slot(*this, &eTSMPEGDecoder::demux_event), m_demux_event_conn);

--- a/lib/dvb/decoder.h
+++ b/lib/dvb/decoder.h
@@ -93,7 +93,6 @@ private:
 	static int m_ac3_delay;
 	static int m_audio_channel;
 	std::string m_radio_pic;
-	std::string m_pip_mode;
 	ePtr<eDVBDemux> m_demux;
 	ePtr<eDVBAudio> m_audio;
 	ePtr<eDVBVideo> m_video;

--- a/lib/dvb/decoder.h
+++ b/lib/dvb/decoder.h
@@ -93,6 +93,7 @@ private:
 	static int m_ac3_delay;
 	static int m_audio_channel;
 	std::string m_radio_pic;
+	std::string m_pip_mode;
 	ePtr<eDVBDemux> m_demux;
 	ePtr<eDVBAudio> m_audio;
 	ePtr<eDVBVideo> m_video;


### PR DESCRIPTION
This should fix the audio on vuplus and possible on other receivers after swap pip.
On vuplus lacks sound while not switch to another channel.