### PR TITLE
cahandler: check for CA_DESCRIPTOR in ElementaryStreamInfo

### DIFF
--- a/lib/dvb/cahandler.cpp
+++ b/lib/dvb/cahandler.cpp
@@ -602,6 +602,17 @@ int eDVBCAService::buildCAPMT(eTable<ProgramMapSection> *ptr)
 			if ((*desc)->getTag() == CA_DESCRIPTOR)
 				scrambled = true;
 		}
+
+		for (ElementaryStreamInfoConstIterator es = (*pmt)->getEsInfo()->begin();
+			es != (*pmt)->getEsInfo()->end() && !scrambled; ++es)
+		{
+			for (DescriptorConstIterator edesc = (*es)->getDescriptors()->begin();
+				edesc != (*es)->getDescriptors()->end() && !scrambled; ++edesc)
+			{
+				if ((*edesc)->getTag() == CA_DESCRIPTOR)
+					scrambled = true;
+			}
+		}
 	}
 
 	std::vector<ProgramMapSection*>::const_iterator i = ptr->getSections().begin();


### PR DESCRIPTION
We need to make sure that CA_DESCRIPTOR doesn't exist also in ElementaryStreamInfo.
If there is, then mark program as scrambled and don't try to use cached CAIDS.

Please merge libdvbsi++ change, since it required from above patch. https://github.com/OpenPLi/openpli-oe-core/pull/136

More info: http://forums.openpli.org/topic/45496-decoding-not-work-on-most-upc-channels/