### PR TITLE
Implement video playback without audio and use it for pip

### DIFF
--- a/lib/python/Screens/PictureInPicture.py
+++ b/lib/python/Screens/PictureInPicture.py
@@ -191,7 +191,7 @@ class PictureInPicture(Screen):
 					Notifications.AddPopup(text = "PiP...\n" + _("No free tuner!"), type = MessageBox.TYPE_ERROR, timeout = 5, id = "ZapPipError")
 				return False
 			self.pipservice = eServiceCenter.getInstance().play(ref)
-			if self.pipservice and not self.pipservice.setTarget(1):
+			if self.pipservice and not self.pipservice.setTarget(1, True):
 				if hasattr(self, "dishpipActive") and self.dishpipActive is not None:
 					self.dishpipActive.startPiPService(ref)
 				self.pipservice.start()

--- a/lib/service/iservice.h
+++ b/lib/service/iservice.h
@@ -948,7 +948,7 @@ public:
 	virtual RESULT start()=0;
 	virtual RESULT stop()=0;
 			/* might have to be changed... */
-	virtual RESULT setTarget(int target)=0;
+	virtual RESULT setTarget(int target, bool noaudio = false)=0;
 	virtual SWIG_VOID(RESULT) seek(ePtr<iSeekableService> &SWIG_OUTPUT)=0;
 	virtual SWIG_VOID(RESULT) pause(ePtr<iPauseableService> &SWIG_OUTPUT)=0;
 	virtual SWIG_VOID(RESULT) info(ePtr<iServiceInformation> &SWIG_OUTPUT)=0;

--- a/lib/service/servicedvb.h
+++ b/lib/service/servicedvb.h
@@ -99,7 +99,7 @@ public:
 	RESULT connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
-	RESULT setTarget(int target);
+	RESULT setTarget(int target, bool noaudio);
 
 	RESULT seek(ePtr<iSeekableService> &ptr);
 	RESULT pause(ePtr<iPauseableService> &ptr);
@@ -206,6 +206,7 @@ protected:
 	int m_decoder_index;
 	int m_have_video_pid;
 	int m_tune_state;
+	bool m_noaudio;
 
 		/* in timeshift mode, we essentially have two channels, and thus pmt handlers. */
 	eDVBServicePMTHandler m_service_handler_timeshift;

--- a/lib/service/servicedvd.cpp
+++ b/lib/service/servicedvd.cpp
@@ -466,12 +466,6 @@ RESULT eServiceDVD::stop()
 	return 0;
 }
 
-RESULT eServiceDVD::setTarget(int /*target*/)
-{
-	eDebug("[eServiceDVD] setTarget");
-	return -1;
-}
-
 RESULT eServiceDVD::pause(ePtr<iPauseableService> &ptr)
 {
 	ptr = this;

--- a/lib/service/servicedvd.h
+++ b/lib/service/servicedvd.h
@@ -65,6 +65,7 @@ class eServiceDVD: public iPlayableService, public iPauseableService, public iSe
 public:
 	virtual ~eServiceDVD();
 		// not implemented (yet)
+	RESULT setTarget(int target, bool noaudio = false) { return -1; }
 	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = 0; return -1; }
 	RESULT audioTracks(ePtr<iAudioTrackSelection> &ptr);
 	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = 0; return -1; }
@@ -80,7 +81,6 @@ public:
 	RESULT connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
-	RESULT setTarget(int target);
 	RESULT info(ePtr<iServiceInformation> &ptr);
 	RESULT pause(ePtr<iPauseableService> &ptr);
 	RESULT subtitle(ePtr<iSubtitleOutput> &ptr);

--- a/lib/service/servicehdmi.cpp
+++ b/lib/service/servicehdmi.cpp
@@ -103,7 +103,7 @@ long long eStaticServiceHDMIInfo::getFileSize(const eServiceReference &ref)
 }
 
 eServiceHDMI::eServiceHDMI(eServiceReference ref)
- : m_ref(ref), m_decoder_index(0)
+ : m_ref(ref), m_decoder_index(0), m_noaudio(false)
 {
 
 }
@@ -124,7 +124,8 @@ RESULT eServiceHDMI::start()
 {
 	m_decoder = new eTSMPEGDecoder(NULL, m_decoder_index);
 	m_decoder->setVideoPID(1, 0);
-	m_decoder->setAudioPID(1, 0);
+	if (!m_noaudio)
+		m_decoder->setAudioPID(1, 0);
 	m_decoder->play();
 	m_event(this, evStart);
 	return 0;
@@ -137,9 +138,10 @@ RESULT eServiceHDMI::stop()
 	return 0;
 }
 
