### PR TITLE
Create cacheEntry for PMTPID and display cached CAIDs

### DIFF
--- a/lib/dvb/idvb.h
+++ b/lib/dvb/idvb.h
@@ -276,7 +276,7 @@ public:
 		cVPID, cMPEGAPID, cTPID, cPCRPID, cAC3PID,
 		cVTYPE, cACHANNEL, cAC3DELAY, cPCMDELAY,
 		cSUBTITLE, cAACHEAPID=12, cDDPPID, cAACAPID,
-		cDATAPID, cacheMax
+		cDATAPID, cPMTPID, cacheMax
 	};
 
 	int getCacheEntry(cacheID);

--- a/lib/dvb/pmt.cpp
+++ b/lib/dvb/pmt.cpp
@@ -597,7 +597,12 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 	{
 		int cached_pcrpid = m_service->getCacheEntry(eDVBService::cPCRPID),
 			vpidtype = m_service->getCacheEntry(eDVBService::cVTYPE),
+			pmtpid = m_service->getCacheEntry(eDVBService::cPMTPID),
 			cnt=0;
+		if (pmtpid > 0)
+		{
+			program.pmtPid = pmtpid;
+		}
 		if ( vpidtype == -1 )
 			vpidtype = videoStream::vtMPEG2;
 		if ( cached_vpid != -1 )

--- a/lib/dvb/pmt.cpp
+++ b/lib/dvb/pmt.cpp
@@ -663,15 +663,22 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 			++cnt;
 			program.textPid = cached_tpid;
 		}
+		if (cnt)
+		{
+			ret = 0;
+		}
+	}
+
+	if (m_service && program.caids.empty()) // Add CAID from cache
+	{
 		CAID_LIST &caids = m_service->m_ca;
-		for (CAID_LIST::iterator it(caids.begin()); it != caids.end(); ++it) {
+		for (CAID_LIST::iterator it(caids.begin()); it != caids.end(); ++it)
+		{
 			program::capid_pair pair;
 			pair.caid = *it;
 			pair.capid = -1; // not known yet
 			program.caids.push_back(pair);
 		}
-		if ( cnt )
-			ret = 0;
 	}
 
 	if (m_demux)


### PR DESCRIPTION
* pmt: fill CAIDs from cached values in lamedb

When CA_descriptor is missing we have no CAIDs filled although our lamedb contains cached values.

Now try to fill the CAIDs using cached information from lamedb only when there are no CAIDs found from CA_descriptor.

* eDVBService: Introduce new cacheID for PMT PID

Introduce new cacheID entry to enumeration (cPMTPID - 16)
that can be used to store a Program Map Table PID.

When we are using flag dxNoDVB we filling pmtPid on program
structure when exists on our cache.

