### PR TITLE
Improve skin text for 7 segment displays

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,13 @@ if test x"$withtextlcd" != xno ; then
 fi
 AM_CONDITIONAL(HAVE_TEXTLCD, test x"$withtextlcd" != xno)
 
+AC_ARG_WITH(7segment,
+	AC_HELP_STRING([--with-7segment], [use 7 segment lcd, yes or no]),
+	[[TEXTSKIN="7segment"]],
+	[[TEXTSKIN="default"]]
+)
+AC_SUBST(TEXTSKIN)
+
 if test `echo "$BOXTYPE" | cut -b 1-7` == "mbmicro"; then
 	AC_DEFINE(FORCE_NO_BLENDING_ACCELERATION, 1,[define when the framebuffer acceleration does not have alphablending support, though the autodetection might indicate that it does])
 	AC_DEFINE(FORCE_NO_FILL_ACCELERATION, 1,[define when the framebuffer acceleration does not have fill support])

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -28,5 +28,5 @@ skin_display.xml: $(srcdir)/skin_display_default.xml
 	test -f $(srcdir)/skin_display_$(BOXTYPE).xml && cp $(srcdir)/skin_display_$(BOXTYPE).xml skin_display.xml || cp $(srcdir)/skin_display_default.xml skin_display.xml
 
 skin_text.xml: $(srcdir)/skin_text_default.xml
-	test -f $(srcdir)/skin_text_$(BOXTYPE).xml && cp $(srcdir)/skin_text_$(BOXTYPE).xml skin_text.xml || cp $(srcdir)/skin_text_default.xml skin_text.xml
+	test -f $(srcdir)/skin_text_$(BOXTYPE).xml && cp $(srcdir)/skin_text_$(BOXTYPE).xml skin_text.xml || cp $(srcdir)/skin_text_$(TEXTSKIN).xml skin_text.xml
 

--- a/data/skin_text_7segment.xml
+++ b/data/skin_text_7segment.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<skin>
+<!-- main-->
+	<screen name="InfoBarSummary" position="0,0" size="1,1">
+		<widget source="session.CurrentService" render="Label" position="0,0" size="1,1">
+			<convert type="VfdDisplay"></convert>
+		</widget>
+	</screen>
+
+<!-- movieplayer-->
+	<screen name="InfoBarMoviePlayerSummary" position="0,0" size="1,1">
+		<widget source="session.CurrentService" render="Label" position="0,0" size="1,1">
+			<convert type="ServicePosition">Remaining</convert>
+		</widget>
+	</screen>
+
+<!-- DVD -->
+	<screen name="DVDSummary" position="0,0" size="1,1">
+		<widget source="session.CurrentService" render="Label" position="0,0" size="1,1">
+			<convert type="ServicePosition">Remaining</convert>
+		</widget>
+	</screen>
+
+<!-- standby -->
+	<screen name="StandbySummary" position="0,0" size="1,1">
+		<widget source="session.CurrentService" render="Label" position="0,0" size="1,1">
+			<convert type="VfdDisplay">Clock</convert>
+		</widget>
+	</screen>
+</skin>

--- a/data/skin_text_h3.xml
+++ b/data/skin_text_h3.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<skin>
+<!-- main-->
+	<screen name="InfoBarSummary" position="0,0" size="1,1">
+		<widget source="session.CurrentService" render="Label" position="0,0" size="1,1">
+			<convert type="VfdDisplay"></convert>
+		</widget>
+	</screen>
+
+<!-- movieplayer-->
+	<screen name="InfoBarMoviePlayerSummary" position="0,0" size="1,1">
+		<widget source="session.CurrentService" render="Label" position="0,0" size="1,1">
+			<convert type="ServicePosition">Remaining</convert>
+		</widget>
+	</screen>
+
+<!-- DVD -->
+	<screen name="DVDSummary" position="0,0" size="1,1">
+		<widget source="session.CurrentService" render="Label" position="0,0" size="1,1">
+			<convert type="ServicePosition">Remaining</convert>
+		</widget>
+	</screen>
+
+<!-- standby -->
+	<screen name="StandbySummary" position="0,0" size="1,1">
+		<widget source="session.CurrentService" render="Label" position="0,0" size="1,1">
+			<convert type="VfdDisplay">Clock</convert>
+		</widget>
+	</screen>
+</skin>


### PR DESCRIPTION
Add skin_text_h3.xml for zgemma h3.
Add skin_text_7segment.xml and configure option --with-7segment.
This allows use this skin for all receivers with 7 segment display without creating a skin for each receiver.