### PR TITLE
frontend: fix snr incorrect max value

### DIFF
--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -1001,36 +1001,36 @@ void eDVBFrontend::calculateSignalQuality(int snr, int &signalquality, int &sign
 	}
 	else if (!strcmp(m_description, "Vuplus DVB-S NIM(AVL2108)")) // VU+Ultimo/VU+Uno DVB-S2 NIM
 	{
-		ret = (int)((((double(snr) / (65536.0 / 100.0)) * 0.1600) + 0.2100) * 100);
+		ret = (int)((((double(snr) / (65535.0 / 100.0)) * 0.1600) + 0.2100) * 100);
 	}
 	else if (!strcmp(m_description, "Vuplus DVB-S NIM(AVL6222)")) // VU+ DVB-S2 Dual NIM
 	{
-		ret = (int)((((double(snr) / (65536.0 / 100.0)) * 0.1244) + 2.5079) * 100);
+		ret = (int)((((double(snr) / (65535.0 / 100.0)) * 0.1244) + 2.5079) * 100);
 		sat_max = 1490;
 	}
 	else if (!strcmp(m_description, "Vuplus DVB-S NIM(AVL6211)")) // VU+ DVB-S2 Dual NIM
 	{
-		ret = (int)((((double(snr) / (65536.0 / 100.0)) * 0.1244) + 2.5079) * 100);
+		ret = (int)((((double(snr) / (65535.0 / 100.0)) * 0.1244) + 2.5079) * 100);
 	}
 	else if (!strcmp(m_description, "BCM7335 DVB-S2 NIM (internal)")) // VU+DUO DVB-S2 NIM
 	{
-		ret = (int)((((double(snr) / (65536.0 / 100.0)) * 0.1244) + 2.5079) * 100);
+		ret = (int)((((double(snr) / (65535.0 / 100.0)) * 0.1244) + 2.5079) * 100);
 	}
 	else if (!strcmp(m_description, "BCM7346 (internal)")) // MaxDigital XP1000
 	{
-		ret = (int)((((double(snr) / (65536.0 / 100.0)) * 0.1880) + 0.1959) * 100);
+		ret = (int)((((double(snr) / (65535.0 / 100.0)) * 0.1880) + 0.1959) * 100);
 	}
 	else if (!strcmp(m_description, "BCM7356 DVB-S2 NIM (internal)")) // VU+ Solo2
 	{
-		ret = (int)((((double(snr) / (65536.0 / 100.0)) * 0.1800) - 1.0000) * 100);
+		ret = (int)((((double(snr) / (65535.0 / 100.0)) * 0.1800) - 1.0000) * 100);
 	}
 	else if (!strcmp(m_description, "Vuplus DVB-S NIM(7376 FBC)")) // VU+ Solo4k
 	{
-		ret = (int)((((double(snr) / (65536.0 / 100.0)) * 0.1480) + 0.9560) * 100);
+		ret = (int)((((double(snr) / (65535.0 / 100.0)) * 0.1480) + 0.9560) * 100);
 	}
 	else if (!strcmp(m_description, "BCM7362 (internal) DVB-S2")) // Xsarius
 	{
-		ret = (int)((((double(snr) / (65536.0 / 100.0)) * 0.28) - 10.0) * 100);
+		ret = (int)((((double(snr) / (65535.0 / 100.0)) * 0.28) - 10.0) * 100);
 	}
 	else if (!strcmp(m_description, "Genpix"))
 	{
@@ -1115,16 +1115,16 @@ void eDVBFrontend::calculateSignalQuality(int snr, int &signalquality, int &sign
 		switch (type)
 		{
 		case feSatellite:
-			signalquality = (ret >= sat_max ? 65536 : ret * 65536 / sat_max);
+			signalquality = (ret >= sat_max ? 65535 : ret * 65535 / sat_max);
 			break;
 		case feCable: // we assume a max of 42db here
-			signalquality = (ret >= 4200 ? 65536 : ret * 65536 / 4200);
+			signalquality = (ret >= 4200 ? 65535 : ret * 65535 / 4200);
 			break;
 		case feTerrestrial: // we assume a max of 29db here
-			signalquality = (ret >= ter_max ? 65536 : ret * 65536 / ter_max);
+			signalquality = (ret >= ter_max ? 65535 : ret * 65535 / ter_max);
 			break;
 		case feATSC: // we assume a max of 42db here
-			signalquality = (ret >= atsc_max ? 65536 : ret * 65536 / atsc_max);
+			signalquality = (ret >= atsc_max ? 65535 : ret * 65535 / atsc_max);
 			break;
 		}
 	}

--- a/lib/python/Components/Converter/FrontendInfo.py
+++ b/lib/python/Components/Converter/FrontendInfo.py
@@ -92,7 +92,7 @@ class FrontendInfo(Converter, object):
 			return string
 		if percent is None:
 			return "N/A"
-		return "%d %%" % (percent * 100 / 65536)
+		return "%d %%" % (percent * 100 / 65535)
 
 	@cached
 	def getBool(self):
@@ -139,5 +139,5 @@ class FrontendInfo(Converter, object):
 			num = self.source.slot_number
 			return num is None and -1 or num
 
-	range = 65536
+	range = 65535
 	value = property(getValue)

--- a/lib/python/Components/TunerInfo.py
+++ b/lib/python/Components/TunerInfo.py
@@ -51,9 +51,9 @@ class TunerInfo(GUIComponent):
 		if self.type == self.SNR_DB:
 			value = self.getValue(self.SNR_DB)
 		elif self.type == self.SNR_PERCENTAGE or self.type == self.SNR_BAR:
-			value = self.getValue(self.SNR) * 100 / 65536
+			value = self.getValue(self.SNR) * 100 / 65535
 		elif self.type == self.AGC_PERCENTAGE or self.type == self.AGC_BAR:
-			value = self.getValue(self.AGC) * 100 / 65536
+			value = self.getValue(self.AGC) * 100 / 65535
 		elif self.type == self.BER_VALUE or self.type == self.BER_BAR:
 			value = self.getValue(self.BER)
 		elif self.type == self.LOCK_STATE:


### PR DESCRIPTION
According to the documentation the drivers return a value from 0 to 0xffff (100%).

https://linuxtv.org/downloads/v4l-dvb-apis/uapi/dvb/frontend-stat-properties.html

In some places we are using 65536 (0x10000) instead of 65535 (0xffff).
That was causing the maximum value to displayed as 99% instead of 100%.

Replace the 65536 with 65535 in frontend CNR/SNR calculatiosn to fix issue.