### PR TITLE
Add converter VfdDisplay

### DIFF
--- a/lib/python/Components/Converter/Makefile.am
+++ b/lib/python/Components/Converter/Makefile.am
@@ -8,4 +8,4 @@ install_PYTHON = \
 	ServiceOrbitalPosition.py CryptoInfo.py TextCase.py \
 	ValueBitTest.py TunerInfo.py ConfigEntryTest.py ClientsStreaming.py TemplatedMultiContent.py ProgressToText.py \
 	Combine.py SensorToText.py ValueToPixmap.py PliExtraInfo.py genre.py TransponderInfo.py \
-	RotorPosition.py
+	RotorPosition.py VfdDisplay.py

--- a/lib/python/Components/Converter/VfdDisplay.py
+++ b/lib/python/Components/Converter/VfdDisplay.py
@@ -14,13 +14,13 @@ class VfdDisplay(Poll, Converter, object):
 		self.showclock = 0
 		self.delay = 5000
 		self.loop = -1
-		self.type = type.split(';')
-		if 'Number' in self.type and 'Clock' not in self.type:  # Only channel number
+		self.type = type.lower().split(';')
+		if 'number' in self.type and 'clock' not in self.type:  # Only channel number
 			self.delay = 0
 			self.poll_enabled = False
 		else:
 			self.poll_enabled = True
-			if 'Clock' in self.type and 'Number' not in self.type:  # Only clock
+			if 'clock' in self.type and 'number' not in self.type:  # Only clock
 				self.showclock = 1
 				self.delay = -1
 			else:
@@ -28,13 +28,13 @@ class VfdDisplay(Poll, Converter, object):
 					if x.isdigit():
 						self.delay = int(x) * 1000
 						break
-				if 'Loop' in self.type and self.delay:
+				if 'loop' in self.type and self.delay:
 					self.loop = self.delay
-			if 'Nozero' in self.type:
+			if 'nozero' in self.type:
 				self.hour = '%'
 			else:
 				self.hour = '%02'
-			if '12h' in self.type or '12H' in self.type:
+			if '12h' in self.type:
 				self.hour = self.hour + 'I'
 			else:
 				self.hour = self.hour + 'H'
@@ -49,7 +49,7 @@ class VfdDisplay(Poll, Converter, object):
 				return self.num
 		else:
 			if self.showclock == 1:
-				if 'Noblink' in self.type:
+				if 'noblink' in self.type:
 					self.poll_interval = self.delay
 				else:
 					self.poll_interval = 1000
@@ -76,13 +76,7 @@ class VfdDisplay(Poll, Converter, object):
 			if self.loop != -1:
 				self.loop = self.delay
 			service = self.source.serviceref
-			if service:
-				if 'Nozero' in self.type:
-					self.num = '%d' % service.getChannelNum()
-				else:
-					self.num = '%04d' % service.getChannelNum()
-			else:
-				self.num = None
+			self.num = service and ('%d' if 'nozero' in self.type else '%04d') % service.getChannelNum() or None
 			Converter.changed(self, what)
 		elif what[0] is self.CHANGED_POLL:
 			Converter.changed(self, what)

--- a/lib/python/Components/Converter/VfdDisplay.py
+++ b/lib/python/Components/Converter/VfdDisplay.py
@@ -1,0 +1,88 @@
+from datetime import datetime
+
+from enigma import iPlayableService
+from Poll import Poll
+from Components.Converter.Converter import Converter
+from Components.Element import cached
+
+
+class VfdDisplay(Poll, Converter, object):
+	def __init__(self, type):
+		Converter.__init__(self, type)
+		Poll.__init__(self)
+		self.num = None
+		self.showclock = 0
+		self.delay = 5000
+		self.loop = -1
+		self.type = type.split(';')
+		if 'Number' in self.type and 'Clock' not in self.type:  # Only channel number
+			self.delay = 0
+			self.poll_enabled = False
+		else:
+			self.poll_enabled = True
+			if 'Clock' in self.type and 'Number' not in self.type:  # Only clock
+				self.showclock = 1
+				self.delay = -1
+			else:
+				for x in self.type:
+					if x.isdigit():
+						self.delay = int(x) * 1000
+						break
+				if 'Loop' in self.type and self.delay:
+					self.loop = self.delay
+			if 'Nozero' in self.type:
+				self.hour = '%'
+			else:
+				self.hour = '%02'
+			if '12h' in self.type or '12H' in self.type:
+				self.hour = self.hour + 'I'
+			else:
+				self.hour = self.hour + 'H'
+
+	@cached
+	def getText(self):
+		if self.showclock == 0:
+			if self.delay:
+				self.poll_interval = self.delay
+				self.showclock = 1
+			if self.num:
+				return self.num
+		else:
+			if self.showclock == 1:
+				if 'Noblink' in self.type:
+					self.poll_interval = self.delay
+				else:
+					self.poll_interval = 1000
+					self.showclock = 3
+				clockformat = self.hour + '%02M'
+			elif self.showclock == 2:
+				self.showclock = 3
+				clockformat = self.hour + '%02M'
+			else:
+				self.showclock = 2
+				clockformat = self.hour + ':%02M'
+			if self.loop != -1:
+				self.loop -= 1000
+				if self.loop <= 0:
+					self.loop = self.delay
+					self.showclock = 0
+			return datetime.today().strftime(clockformat)
+
+	text = property(getText)
+
+	def changed(self, what):
+		if what[0] is self.CHANGED_SPECIFIC and self.delay >= 0 and what[1] == iPlayableService.evStart:
+			self.showclock = 0
+			if self.loop != -1:
+				self.loop = self.delay
+			service = self.source.serviceref
+			if service:
+				if 'Nozero' in self.type:
+					self.num = '%d' % service.getChannelNum()
+				else:
+					self.num = '%04d' % service.getChannelNum()
+			else:
+				self.num = None
+			Converter.changed(self, what)
+		elif what[0] is self.CHANGED_POLL:
+			Converter.changed(self, what)


### PR DESCRIPTION
This adds converter that you can use in skin_text.xml for 7 segment vfd displays.

By default you can use:
<widget source=session.CurrentService render=Label position=0,0 size=1,1>
    <convert type=VfdDisplay></convert>
</widget>
This show service number after the channel switching, and after 5 seconds show the clock.

Possible attributes:
  Number - show channel number
  Clock - show clock
  12h or 12H - show the clock in 12 hour format
  Noblink - do not show a blinking : between the digits (probably not supported by display)
  Nozero - do not show a zero before the channel number and the clock (64 instead of 0064)
  Loop - constantly change the channel number and the clock
  digit (2) - delay time in seconds (default 5)

Examples;
  Show only channel number:
    <convert type=VfdDisplay>Number</convert>
  Show only clock:
    <convert type=VfdDisplay>Clock</convert>
  Show channel number and after 10 seconds clock:
    <convert type=VfdDisplay>10</convert>
  Loop channel number and clock:
    <convert type=VfdDisplay>Loop</convert>
  Loop channel number and clock, dealy 10 seconds, do not show a zero before:
    <convert type=VfdDisplay>Loop;10;Nozero</convert>