### PR TITLE
doRecord: Always add our cached PIDS to recorded PIDS

### DIFF
--- a/lib/service/servicedvbrecord.cpp
+++ b/lib/service/servicedvbrecord.cpp
@@ -1,5 +1,6 @@
 #include <lib/service/servicedvbrecord.h>
 #include <lib/base/eerror.h>
+#include <lib/dvb/db.h>
 #include <lib/dvb/epgcache.h>
 #include <lib/dvb/metaparser.h>
 #include <lib/base/nconfig.h> 
@@ -344,6 +345,29 @@ int eDVBServiceRecord::doRecord()
 		else
 		{
 			std::set<int> pids_to_record;
+
+			eServiceReferenceDVB ref = m_ref.getParentServiceReference();
+			ePtr<eDVBService> service;
+
+			if (!ref.valid())
+				ref = m_ref;
+
+			if(!eDVBDB::getInstance()->getService(ref, service))
+			{
+				// cached pids
+				for (int x = 0; x < eDVBService::cacheMax; ++x)
+				{
+					int entry = service->getCacheEntry((eDVBService::cacheID)x);
+					if (entry != -1)
+					{
+						if (eDVBService::cSUBTITLE == (eDVBService::cacheID)x)
+						{
+							entry = (entry&0xFFFF0000)>>16;
+						}
+						pids_to_record.insert(entry);
+					}
+				}
+			}
 
 			pids_to_record.insert(0); // PAT
 


### PR DESCRIPTION
When streaming or recording always add our cached PIDS in pids to record.

Eg. that gives the possibility to record PIDS not included in PMT video/audio sections.