### PR TITLE
servicedvb: do not try to record non pid values from cache

### DIFF
--- a/lib/service/servicedvbrecord.cpp
+++ b/lib/service/servicedvbrecord.cpp
@@ -352,6 +352,11 @@ int eDVBServiceRecord::doRecord()
 				// cached pids
 				for (int x = 0; x < eDVBService::cacheMax; ++x)
 				{
+					if (x == 5)
+					{
+						x += 3; // ignore cVTYPE, cACHANNEL, cAC3DELAY, cPCMDELAY
+						continue;
+					}
 					int entry = service->getCacheEntry((eDVBService::cacheID)x);
 					if (entry != -1)
 					{

--- a/lib/service/servicedvbstream.cpp
+++ b/lib/service/servicedvbstream.cpp
@@ -181,6 +181,11 @@ int eDVBServiceStream::doRecord()
 			// cached pids
 			for (int x = 0; x < eDVBService::cacheMax; ++x)
 			{
+				if (x == 5)
+				{
+					x += 3; // ignore cVTYPE, cACHANNEL, cAC3DELAY, cPCMDELAY
+					continue;
+				}
 				int entry = service->getCacheEntry((eDVBService::cacheID)x);
 				if (entry != -1)
 				{
@@ -311,6 +316,11 @@ bool eDVBServiceStream::recordCachedPids()
 		// cached pids
 		for (int x = 0; x < eDVBService::cacheMax; ++x)
 		{
+			if (x == 5)
+			{
+				x += 3; // ignore cVTYPE, cACHANNEL, cAC3DELAY, cPCMDELAY
+				continue;
+			}
 			int entry = service->getCacheEntry((eDVBService::cacheID)x);
 			if (entry != -1)
 			{


### PR DESCRIPTION
In cache we are storing cVTYPE, cACHANNEL, cAC3DELAY and cPCMDELAY.

None of them is PID so exclude their values from recording pids.