### PR TITLE
Move InitSetupDevices to the beginning of mytest

### DIFF
--- a/mytest.py
+++ b/mytest.py
@@ -14,6 +14,11 @@ enigma.eSocketNotifier = eBaseImpl.eSocketNotifier
 enigma.eConsoleAppContainer = eConsoleImpl.eConsoleAppContainer
 
 from traceback import print_exc
+
+profile("SetupDevices")
+import Components.SetupDevices
+Components.SetupDevices.InitSetupDevices()
+
 profile("SimpleSummary")
 from Screens import InfoBar
 from Screens.SimpleSummary import SimpleSummary
@@ -523,10 +528,6 @@ profile("InputDevice")
 import Components.InputDevice
 Components.InputDevice.InitInputDevices()
 import Components.InputHotplug
-
-profile("SetupDevices")
-import Components.SetupDevices
-Components.SetupDevices.InitSetupDevices()
 
 profile("AVSwitch")
 import Components.AVSwitch


### PR DESCRIPTION
InitSetupDevices activate the translation and therefore it is important to enable it as soon as possible.
This fix translation for example in NimManager where for the configs are used constructed values, but due to the fact that translation is not yet enabled the translation of these configs not working.
Also set the time zone is better before the other component start.