### PR TITLE
TransponderInfo: handle ATSC Transpoder info

### DIFF
--- a/lib/python/Components/Converter/TransponderInfo.py
+++ b/lib/python/Components/Converter/TransponderInfo.py
@@ -46,6 +46,8 @@ class TransponderInfo(Converter, object):
 			elif "DVB-C" in transponderdata["system"]:
 				return "%s %d MHz %d %s %s" % (transponderdata["system"], transponderdata["frequency"]/1000 + 0.5, transponderdata["symbol_rate"]/1000 + 0.5, transponderdata["fec_inner"], \
 					transponderdata["modulation"])
+			elif "ATSC" in transponderdata["system"]:
+				return "%s %d MHz %s" % (transponderdata["system"], transponderdata["frequency"]/1000 + 0.5, transponderdata["modulation"])
 			return "%s %d %s %d %s %s %s" % (transponderdata["system"], transponderdata["frequency"]/1000 + 0.5, transponderdata["polarization_abbreviation"], transponderdata["symbol_rate"]/1000 + 0.5, \
 				transponderdata["fec_inner"], transponderdata["modulation"], transponderdata["detailed_satpos" in self.type and "orbital_position" or "orb_pos"])
 		if ref:


### PR DESCRIPTION
With ATSC check we are having trying to read non existing values causing the following crash:

<   617.847>   File "/usr/lib/enigma2/python/Components/Converter/TransponderInfo.py", line 49, in getText
<   617.848> KeyError: 'polarization_abbreviation'