### PR TITLE
[frontend] Fix SNR for Vuplus DVB-S NIM(AVL6222) (DVB-S2)

### DIFF
--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -1012,6 +1012,7 @@ void eDVBFrontend::calculateSignalQuality(int snr, int &signalquality, int &sign
 	else if (!strcmp(m_description, "Vuplus DVB-S NIM(AVL6222)")) // VU+ DVB-S2 Dual NIM
 	{
 		ret = (int)((((double(snr) / (65536.0 / 100.0)) * 0.1244) + 2.5079) * 100);
+		sat_max = 1490;
 	}
 	else if (!strcmp(m_description, "Vuplus DVB-S NIM(AVL6211)")) // VU+ DVB-S2 Dual NIM
 	{


### PR DESCRIPTION
-thanks pizzelnet
SNR fix for Vuplus DVB-S NIM(AVL6222) (DVB-S2) with a maximum of 14.9
dB.