-RESULT eServiceHDMI::setTarget(int target)
+RESULT eServiceHDMI::setTarget(int target, bool noaudio = false)
 {
 	m_decoder_index = target;
+	m_noaudio = noaudio;
 	return 0;
 }
 

--- a/lib/service/servicehdmi.h
+++ b/lib/service/servicehdmi.h
@@ -46,7 +46,7 @@ public:
 	RESULT connectEvent(const Slot2<void, iPlayableService*, int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
-	RESULT setTarget(int target);
+	RESULT setTarget(int target, bool noaudio);
 
 	RESULT pause(ePtr<iPauseableService> &ptr) { ptr = 0; return -1; }
 	RESULT seek(ePtr<iSeekableService> &ptr) { ptr = 0; return -1; }
@@ -78,6 +78,7 @@ private:
 	Signal2<void,iPlayableService*, int> m_event;
 	eServiceReference m_ref;
 	int m_decoder_index;
+	bool m_noaudio;
 	ePtr<iTSMPEGDecoder> m_decoder;
 };
 

--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -803,11 +803,6 @@ RESULT eServiceMP3::stop()
 	return 0;
 }
 
-RESULT eServiceMP3::setTarget(int target)
-{
-	return -1;
-}
-
 RESULT eServiceMP3::pause(ePtr<iPauseableService> &ptr)
 {
 	ptr=this;

--- a/lib/service/servicemp3.h
+++ b/lib/service/servicemp3.h
@@ -132,7 +132,6 @@ public:
 	RESULT connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
-	RESULT setTarget(int target);
 
 	RESULT pause(ePtr<iPauseableService> &ptr);
 	RESULT setSlowMotion(int ratio);
@@ -146,6 +145,7 @@ public:
 	RESULT cueSheet(ePtr<iCueSheet> &ptr);
 
 		// not implemented (yet)
+	RESULT setTarget(int target, bool noaudio = false) { return -1; }
 	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = 0; return -1; }
 	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = 0; return -1; }
 	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = 0; return -1; }

--- a/lib/service/servicets.h
+++ b/lib/service/servicets.h
@@ -56,7 +56,7 @@ public:
 	RESULT info(ePtr<iServiceInformation>&);
 
 	// not implemented
-	RESULT setTarget(int target) { return -1; };
+	RESULT setTarget(int target, bool noaudio = false) { return -1; };
 	RESULT setSlowMotion(int ratio) { return -1; };
 	RESULT setFastForward(int ratio) { return -1; };
 	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = this; return 0; };

--- a/lib/service/servicewebts.h
+++ b/lib/service/servicewebts.h
@@ -87,7 +87,7 @@ public:
 	RESULT info(ePtr<iServiceInformation>&);
 
 	// not implemented
-	RESULT setTarget(int target) { return -1; };
+	RESULT setTarget(int target, bool noaudio = false) { return -1; };
 	RESULT setSlowMotion(int ratio) { return -1; };
 	RESULT setFastForward(int ratio) { return -1; };
 	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = this; return 0; };

--- a/lib/service/servicexine.cpp
+++ b/lib/service/servicexine.cpp
@@ -212,11 +212,6 @@ RESULT eServiceXine::stop()
 	return 0;
 }
 
-RESULT eServiceXine::setTarget(int target)
-{
-	return -1;
-}
-
 RESULT eServiceXine::pause(ePtr<iPauseableService> &ptr)
 {
 	ptr=this;

--- a/lib/service/servicexine.h
+++ b/lib/service/servicexine.h
@@ -52,7 +52,6 @@ public:
 	RESULT connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
-	RESULT setTarget(int target);
 
 	RESULT pause(ePtr<iPauseableService> &ptr);
 	RESULT setSlowMotion(int ratio);
@@ -61,6 +60,7 @@ public:
 	RESULT seek(ePtr<iSeekableService> &ptr);
 
 		// not implemented (yet)
+	RESULT setTarget(int target, bool noaudio = false) { return -1; }
 	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = 0; return -1; }
 	RESULT audioTracks(ePtr<iAudioTrackSelection> &ptr) { ptr = 0; return -1; }
 	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = 0; return -1; }


### PR DESCRIPTION
Currently we parallel processing audio for pip as for a normal channel, but after that do not use it anywhere.
In addition, it causes problems with audio in pip on vuplus receivers.
Therefore add variable noaudio in setTarget, and disable audio if decoder used for pip, and not used external pip.
By default, set noaudio to false to keep compatibility.
In classes, where setTarget not implemented, moves it to the header files.