### PR TITLE
dvbtime: check if parms is null before calling getSystem

### DIFF
--- a/lib/dvb/dvbtime.cpp
+++ b/lib/dvb/dvbtime.cpp
@@ -304,7 +304,10 @@ void eDVBLocalTimeHandler::setUseDVBTime(bool b)
 					int system;
 					ePtr<iDVBFrontendParameters> parms;
 					it->second.channel->getCurrentFrontendParameters(parms);
-					parms->getSystem(system);
+					if (parms)
+					{
+						parms->getSystem(system);
+					}
 
 					it->second.timetable = NULL;
 					if (system == iDVBFrontend::feATSC)
@@ -334,7 +337,10 @@ void eDVBLocalTimeHandler::syncDVBTime()
 			int system;
 			ePtr<iDVBFrontendParameters> parms;
 			it->second.channel->getCurrentFrontendParameters(parms);
-			parms->getSystem(system);
+			if (parms)
+			{
+				parms->getSystem(system);
+			}
 
 			it->second.timetable = NULL;
 			if (system == iDVBFrontend::feATSC)
@@ -542,7 +548,10 @@ void eDVBLocalTimeHandler::updateTime( time_t tp_time, eDVBChannel *chan, int up
 			int system;
 			ePtr<iDVBFrontendParameters> parms;
 			chan->getCurrentFrontendParameters(parms);
-			parms->getSystem(system);
+			if (parms)
+			{
+				parms->getSystem(system);
+			}
 
 			int updateCount = it->second.timetable->getUpdateCount();
 			it->second.timetable = NULL;
@@ -587,7 +596,10 @@ void eDVBLocalTimeHandler::DVBChannelStateChanged(iDVBChannel *chan)
 			int system;
 			ePtr<iDVBFrontendParameters> parms;
 			it->second.channel->getCurrentFrontendParameters(parms);
-			parms->getSystem(system);
+			if (parms)
+			{
+				parms->getSystem(system);
+			}
 
 			switch (state)
 			{


### PR DESCRIPTION
The getCurrentFrontendParameters returns NULL parms on streams.
So we need to check parms before accessing getSystem.

More info: http://forums.openpli.org/topic/44758-dm500hd-iptv-channels-not-working-after-update-29102016