### PR TITLE
Use debug and error log level for python loggings

### DIFF
--- a/lib/base/eerror.cpp
+++ b/lib/base/eerror.cpp
@@ -186,11 +186,10 @@ void eDebugImpl(int flags, const char* fmt, ...)
 		bsodFatal("enigma2");
 }
 
-void ePythonOutput(const char *string)
+void ePythonOutput(const char *string, int lvl)
 {
 #ifdef DEBUG
-	// Only show message when the debug level is at least "warning"
-	if (debugLvl >= lvlWarning)
+	if (debugLvl >= lvl)
 		eDebugImpl(_DBGFLG_NONEWLINE, "%s", string);
 #endif
 }

--- a/lib/base/eerror.h
+++ b/lib/base/eerror.h
@@ -153,6 +153,6 @@ enum { lvlDebug=4, lvlInfo=3, lvlWarning=2, lvlError=1, lvlFatal=0 };
 
 #endif // SWIG
 
-void ePythonOutput(const char *);
+void ePythonOutput(const char *, int lvl = lvlDebug);
 
 #endif // __E_ERROR__

--- a/lib/python/Tools/RedirectOutput.py
+++ b/lib/python/Tools/RedirectOutput.py
@@ -1,7 +1,10 @@
 import sys
 from enigma import ePythonOutput
 
-class EnigmaOutput:
+class EnigmaLogDebug:
+
+	lvlDebug = 4
+
 	def __init__(self):
 		self.line = ''
 
@@ -10,13 +13,35 @@ class EnigmaOutput:
 			data = data.encode("UTF-8")
 		self.line += data
 		if '\n' in data:
-			ePythonOutput(self.line)
+			ePythonOutput(self.line, self.lvlDebug)
 			self.line = ''
 
 	def flush(self):
 		pass
 
-        def isatty(self):
-                return True
+	def isatty(self):
+		return True
 
-sys.stdout = sys.stderr = EnigmaOutput()
+class EnigmaLogFatal:
+
+	lvlError = 1
+
+	def __init__(self):
+		self.line = ''
+
+	def write(self, data):
+		if isinstance(data, unicode):
+			data = data.encode("UTF-8")
+		self.line += data
+		if '\n' in data:
+			ePythonOutput(self.line, self.lvlError)
+			self.line = ''
+
+	def flush(self):
+		pass
+
+	def isatty(self):
+		return True
+
+sys.stdout = EnigmaLogDebug()
+sys.stderr = EnigmaLogFatal()


### PR DESCRIPTION
Normal python loggings(print) get debug log level. Stacktraces get error log level.
-> Normal prints in python are not shown any longer in the log as long
  as you don't specify different log level.
-> Stacktraces are also shown when log level is lower than warning.