### PR TITLE
Streamserver: use 30 seconds socket timeout

### DIFF
--- a/lib/dvb/streamserver.cpp
+++ b/lib/dvb/streamserver.cpp
@@ -51,6 +51,12 @@ static void set_tcp_buffer_size(int fd, int optname, int buf_size)
 		eDebug("Failed to set TCP SNDBUF or RCVBUF size: %m");
 }
 
+static void set_tcp_parameter(int fd, int optname, int parameter)
+{
+	if (::setsockopt(fd, SOL_TCP, optname, &parameter, sizeof(parameter)))
+		eDebug("Failed to set TCP paramter: %m");
+}
+
 void eStreamClient::notifier(int what)
 {
 	if (!(what & eSocketNotifier::Read))
@@ -139,6 +145,8 @@ void eStreamClient::notifier(int what)
 				set_tcp_buffer_size(streamFd, SO_RCVBUF, 1 * 1024);
 				 /* We like 188k packets, so set the TCP window size to that */
 				set_tcp_buffer_size(streamFd, SO_SNDBUF, 188 * 1024);
+				/* Set 30 seconds timeout */
+				set_tcp_parameter(streamFd, TCP_USER_TIMEOUT, 30 * 1000);
 				if (serviceref.substr(0, 10) == "file?file=") /* convert openwebif stream reqeust back to serviceref */
 					serviceref = "1:0:1:0:0:0:0:0:0:0:" + serviceref.substr(10);
 				pos = serviceref.find('?');

--- a/lib/network/socket.h
+++ b/lib/network/socket.h
@@ -5,6 +5,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <sys/un.h>
 #include <netdb.h>
 #include <fcntl.h>


### PR DESCRIPTION
The streamserver locks a tuner for several minutes, if there is
an abnormal connection drop (eg power issue, cable removal etc).

Use TCP_USER_TIMEOUT with timeouf of 30 seconds to allow streamserver
to recover faster, releasing the tuner back to Enigma2.