### PR TITLE
pmt: honor user preference for default ac3/ac3+

### DIFF
--- a/lib/dvb/pmt.cpp
+++ b/lib/dvb/pmt.cpp
@@ -549,7 +549,7 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 				program.defaultAudioStream = autoaudio_aache;
 			else if (autoaudio_aac != -1)
 				program.defaultAudioStream = autoaudio_aac;
-			else if (first_non_mpeg != -1)
+			else if (first_non_mpeg != -1 && (defaultac3 || defaultddp))
 				program.defaultAudioStream = first_non_mpeg;
 		}
 


### PR DESCRIPTION
In streams or in channels without languages, we are always give a preference to non mpeg audio, although user has default ac3 and default ddp no.

This patch will select a non mpeg audio if we have default ac3 or default ddp yes.