### PR TITLE
jess: use corect initial value in SATCR

### DIFF
--- a/lib/dvb/sec.cpp
+++ b/lib/dvb/sec.cpp
@@ -823,7 +823,7 @@ RESULT eDVBSatelliteEquipmentControl::prepare(iDVBFrontend &frontend, const eDVB
 
 					default:
 					{
-						frontend.setData(eDVBFrontend::SATCR, 0);
+						frontend.setData(eDVBFrontend::SATCR, -1);
 						frontend.setData(eDVBFrontend::DICTION, SatCR_format_none);
 
 						eDebug("**** SatCR_format neither Unicable nor JESS!");
@@ -838,7 +838,7 @@ RESULT eDVBSatelliteEquipmentControl::prepare(iDVBFrontend &frontend, const eDVB
 			}
 			else
 			{
-				frontend.setData(eDVBFrontend::SATCR, 0);
+				frontend.setData(eDVBFrontend::SATCR, -1);
 				frontend.setData(eDVBFrontend::DICTION, SatCR_format_none);
 			}
 


### PR DESCRIPTION
We need to use -1 as initial value in SATCR when curent mode is not JESS or UNICABLE.

This fixes GS when prepareTurnOffSatCR called when closing frontend because SATCR had value 0.