### PR TITLE
Add "Dub" to Portuguese audio language choices.

### DIFF
--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -609,7 +609,7 @@ def InitUsageConfig():
 		("ltz", _("Luxembourgish")),
 		("nor", _("Norwegian")),
 		("pol", _("Polish")),
-		("por dub DUB ud1", _("Portuguese")),
+		("por dub Dub DUB ud1", _("Portuguese")),
 		("fas per", _("Persian")),
 		("ron rum", _("Romanian")),
 		("rus", _("Russian")),


### PR DESCRIPTION
Dub is a abreviation to Dublado that is Portuguese too..