### PR TITLE
ServiceInfo: small optimization in ShowTransponderInformation

### DIFF
--- a/lib/python/Screens/ServiceInfo.py
+++ b/lib/python/Screens/ServiceInfo.py
@@ -178,14 +178,15 @@ class ServiceInfo(Screen):
 
 	def ShowTransponderInformation(self):
 		if self.type == TYPE_SERVICE_INFO:
-			if self.feinfo and self.feinfo.getAll(True):
+			frontendData = self.feinfo and self.feinfo.getAll(True)
+			if frontendData:
 				if self["key_blue"].text == _("Tuner setting values"):
 					self["Title"].text = _("Service info - tuner setting values")
 					self["key_blue"].text = self["blue"].text = _("Tuner live values")
 				else:
 					self["Title"].text = _("Service info - tuner live values")
 					self["key_blue"].text = self["blue"].text = _("Tuner setting values")
-				frontendData = self.feinfo and self.feinfo.getAll(self.getTitle() == _("Service info - tuner setting values"))
+					frontendData = self.feinfo.getAll(False)
 				self.fillList(self.getFEData(frontendData))
 			elif self.transponder_info:
 				self["Title"].text = _("Service info - tuner setting values")


### PR DESCRIPTION
Avoids unnecessary function calls.
Call self.feinfo.getAll(False) only if need data from the tuner.