### PR TITLE
Use in instead of the has_key() method in mytest and e2reactor

### DIFF
--- a/e2reactor.py
+++ b/e2reactor.py
@@ -55,12 +55,15 @@ class PollReactor(posixbase.PosixReactorBase):
 			pass
 
 		mask = 0
-		if reads.has_key(fd): mask = mask | select.POLLIN
-		if writes.has_key(fd): mask = mask | select.POLLOUT
+		if fd in reads:
+			mask = mask | select.POLLIN
+		if fd in writes:
+			mask = mask | select.POLLOUT
 		if mask != 0:
 			poller.register(fd, mask)
 		else:
-			if selectables.has_key(fd): del selectables[fd]
+			if fd in selectables:
+				del selectables[fd]
 
 
 		poller.eApp.interruptPoll()
@@ -82,7 +85,7 @@ class PollReactor(posixbase.PosixReactorBase):
 				# Hmm, maybe not the right course of action?  This method can't
 				# fail, because it happens inside error detection...
 				return
-		if mdict.has_key(fd):
+		if fd in mdict:
 			del mdict[fd]
 			self._updateRegistration(fd)
 
@@ -90,7 +93,7 @@ class PollReactor(posixbase.PosixReactorBase):
 		"""Add a FileDescriptor for notification of data available to read.
 		"""
 		fd = reader.fileno()
-		if not reads.has_key(fd):
+		if fd not in reads:
 			selectables[fd] = reader
 			reads[fd] =  1
 			self._updateRegistration(fd)
@@ -99,7 +102,7 @@ class PollReactor(posixbase.PosixReactorBase):
 		"""Add a FileDescriptor for notification of data available to write.
 		"""
 		fd = writer.fileno()
-		if not writes.has_key(fd):
+		if fd not in writes:
 			selectables[fd] = writer
 			writes[fd] =  1
 			self._updateRegistration(fd)

--- a/mytest.py
+++ b/mytest.py
@@ -118,7 +118,7 @@ def dump(dir, p = ""):
 			dump(val, p + "(dict)/" + entry)
 	if hasattr(dir, "__dict__"):
 		for name, value in dir.__dict__.items():
-			if not had.has_key(str(value)):
+			if str(value) not in had:
 				had[str(value)] = 1
 				dump(value, p + "/" + str(name))
 			else:


### PR DESCRIPTION
According to: http://legacy.python.org/dev/peps/pep-0290/#looping-over-dictionaries
It is better and faster.