### PR TITLE
[PictureInPicture] add notify  if use transcoding and start pip for s…

### DIFF
--- a/lib/python/Components/Sources/StreamService.py
+++ b/lib/python/Components/Sources/StreamService.py
@@ -1,5 +1,6 @@
 from Source import Source
 from Components.Element import cached
+from Components.SystemInfo import SystemInfo
 from enigma import eServiceReference
 
 StreamServiceList = []
@@ -35,6 +36,14 @@ class StreamService(Source):
 			print "[StreamService] has no service ref set"
 			return
 		print "[StreamService]e execBegin", self.ref.toString()
+		if SystemInfo["CanDoTranscodeAndPIP"]:
+			from Screens.InfoBar import InfoBar
+			if InfoBar.instance and hasattr(InfoBar.instance.session, 'pipshown') and InfoBar.instance.session.pipshown:
+				hasattr(InfoBar.instance, "showPiP") and InfoBar.instance.showPiP()
+				print "[StreamService] try to disable pip before start stream"
+				if hasattr(InfoBar.instance.session, 'pip'):
+					del InfoBar.instance.session.pip
+					InfoBar.instance.session.pipshown = False
 		self.__service = self.navcore.recordService(self.ref)
 		self.navcore.record_event.append(self.recordEvent)
 		if self.__service is not None:
@@ -51,3 +60,4 @@ class StreamService(Source):
 				StreamServiceList.remove(self.__service.__deref__())
 			self.navcore.stopRecordService(self.__service)
 			self.__service = None
+			self.ref = None

--- a/lib/python/Components/SystemInfo.py
+++ b/lib/python/Components/SystemInfo.py
@@ -50,3 +50,4 @@ SystemInfo["HasColorspaceSimple"] = SystemInfo["HasColorspace"] and HardwareInfo
 SystemInfo["HasMultichannelPCM"] = fileCheck("/proc/stb/audio/multichannel_pcm")
 SystemInfo["HasMMC"] = HardwareInfo().get_device_model() in ('vusolo4k', 'hd51', 'hd52')
 SystemInfo["CommonInterfaceCIDelay"] = fileCheck("/proc/stb/tsmux/rmx_delay")
+SystemInfo["CanDoTranscodeAndPIP"] = HardwareInfo().get_device_model() in "vusolo4k"

--- a/lib/python/Screens/PictureInPicture.py
+++ b/lib/python/Screens/PictureInPicture.py
@@ -3,10 +3,11 @@ from Screens.Dish import Dishpip
 from enigma import ePoint, eSize, eRect, eServiceCenter, getBestPlayableServiceReference, eServiceReference, eTimer
 from Components.SystemInfo import SystemInfo
 from Components.VideoWindow import VideoWindow
-from Components.config import config, ConfigPosition, ConfigYesNo, ConfigSelection
+from Components.Sources.StreamService import StreamServiceList
+from Components.config import config, ConfigPosition, ConfigSelection
 from Tools import Notifications
+from Tools.HardwareInfo import HardwareInfo
 from Screens.MessageBox import MessageBox
-from os import access, W_OK
 
 MAX_X = 720
 MAX_Y = 576
@@ -177,6 +178,13 @@ class PictureInPicture(Screen):
 			return False
 		ref = self.resolveAlternatePipService(service)
 		if ref:
+			if HardwareInfo().get_device_model().startswith('vusolo4k') and StreamServiceList:
+				self.pipservice = None
+				self.currentService = None
+				self.currentServiceReference = None
+				if not config.usage.hide_zap_errors.value:
+					Notifications.AddPopup(text = "PiP...\n" + _("Connected transcoding, limit - no PiP!"), type = MessageBox.TYPE_ERROR, timeout = 5, id = "ZapPipError")
+				return False
 			if self.isPlayableForPipService(ref):
 				print "playing pip service", ref and ref.toString()
 			else:

--- a/lib/python/Screens/PictureInPicture.py
+++ b/lib/python/Screens/PictureInPicture.py
@@ -178,7 +178,7 @@ class PictureInPicture(Screen):
 			return False
 		ref = self.resolveAlternatePipService(service)
 		if ref:
-			if HardwareInfo().get_device_model().startswith('vusolo4k') and StreamServiceList:
+			if SystemInfo["CanDoTranscodeAndPIP"] and StreamServiceList:
 				self.pipservice = None
 				self.currentService = None
 				self.currentServiceReference = None

--- a/lib/python/Screens/PictureInPicture.py
+++ b/lib/python/Screens/PictureInPicture.py
@@ -6,7 +6,6 @@ from Components.VideoWindow import VideoWindow
 from Components.Sources.StreamService import StreamServiceList
 from Components.config import config, ConfigPosition, ConfigSelection
 from Tools import Notifications
-from Tools.HardwareInfo import HardwareInfo
 from Screens.MessageBox import MessageBox
 
 MAX_X = 720


### PR DESCRIPTION
…olo4k

-PiP not avaible when use transcoding
- this added in drivers

20160516(solo4k)
- Support SD/HD Transcoding in live TV mode(mutually exclusive with Pip)
** Restriction : No Pip/MiniTV, Slow LCD Drawing