### PR TITLE
[ServiceInfo] sanity check for current play service

### DIFF
--- a/lib/python/Screens/ServiceInfo.py
+++ b/lib/python/Screens/ServiceInfo.py
@@ -90,7 +90,7 @@ class ServiceInfo(Screen):
 
 		self.transponder_info = self.info = self.feinfo = None
 		play_service = session.nav.getCurrentlyPlayingServiceReference()
-		if serviceref and play_service == serviceref:
+		if serviceref and play_service and play_service == serviceref:
 			serviceref = None
 		if serviceref:
 			self.type = TYPE_TRANSPONDER_INFO

--- a/lib/python/Screens/ServiceInfo.py
+++ b/lib/python/Screens/ServiceInfo.py
@@ -89,7 +89,10 @@ class ServiceInfo(Screen):
 		self.setTitle(_("Service info"))
 
 		self.transponder_info = self.info = self.feinfo = None
-		if serviceref and session.nav.getCurrentlyPlayingServiceReference() != serviceref:
+		play_service = session.nav.getCurrentlyPlayingServiceReference()
+		if serviceref and play_service == serviceref:
+			serviceref = None
+		if serviceref:
 			self.type = TYPE_TRANSPONDER_INFO
 			self.skinName="ServiceInfoSimple"
 			self.transponder_info = eServiceCenter.getInstance().info(serviceref).getInfoObject(serviceref, iServiceInformation.sTransponderData)
@@ -105,7 +108,7 @@ class ServiceInfo(Screen):
 				self.info = service.info()
 				self.feinfo = service.frontendInfo()
 				if not self.feinfo.getAll(True):
-					serviceref = session.nav.getCurrentlyPlayingServiceReference()
+					serviceref = play_service
 					self.transponder_info = serviceref and eServiceCenter.getInstance().info(serviceref).getInfoObject(serviceref, iServiceInformation.sTransponderData)
 
 		self.onShown.append(self.ShowServiceInformation)


### PR DESCRIPTION
<   164.103>   File "/usr/lib/enigma2/python/Screens/ServiceInfo.py",
line 92, in __init__
<   164.104>     if serviceref and
session.nav.getCurrentlyPlayingServiceReference() != serviceref:
<
164.104> ValueError: invalid null reference in method
'eServiceReference___ne__', argument 2 of type 'eServiceReference const
&'