### PR TITLE
About: read image install date using /etc/version

### DIFF
--- a/lib/python/Components/About.py
+++ b/lib/python/Components/About.py
@@ -20,7 +20,7 @@ def getImageVersionString():
 
 def getFlashDateString():
 	try:
-		return time.strftime(_("%Y-%m-%d %H:%M"), time.localtime(os.stat("/boot").st_ctime))
+		return time.strftime(_("%Y-%m-%d %H:%M"), time.strptime(open("/etc/version").read().strip(), '%Y%m%d%H%M'))
 	except:
 		return _("unknown")
 


### PR DESCRIPTION
This solves install date displayed as 1970 in some machines