### PR TITLE
frontend: fix fallback to FE_READ_SNR

### DIFF
--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -1161,7 +1161,6 @@ int eDVBFrontend::readFrontendData(int type)
 			{
 				int signalquality = 0;
 				int signalqualitydb = 0;
-				bool valueprovided = false;
 #if DVB_API_VERSION > 5 || DVB_API_VERSION == 5 && DVB_API_VERSION_MINOR >= 10
 				if (m_dvbversion >= DVB_VERSION(5, 10))
 				{
@@ -1179,26 +1178,25 @@ int eDVBFrontend::readFrontendData(int type)
 					{
 						for(unsigned int i=0; i<prop[0].u.st.len; i++)
 						{
-							if (prop[0].u.st.stat[i].scale == FE_SCALE_DECIBEL)
+							if (prop[0].u.st.stat[i].scale == FE_SCALE_DECIBEL &&
+								type == iFrontendInformation_ENUMS::signalQualitydB)
 							{
-								valueprovided = type == iFrontendInformation_ENUMS::signalQualitydB;
 								signalqualitydb = prop[0].u.st.stat[i].svalue / 10;
+								return signalqualitydb;
 							}
-							else if (prop[0].u.st.stat[i].scale == FE_SCALE_RELATIVE)
+							else if (prop[0].u.st.stat[i].scale == FE_SCALE_RELATIVE &&
+								type == iFrontendInformation_ENUMS::signalQuality)
 							{
-								valueprovided = type == iFrontendInformation_ENUMS::signalQuality;
 								signalquality = prop[0].u.st.stat[i].svalue;
+								return signalquality;
 							}
 						}
 					}
 				}
 #endif
-				if (!valueprovided)
-				{
-					/* fallback to old DVB API */
-					int snr = readFrontendData(iFrontendInformation_ENUMS::snrValue);
-					calculateSignalQuality(snr, signalquality, signalqualitydb);
-				}
+				/* fallback to old DVB API */
+				int snr = readFrontendData(iFrontendInformation_ENUMS::snrValue);
+				calculateSignalQuality(snr, signalquality, signalqualitydb);
 
 				if (type == iFrontendInformation_ENUMS::signalQuality)
 				{


### PR DESCRIPTION
Once we get the desired value from DVB API return it, so when no value
is found we are going to fallback to old DVB API.