### PR TITLE
Disable audio in pip

### DIFF
--- a/lib/python/Screens/PictureInPicture.py
+++ b/lib/python/Screens/PictureInPicture.py
@@ -184,7 +184,7 @@ class PictureInPicture(Screen):
 					Notifications.AddPopup(text = "PiP...\n" + _("No free tuner!"), type = MessageBox.TYPE_ERROR, timeout = 5, id = "ZapPipError")
 				return False
 			self.pipservice = eServiceCenter.getInstance().play(ref)
-			if self.pipservice and not self.pipservice.setTarget(1):
+			if self.pipservice and not self.pipservice.setTarget(-1):
 				if hasattr(self, "dishpipActive") and self.dishpipActive is not None:
 					self.dishpipActive.startPiPService(ref)
 				self.pipservice.start()

--- a/lib/python/Screens/PictureInPicture.py
+++ b/lib/python/Screens/PictureInPicture.py
@@ -183,12 +183,8 @@ class PictureInPicture(Screen):
 				if not config.usage.hide_zap_errors.value:
 					Notifications.AddPopup(text = "PiP...\n" + _("No free tuner!"), type = MessageBox.TYPE_ERROR, timeout = 5, id = "ZapPipError")
 				return False
-			if config.av.pip_mode.value == "external":
-				useaudio = 1
-			else:
-				useaudio = -1
 			self.pipservice = eServiceCenter.getInstance().play(ref)
-			if self.pipservice and not self.pipservice.setTarget(useaudio):
+			if self.pipservice and not self.pipservice.setTarget(1, True):
 				if hasattr(self, "dishpipActive") and self.dishpipActive is not None:
 					self.dishpipActive.startPiPService(ref)
 				self.pipservice.start()

--- a/lib/python/Screens/PictureInPicture.py
+++ b/lib/python/Screens/PictureInPicture.py
@@ -183,8 +183,12 @@ class PictureInPicture(Screen):
 				if not config.usage.hide_zap_errors.value:
 					Notifications.AddPopup(text = "PiP...\n" + _("No free tuner!"), type = MessageBox.TYPE_ERROR, timeout = 5, id = "ZapPipError")
 				return False
+			if config.av.pip_mode.value == "external":
+				useaudio = 1
+			else:
+				useaudio = -1
 			self.pipservice = eServiceCenter.getInstance().play(ref)
-			if self.pipservice and not self.pipservice.setTarget(-1):
+			if self.pipservice and not self.pipservice.setTarget(useaudio):
 				if hasattr(self, "dishpipActive") and self.dishpipActive is not None:
 					self.dishpipActive.startPiPService(ref)
 				self.pipservice.start()

--- a/lib/service/iservice.h
+++ b/lib/service/iservice.h
@@ -948,7 +948,7 @@ public:
 	virtual RESULT start()=0;
 	virtual RESULT stop()=0;
 			/* might have to be changed... */
