### PR TITLE
cahandler: create cached caPMT when flag dxNoDVB used

### DIFF
--- a/lib/dvb/cahandler.h
+++ b/lib/dvb/cahandler.h
@@ -125,6 +125,7 @@ public:
 	void sendCAPMT();
 	int writeCAPMTObject(eSocket *socket, int list_management = -1);
 	int buildCAPMT(eTable<ProgramMapSection> *ptr);
+	int buildCAPMT(ePtr<eDVBService> &dvbservice);
 	void connectionLost();
 };
 
@@ -176,6 +177,7 @@ public:
 	int registerService(const eServiceReferenceDVB &service, int adapter, int demux_nums[2], int servicetype, eDVBCAService *&caservice);
 	int unregisterService(const eServiceReferenceDVB &service , int adapter, int demux_nums[2], eTable<ProgramMapSection> *ptr);
 	void handlePMT(const eServiceReferenceDVB &service, ePtr<eTable<ProgramMapSection> > &ptr);
+	void handlePMT(const eServiceReferenceDVB &service, ePtr<eDVBService> &dvbservice);
 	void connectionLost(ePMTClient *client);
 
 	static eDVBCAHandler *getInstance() { return instance; }

--- a/lib/dvb/pmt.cpp
+++ b/lib/dvb/pmt.cpp
@@ -76,6 +76,11 @@ void eDVBServicePMTHandler::channelStateChanged(iDVBChannel *channel)
 					{
 						registerCAService();
 					}
+					if (m_ca_servicePtr && !m_service->usePMT())
+					{
+						eDebug("[eDVBServicePMTHandler] create cached caPMT");
+						eDVBCAHandler::getInstance()->handlePMT(m_reference, m_service);
+					}
 				}
 			}
 


### PR DESCRIPTION
When flag dont use PMT for this service is set, create caPMT from cached pids.