### PR TITLE
Return back duplicate translation in the config

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -350,11 +350,15 @@ class ConfigSelection(ConfigElement):
 	def getText(self):
 		if self._descr is None:
 			self._descr = self.description[self.value]
+		if self._descr:
+			return _(self._descr)
 		return self._descr
 
 	def getMulti(self, selected):
 		if self._descr is None:
 			self._descr = self.description[self.value]
+		if self._descr:
+			return ("text", _(self._descr))
 		return ("text", self._descr)
 
 	# HTML
@@ -395,10 +399,16 @@ class ConfigBoolean(ConfigElement):
 			self.value = True
 
 	def getText(self):
-		return self.descriptions[self.value]
+		descr = self.descriptions[self.value]
+		if descr:
+			return _(descr)
+		return descr
 
 	def getMulti(self, selected):
-		return ("text", self.descriptions[self.value])
+		descr = self.descriptions[self.value]
+		if descr:
+			return ("text", _(descr))
+		return ("text", descr)
 
 	def tostring(self, value):
 		if not value:


### PR DESCRIPTION
This can be useful after you change the language in the start wizard.
It does not provide a full translation for all.
It works only in one direction- from the English to other language.
But it is very likely that in the start wizard you need to translate only the config values after language change from English to your local.