-	virtual RESULT setTarget(int target)=0;
+	virtual RESULT setTarget(int target, bool noaudio = false)=0;
 	virtual SWIG_VOID(RESULT) seek(ePtr<iSeekableService> &SWIG_OUTPUT)=0;
 	virtual SWIG_VOID(RESULT) pause(ePtr<iPauseableService> &SWIG_OUTPUT)=0;
 	virtual SWIG_VOID(RESULT) info(ePtr<iServiceInformation> &SWIG_OUTPUT)=0;

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -1025,6 +1025,7 @@ eDVBServicePlay::eDVBServicePlay(const eServiceReference &ref, eDVBService *serv
 	m_decoder_index(0),
 	m_have_video_pid(0),
 	m_tune_state(-1),
+	m_pip_decoder(false),
 	m_is_stream(ref.path.substr(0, 7) == "http://"),
 	m_is_pvr(!ref.path.empty() && !m_is_stream),
 	m_is_paused(0),
@@ -1447,6 +1448,13 @@ RESULT eDVBServicePlay::stop()
 
 RESULT eDVBServicePlay::setTarget(int target)
 {
+	/* target -1 used for pip, change decoder index to 1 */
+	if (target == -1)
+	{
+		target = 1;
+		m_pip_decoder = (eConfigManager::getConfigValue("config.av.pip_mode") != "external");
+	}
+
 	m_decoder_index = target;
 	return 0;
 }
@@ -2849,54 +2857,61 @@ void eDVBServicePlay::updateDecoder(bool sendSeekableStateChanged)
 	if (m_decoder)
 	{
 		bool wasSeekable = m_decoder->getVideoProgressive() != -1;
-		if (m_dvb_service)
+		/* use audio only if not pip */
+		if (!m_pip_decoder)
 		{
-			achannel = m_dvb_service->getCacheEntry(eDVBService::cACHANNEL);
-			ac3_delay = m_dvb_service->getCacheEntry(eDVBService::cAC3DELAY);
-			pcm_delay = m_dvb_service->getCacheEntry(eDVBService::cPCMDELAY);
-		}
-		else // subservice
-		{
-			eServiceReferenceDVB ref;
-			m_service_handler.getServiceReference(ref);
-			eServiceReferenceDVB parent = ref.getParentServiceReference();
-			if (!parent)
-				parent = ref;
-			if (parent)
+			if (m_dvb_service)
 			{
-				ePtr<eDVBResourceManager> res_mgr;
-				if (!eDVBResourceManager::getInstance(res_mgr))
+				achannel = m_dvb_service->getCacheEntry(eDVBService::cACHANNEL);
+				ac3_delay = m_dvb_service->getCacheEntry(eDVBService::cAC3DELAY);
+				pcm_delay = m_dvb_service->getCacheEntry(eDVBService::cPCMDELAY);
+			}
+			else // subservice
+			{
+				eServiceReferenceDVB ref;
+				m_service_handler.getServiceReference(ref);
+				eServiceReferenceDVB parent = ref.getParentServiceReference();
+				if (!parent)
+					parent = ref;
+				if (parent)
 				{
-					ePtr<iDVBChannelList> db;
-					if (!res_mgr->getChannelList(db))
+					ePtr<eDVBResourceManager> res_mgr;
+					if (!eDVBResourceManager::getInstance(res_mgr))
 					{
-						ePtr<eDVBService> origService;
-						if (!db->getService(parent, origService))
+						ePtr<iDVBChannelList> db;
+						if (!res_mgr->getChannelList(db))
 						{
-		 					ac3_delay = origService->getCacheEntry(eDVBService::cAC3DELAY);
-							pcm_delay = origService->getCacheEntry(eDVBService::cPCMDELAY);
+							ePtr<eDVBService> origService;
+							if (!db->getService(parent, origService))
+							{
+			 					ac3_delay = origService->getCacheEntry(eDVBService::cAC3DELAY);
+								pcm_delay = origService->getCacheEntry(eDVBService::cPCMDELAY);
+							}
 						}
 					}
 				}
 			}
-		}
 
-		setAC3Delay(ac3_delay == -1 ? 0 : ac3_delay);
-		setPCMDelay(pcm_delay == -1 ? 0 : pcm_delay);
+			setAC3Delay(ac3_delay == -1 ? 0 : ac3_delay);
+			setPCMDelay(pcm_delay == -1 ? 0 : pcm_delay);
+		}
 
 		m_decoder->setVideoPID(vpid, vpidtype);
 		m_have_video_pid = (vpid > 0 && vpid < 0x2000);
 
-		selectAudioStream();
+		if (!m_pip_decoder)
+		{
+			selectAudioStream();
 
 #if HAVE_AMLOGIC
-		m_decoder->setSyncPCR(pcrpid);
-#else
-		if (!(m_is_pvr || m_is_stream || m_timeshift_active))
 			m_decoder->setSyncPCR(pcrpid);
-		else
-			m_decoder->setSyncPCR(-1);
+#else
+			if (!(m_is_pvr || m_is_stream || m_timeshift_active))
+				m_decoder->setSyncPCR(pcrpid);
+			else
+				m_decoder->setSyncPCR(-1);
 #endif
+		}
 
 		if (m_decoder_index == 0)
 		{
@@ -2922,7 +2937,8 @@ void eDVBServicePlay::updateDecoder(bool sendSeekableStateChanged)
 		else
 			m_decoder->set();
 
-		m_decoder->setAudioChannel(achannel);
+		if (!m_pip_decoder)
+			m_decoder->setAudioChannel(achannel);
 
 		if (mustPlay && m_decode_demux && m_decoder_index == 0)
 		{

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -1025,7 +1025,7 @@ eDVBServicePlay::eDVBServicePlay(const eServiceReference &ref, eDVBService *serv
 	m_decoder_index(0),
 	m_have_video_pid(0),
 	m_tune_state(-1),
-	m_pip_decoder(false),
+	m_noaudio(false),
 	m_is_stream(ref.path.substr(0, 7) == "http://"),
 	m_is_pvr(!ref.path.empty() && !m_is_stream),
 	m_is_paused(0),
@@ -1452,7 +1452,7 @@ RESULT eDVBServicePlay::setTarget(int target)
 	if (target == -1)
 	{
 		target = 1;
-		m_pip_decoder = (eConfigManager::getConfigValue("config.av.pip_mode") != "external");
+		m_noaudio = true;
 	}
 
 	m_decoder_index = target;
@@ -2858,7 +2858,7 @@ void eDVBServicePlay::updateDecoder(bool sendSeekableStateChanged)
 	{
 		bool wasSeekable = m_decoder->getVideoProgressive() != -1;
 		/* use audio only if not pip */
-		if (!m_pip_decoder)
+		if (!m_noaudio)
 		{
 			if (m_dvb_service)
 			{
@@ -2899,7 +2899,7 @@ void eDVBServicePlay::updateDecoder(bool sendSeekableStateChanged)
 		m_decoder->setVideoPID(vpid, vpidtype);
 		m_have_video_pid = (vpid > 0 && vpid < 0x2000);
 
-		if (!m_pip_decoder)
+		if (!m_noaudio)
 		{
 			selectAudioStream();
 
@@ -2937,7 +2937,7 @@ void eDVBServicePlay::updateDecoder(bool sendSeekableStateChanged)
 		else
 			m_decoder->set();
 
-		if (!m_pip_decoder)
+		if (!m_noaudio)
 			m_decoder->setAudioChannel(achannel);
 
 		if (mustPlay && m_decode_demux && m_decoder_index == 0)

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -1446,16 +1446,10 @@ RESULT eDVBServicePlay::stop()
 	return 0;
 }
 
-RESULT eDVBServicePlay::setTarget(int target)
+RESULT eDVBServicePlay::setTarget(int target, bool noaudio = false)
 {
-	/* target -1 used for pip, change decoder index to 1 */
-	if (target == -1)
-	{
-		target = 1;
-		m_noaudio = true;
-	}
-
 	m_decoder_index = target;
+	m_noaudio = noaudio;
 	return 0;
 }
 

--- a/lib/service/servicedvb.h
+++ b/lib/service/servicedvb.h
@@ -206,6 +206,7 @@ protected:
 	int m_decoder_index;
 	int m_have_video_pid;
 	int m_tune_state;
+	bool m_pip_decoder;
 
 		/* in timeshift mode, we essentially have two channels, and thus pmt handlers. */
 	eDVBServicePMTHandler m_service_handler_timeshift;

--- a/lib/service/servicedvb.h
+++ b/lib/service/servicedvb.h
@@ -99,7 +99,7 @@ public:
 	RESULT connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
-	RESULT setTarget(int target);
+	RESULT setTarget(int target, bool noaudio);
 
 	RESULT seek(ePtr<iSeekableService> &ptr);
 	RESULT pause(ePtr<iPauseableService> &ptr);

--- a/lib/service/servicedvb.h
+++ b/lib/service/servicedvb.h
@@ -206,7 +206,7 @@ protected:
 	int m_decoder_index;
 	int m_have_video_pid;
 	int m_tune_state;
-	bool m_pip_decoder;
+	bool m_noaudio;
 
 		/* in timeshift mode, we essentially have two channels, and thus pmt handlers. */
 	eDVBServicePMTHandler m_service_handler_timeshift;

--- a/lib/service/servicedvd.cpp
+++ b/lib/service/servicedvd.cpp
@@ -466,12 +466,6 @@ RESULT eServiceDVD::stop()
 	return 0;
 }
 
-RESULT eServiceDVD::setTarget(int /*target*/)
-{
-	eDebug("[eServiceDVD] setTarget");
-	return -1;
-}
-
 RESULT eServiceDVD::pause(ePtr<iPauseableService> &ptr)
 {
 	ptr = this;

--- a/lib/service/servicedvd.h
+++ b/lib/service/servicedvd.h
@@ -65,6 +65,7 @@ class eServiceDVD: public iPlayableService, public iPauseableService, public iSe
 public:
 	virtual ~eServiceDVD();
 		// not implemented (yet)
+	RESULT setTarget(int target, bool noaudio = false) { return -1; }
 	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = 0; return -1; }
 	RESULT audioTracks(ePtr<iAudioTrackSelection> &ptr);
 	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = 0; return -1; }
@@ -80,7 +81,6 @@ public:
 	RESULT connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
-	RESULT setTarget(int target);
 	RESULT info(ePtr<iServiceInformation> &ptr);
 	RESULT pause(ePtr<iPauseableService> &ptr);
 	RESULT subtitle(ePtr<iSubtitleOutput> &ptr);

--- a/lib/service/servicehdmi.cpp
+++ b/lib/service/servicehdmi.cpp
@@ -103,7 +103,7 @@ long long eStaticServiceHDMIInfo::getFileSize(const eServiceReference &ref)
 }
 
 eServiceHDMI::eServiceHDMI(eServiceReference ref)
- : m_ref(ref), m_decoder_index(0)
+ : m_ref(ref), m_decoder_index(0), m_pip_decoder(false)
 {
 
 }
@@ -124,7 +124,8 @@ RESULT eServiceHDMI::start()
 {
 	m_decoder = new eTSMPEGDecoder(NULL, m_decoder_index);
 	m_decoder->setVideoPID(1, 0);
-	m_decoder->setAudioPID(1, 0);
+	if (!m_pip_decoder)
+		m_decoder->setAudioPID(1, 0);
 	m_decoder->play();
 	m_event(this, evStart);
 	return 0;
@@ -139,6 +140,13 @@ RESULT eServiceHDMI::stop()
 
 RESULT eServiceHDMI::setTarget(int target)
 {
+	/* target -1 used for pip, change decoder index to 1 */
+	if (target == -1)
+	{
+		target = 1;
+		m_pip_decoder = (eConfigManager::getConfigValue("config.av.pip_mode") != "external");
+	}
+
 	m_decoder_index = target;
 	return 0;
 }

--- a/lib/service/servicehdmi.cpp
+++ b/lib/service/servicehdmi.cpp
@@ -138,16 +138,10 @@ RESULT eServiceHDMI::stop()
 	return 0;
 }
 
-RESULT eServiceHDMI::setTarget(int target)
+RESULT eServiceHDMI::setTarget(int target, bool noaudio = false)
 {
-	/* target -1 used for pip, change decoder index to 1 */
-	if (target == -1)
-	{
-		target = 1;
-		m_noaudio = true;
-	}
-
 	m_decoder_index = target;
+	m_noaudio = noaudio;
 	return 0;
 }
 

--- a/lib/service/servicehdmi.cpp
+++ b/lib/service/servicehdmi.cpp
@@ -103,7 +103,7 @@ long long eStaticServiceHDMIInfo::getFileSize(const eServiceReference &ref)
 }
 
 eServiceHDMI::eServiceHDMI(eServiceReference ref)
- : m_ref(ref), m_decoder_index(0), m_pip_decoder(false)
+ : m_ref(ref), m_decoder_index(0), m_noaudio(false)
 {
 
 }
@@ -124,7 +124,7 @@ RESULT eServiceHDMI::start()
 {
 	m_decoder = new eTSMPEGDecoder(NULL, m_decoder_index);
 	m_decoder->setVideoPID(1, 0);
-	if (!m_pip_decoder)
+	if (!m_noaudio)
 		m_decoder->setAudioPID(1, 0);
 	m_decoder->play();
 	m_event(this, evStart);
@@ -144,7 +144,7 @@ RESULT eServiceHDMI::setTarget(int target)
 	if (target == -1)
 	{
 		target = 1;
-		m_pip_decoder = (eConfigManager::getConfigValue("config.av.pip_mode") != "external");
+		m_noaudio = true;
 	}
 
 	m_decoder_index = target;

--- a/lib/service/servicehdmi.h
+++ b/lib/service/servicehdmi.h
@@ -46,7 +46,7 @@ public:
 	RESULT connectEvent(const Slot2<void, iPlayableService*, int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
-	RESULT setTarget(int target);
+	RESULT setTarget(int target, bool noaudio);
 
 	RESULT pause(ePtr<iPauseableService> &ptr) { ptr = 0; return -1; }
 	RESULT seek(ePtr<iSeekableService> &ptr) { ptr = 0; return -1; }

--- a/lib/service/servicehdmi.h
+++ b/lib/service/servicehdmi.h
@@ -78,6 +78,7 @@ private:
 	Signal2<void,iPlayableService*, int> m_event;
 	eServiceReference m_ref;
 	int m_decoder_index;
+	bool m_pip_decoder;
 	ePtr<iTSMPEGDecoder> m_decoder;
 };
 

--- a/lib/service/servicehdmi.h
+++ b/lib/service/servicehdmi.h
@@ -78,7 +78,7 @@ private:
 	Signal2<void,iPlayableService*, int> m_event;
 	eServiceReference m_ref;
 	int m_decoder_index;
-	bool m_pip_decoder;
+	bool m_noaudio;
 	ePtr<iTSMPEGDecoder> m_decoder;
 };
 

--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -803,11 +803,6 @@ RESULT eServiceMP3::stop()
 	return 0;
 }
 
-RESULT eServiceMP3::setTarget(int target)
-{
-	return -1;
-}
-
 RESULT eServiceMP3::pause(ePtr<iPauseableService> &ptr)
 {
 	ptr=this;

--- a/lib/service/servicemp3.h
+++ b/lib/service/servicemp3.h
@@ -132,7 +132,6 @@ public:
 	RESULT connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
-	RESULT setTarget(int target);
 
 	RESULT pause(ePtr<iPauseableService> &ptr);
 	RESULT setSlowMotion(int ratio);
@@ -146,6 +145,7 @@ public:
 	RESULT cueSheet(ePtr<iCueSheet> &ptr);
 
 		// not implemented (yet)
+	RESULT setTarget(int target, bool noaudio = false) { return -1; }
 	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = 0; return -1; }
 	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = 0; return -1; }
 	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = 0; return -1; }

