### PR TITLE
Add new option 'use dvbapi5 statistics' for show snr/db in gui

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -81,6 +81,7 @@
 		<item level="2" text="Show picons in display" description="Configure if service picons will be shown in display (when supported by the skin)." requires="HasFrontDisplayPicon">config.usage.show_picon_in_display</item>
 		<item level="2" text="Infobar frontend data source" description="Configure the source of the frontend data as shown on the infobars. 'Settings' is as stored on the settings. 'Tuner' is as reported by the tuner.">config.usage.infobar_frontend_source</item>
 		<item level="2" text="Show SNR percentage instead of dB value" description="By default, SNR will be shown in dB (when supported by the tuner). This setting forces SNR to be shown as a percentage instead.">config.usage.swap_snr_on_osd</item>
+		<item level="2" text="Use DVB API 5 statistics SNR/dB" description="By default, with support in the drivers, used statistics DVB API 5. When disabled, use the old method of calculating SNR/dB.">config.usage.use_dvbapi5_statistics</item>
 		<item level="2" text="Show EIT now/next in infobar" description="When enabled, display the EIT now/next eventdata in infobar. When disabled, display now/next eventdata from the EPG cache instead.">config.usage.show_eit_nownext</item>
 		<item level="2" text="Behavior of 0 key in PiP-mode" description="Configure the function of the '0' button do when PIP is active." requires="PIPAvailable">config.usage.pip_zero_button</item>
 		<item level="2" text="Close PiP on exit" description="When enabled the PiP can be closed by the exit button." requires="PIPAvailable">config.usage.pip_hideOnExit</item>

--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -676,6 +676,8 @@ int eDVBFrontend::openFrontend()
 	if (!m_multitype)
 		m_type = feSatellite;
 
+	use_dvbapi5_statistics = eConfigManager::getConfigBoolValue("config.usage.use_dvbapi5_statistics");
+
 	setTone(iDVBFrontend::toneOff);
 	setVoltage(iDVBFrontend::voltageOff);
 
@@ -1165,7 +1167,7 @@ int eDVBFrontend::readFrontendData(int type)
 				int signalquality = 0;
 				int signalqualitydb = 0;
 #if DVB_API_VERSION > 5 || DVB_API_VERSION == 5 && DVB_API_VERSION_MINOR >= 10
-				if (m_dvbversion >= DVB_VERSION(5, 10))
+				if (use_dvbapi5_statistics && m_dvbversion >= DVB_VERSION(5, 10))
 				{
 					dtv_property prop[1];
 					prop[0].cmd = DTV_STAT_CNR;

--- a/lib/dvb/frontend.h
+++ b/lib/dvb/frontend.h
@@ -88,6 +88,7 @@ private:
 	bool m_rotor_mode;
 	bool m_need_rotor_workaround;
 	bool m_multitype;
+	bool use_dvbapi5_statistics;
 	std::map<fe_delivery_system_t, bool> m_delsys, m_delsys_whitelist;
 	std::string m_filename;
 	char m_description[128];

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -293,6 +293,7 @@ def InitUsageConfig():
 	config.usage.movielist_unseen = ConfigYesNo(default = False)
 
 	config.usage.swap_snr_on_osd = ConfigYesNo(default = False)
+	config.usage.use_dvbapi5_statistics = ConfigYesNo(default = True)
 
 	def SpinnerOnOffChanged(configElement):
 		setSpinnerOnOff(int(configElement.value))


### PR DESCRIPTION
For DVB API 5 need same recalculation.
Samy simple option if DVB API 5 incorrect values, return to old DVB API.
In the DVB API made great recalculation value.

et8500/et7x00/sundtek/osmega --> incorrect values for DVB API 5
