### PR TITLE
Simplify Font freetype 1 & 2 compatibility

### DIFF
--- a/lib/gdi/font.cpp
+++ b/lib/gdi/font.cpp
@@ -116,20 +116,12 @@ int fontRenderClass::getFaceProperties(const std::string &face, FTC_FaceID &id, 
 	return -1;
 }
 
-#ifdef HAVE_FREETYPE2
-inline FT_Error fontRenderClass::getGlyphBitmap(FTC_Image_Desc *font, FT_UInt glyph_index, FTC_SBit *sbit)
-#else
-inline FT_Error fontRenderClass::getGlyphBitmap(FTC_Image_Desc *font, FT_ULong glyph_index, FTC_SBit *sbit)
-#endif
+inline FT_Error fontRenderClass::getGlyphBitmap(FTC_Image_Desc *font, GlyphIndex glyph_index, FTC_SBit *sbit)
 {
 	return FTC_SBit_Cache_Lookup(sbitsCache, font, glyph_index, sbit);
 }
 
-#ifdef HAVE_FREETYPE2
-inline FT_Error fontRenderClass::getGlyphImage(FTC_Image_Desc *font, FT_UInt glyph_index, FT_Glyph *glyph, FT_Glyph *borderglyph, int bordersize)
-#else
-inline FT_Error fontRenderClass::getGlyphImage(FTC_Image_Desc *font, FT_ULong glyph_index, FT_Glyph *glyph, FT_Glyph *borderglyph, int bordersize)
-#endif
+inline FT_Error fontRenderClass::getGlyphImage(FTC_Image_Desc *font, GlyphIndex glyph_index, FT_Glyph *glyph, FT_Glyph *borderglyph, int bordersize)
 {
 	FT_Glyph image;
 	FT_Error err = FTC_ImageCache_Lookup(imageCache, font, glyph_index, &image, NULL);
@@ -309,20 +301,12 @@ Font::Font(fontRenderClass *render, FTC_FaceID faceid, int isize, int tw, int re
 //	font.image_type |= ftc_image_flag_autohinted;
 }
 
-#ifdef HAVE_FREETYPE2
-inline FT_Error Font::getGlyphBitmap(FT_UInt glyph_index, FTC_SBit *sbit)
-#else
-inline FT_Error Font::getGlyphBitmap(FT_ULong glyph_index, FTC_SBit *sbit)
-#endif
+inline FT_Error Font::getGlyphBitmap(GlyphIndex glyph_index, FTC_SBit *sbit)
 {
 	return renderer->getGlyphBitmap(&font, glyph_index, sbit);
 }
 
-#ifdef HAVE_FREETYPE2
-inline FT_Error Font::getGlyphImage(FT_UInt glyph_index, FT_Glyph *glyph, FT_Glyph *borderglyph, int bordersize)
-#else
-inline FT_Error Font::getGlyphImage(FT_ULong glyph_index, FT_Glyph *glyph, FT_Glyph *borderglyph, int bordersize)
-#endif
+inline FT_Error Font::getGlyphImage(GlyphIndex glyph_index, FT_Glyph *glyph, FT_Glyph *borderglyph, int bordersize)
 {
 	return renderer->getGlyphImage(&font, glyph_index, glyph, borderglyph, bordersize);
 }

--- a/lib/gdi/font.cpp
+++ b/lib/gdi/font.cpp
@@ -301,6 +301,10 @@ Font::Font(fontRenderClass *render, FTC_FaceID faceid, int isize, int tw, int re
 //	font.image_type |= ftc_image_flag_autohinted;
 }
 
+Font::~Font()
+{
+}
+
 inline FT_Error Font::getGlyphBitmap(GlyphIndex glyph_index, FTC_SBit *sbit)
 {
 	return renderer->getGlyphBitmap(&font, glyph_index, sbit);
@@ -309,10 +313,6 @@ inline FT_Error Font::getGlyphBitmap(GlyphIndex glyph_index, FTC_SBit *sbit)
 inline FT_Error Font::getGlyphImage(GlyphIndex glyph_index, FT_Glyph *glyph, FT_Glyph *borderglyph, int bordersize)
 {
 	return renderer->getGlyphImage(&font, glyph_index, glyph, borderglyph, bordersize);
-}
-
-Font::~Font()
-{
 }
 
 DEFINE_REF(eTextPara);

--- a/lib/gdi/font.h
+++ b/lib/gdi/font.h
@@ -19,17 +19,16 @@ typedef FT_UInt GlyphIndex;
 typedef FT_ULong GlyphIndex;
 #endif
 
+#include <string>
 #include <vector>
+#include <list>
+#include <set>
 
 #include <lib/gdi/fb.h>
 #include <lib/gdi/esize.h>
 #include <lib/gdi/epoint.h>
 #include <lib/gdi/erect.h>
-#include <string>
-#include <list>
 #include <lib/base/object.h>
-
-#include <set>
 
 class FontRenderClass;
 class Font;
@@ -38,6 +37,7 @@ class gFont;
 class gRGB;
 
 #endif
+
 class fontRenderClass
 {
 #ifndef SWIG

--- a/lib/gdi/font.h
+++ b/lib/gdi/font.h
@@ -12,6 +12,13 @@
 typedef FTC_ImageCache FTC_Image_Cache;
 typedef FTC_ImageTypeRec FTC_Image_Desc;
 typedef FTC_SBitCache FTC_SBit_Cache;
+
+#ifdef HAVE_FREETYPE2
+typedef FT_UInt GlyphIndex;
+#else
+typedef FT_ULong GlyphIndex;
+#endif
+
 #include <vector>
 
 #include <lib/gdi/fb.h>
@@ -54,13 +61,10 @@ class fontRenderClass
 	int strokerRadius;
 
 	int getFaceProperties(const std::string &face, FTC_FaceID &id, int &renderflags);
-#ifdef HAVE_FREETYPE2
-	FT_Error getGlyphBitmap(FTC_Image_Desc *font, FT_UInt glyph_index, FTC_SBit *sbit);
-	FT_Error getGlyphImage(FTC_Image_Desc *font, FT_UInt glyph_index, FT_Glyph *glyph, FT_Glyph *borderglyph, int bordersize);
-#else
-	FT_Error getGlyphBitmap(FTC_Image_Desc *font, FT_ULong glyph_index, FTC_SBit *sbit);
-	FT_Error getGlyphImage(FTC_Image_Desc *font, FT_ULong glyph_index, FT_Glyph *glyph, FT_Glyph *borderglyph, int bordersize);
-#endif
+
+    FT_Error getGlyphBitmap(FTC_Image_Desc *font, GlyphIndex glyph_index, FTC_SBit *sbit);
+    FT_Error getGlyphImage(FTC_Image_Desc *font, GlyphIndex glyph_index, FT_Glyph *glyph, FT_Glyph *borderglyph, int bordersize);
+
 	static fontRenderClass *instance;
 #else
 	fontRenderClass();
@@ -100,11 +104,8 @@ struct pGlyph
 	int x, y, w;
 	unsigned long newcolor;
 	ePtr<Font> font;
-#ifdef HAVE_FREETYPE2
-	FT_UInt glyph_index;
-#else
-	FT_ULong glyph_index;
-#endif
+	GlyphIndex glyph_index;
+
 	int flags;
 	eRect bbox;
 	FT_Glyph image, borderimage;
@@ -216,13 +217,8 @@ public:
 	FTC_ScalerRec scaler;
 	FTC_Image_Desc font;
 	fontRenderClass *renderer;
-#ifdef HAVE_FREETYPE2
-	FT_Error getGlyphBitmap(FT_UInt glyph_index, FTC_SBit *sbit);
-	FT_Error getGlyphImage(FT_UInt glyph_index, FT_Glyph *glyph, FT_Glyph *borderglyph, int bordersize);
-#else
 	FT_Error getGlyphBitmap(FT_ULong glyph_index, FTC_SBit *sbit);
 	FT_Error getGlyphImage(FT_ULong glyph_index, FT_Glyph *glyph, FT_Glyph *borderglyph, int bordersize);
-#endif
 	FT_Face face;
 	FT_Size size;
 


### PR DESCRIPTION
Once in a while I like to spend some time on my favorite set-top box software project.
This time, while browsing the code and doing some cppcheck runs I stumbled upon a
ifdef construction that was wraps around function definitions of the Font class. And as
it seemed to me, its only purpose was to building enigma with freetype 1 or freetype 2.
So, by moving the type difference to a typedef we achieve exactly the same and have
more readable code as a nice bonus (code readability is actually the only motivation of
this pr).