--- a/lib/service/servicets.h
+++ b/lib/service/servicets.h
@@ -56,7 +56,7 @@ public:
 	RESULT info(ePtr<iServiceInformation>&);
 
 	// not implemented
-	RESULT setTarget(int target) { return -1; };
+	RESULT setTarget(int target, bool noaudio = false) { return -1; };
 	RESULT setSlowMotion(int ratio) { return -1; };
 	RESULT setFastForward(int ratio) { return -1; };
 	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = this; return 0; };

--- a/lib/service/servicewebts.h
+++ b/lib/service/servicewebts.h
@@ -87,7 +87,7 @@ public:
 	RESULT info(ePtr<iServiceInformation>&);
 
 	// not implemented
-	RESULT setTarget(int target) { return -1; };
+	RESULT setTarget(int target, bool noaudio = false) { return -1; };
 	RESULT setSlowMotion(int ratio) { return -1; };
 	RESULT setFastForward(int ratio) { return -1; };
 	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = this; return 0; };

--- a/lib/service/servicexine.cpp
+++ b/lib/service/servicexine.cpp
@@ -212,11 +212,6 @@ RESULT eServiceXine::stop()
 	return 0;
 }
 
-RESULT eServiceXine::setTarget(int target)
-{
-	return -1;
-}
-
 RESULT eServiceXine::pause(ePtr<iPauseableService> &ptr)
 {
 	ptr=this;

--- a/lib/service/servicexine.h
+++ b/lib/service/servicexine.h
@@ -52,7 +52,6 @@ public:
 	RESULT connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
-	RESULT setTarget(int target);
 
 	RESULT pause(ePtr<iPauseableService> &ptr);
 	RESULT setSlowMotion(int ratio);
@@ -61,6 +60,7 @@ public:
 	RESULT seek(ePtr<iSeekableService> &ptr);
 
 		// not implemented (yet)
+	RESULT setTarget(int target, bool noaudio = false) { return -1; }
 	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = 0; return -1; }
 	RESULT audioTracks(ePtr<iAudioTrackSelection> &ptr) { ptr = 0; return -1; }
 	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = 0; return -1; }


### PR DESCRIPTION
Currently we parallel processing audio for pip as for a normal channel, but after that do not use it anywhere.
In addition, it causes problems with audio in pip on vuplus receivers.

Therefore not use audio if decoder used for pip, and not used external pip.