### PR TITLE
Allow stopping all streams from StreamingClientsInfo

### DIFF
--- a/lib/dvb/streamserver.cpp
+++ b/lib/dvb/streamserver.cpp
@@ -283,6 +283,19 @@ void eStreamServer::stopStream()
 	}
 }
 
+bool eStreamServer::stopStreamClient(const std::string remotehost, const std::string serviceref)
+{
+	for (eSmartPtrList<eStreamClient>::iterator it = clients.begin(); it != clients.end(); ++it)
+	{
+		if(it->getRemoteHost() == remotehost && it->getServiceref() == serviceref)
+		{
+			it->stopStream();
+			return true;
+		}
+	}
+	return false;
+}
+
 PyObject *eStreamServer::getConnectedClients()
 {
 	ePyObject ret;

--- a/lib/dvb/streamserver.h
+++ b/lib/dvb/streamserver.h
@@ -64,6 +64,7 @@ public:
 
 	static eStreamServer *getInstance();
 	void stopStream();
+	bool stopStreamClient(const std::string remotehost, const std::string serviceref);
 	PyObject *getConnectedClients();
 };
 

--- a/lib/python/Screens/StreamingClientsInfo.py
+++ b/lib/python/Screens/StreamingClientsInfo.py
@@ -1,23 +1,37 @@
 from Screen import Screen
 from Components.ActionMap import ActionMap
+from Components.Button import Button
 from Components.ScrollLabel import ScrollLabel
 from Components.Converter.ClientsStreaming import ClientsStreaming
 import skin
-
+import enigma
 
 class StreamingClientsInfo(Screen):
 	def __init__(self, session):
 		Screen.__init__(self, session)
 		self.setTitle(_("Streaming clients info"))
+
 		clients = ClientsStreaming("INFO_RESOLVE")
 		text = clients.getText()
 
 		self["ScrollLabel"] = ScrollLabel(text or _("No stream clients"))
+		self["key_red"] = Button(text and _("Stop Streams") or "")
 
 		self["actions"] = ActionMap(["ColorActions", "SetupActions", "DirectionActions"],
 		{
 			"cancel": self.close,
 			"ok": self.close,
+			"red": self.stopStreams,
 			"up": self["ScrollLabel"].pageUp,
 			"down": self["ScrollLabel"].pageDown
 		})
+
+	def stopStreams(self):
+		streamServer = enigma.eStreamServer.getInstance()
+		if not streamServer:
+			return
+
+		for x in streamServer.getConnectedClients():
+			streamServer.stopStream()
+
+		self.close()


### PR DESCRIPTION
* StreamingClientsInfo: Allow stopping all streams

Allows to stop all streams, releasing tuners back to enigma2

* streamserver: introduce stopStreamClient function

The stopStreamClient can be used to stop specific stream by passing ip and serviceref.