### PR TITLE
fixed cppcheck warning about m_widget_arg2 not being initialized.

### DIFF
--- a/lib/actions/action.cpp
+++ b/lib/actions/action.cpp
@@ -186,11 +186,26 @@ void eActionMap::unbindKeyDomain(const std::string &domain)
 
 struct call_entry
 {
-	ePyObject m_fnc, m_arg;
+	ePyObject m_fnc;
+	ePyObject m_arg;
 	eWidget *m_widget;
-	void *m_widget_arg, *m_widget_arg2;
-	call_entry(ePyObject fnc, ePyObject arg): m_fnc(fnc), m_arg(arg), m_widget(0), m_widget_arg(0) { }
-	call_entry(eWidget *widget, void *arg, void *arg2): m_widget(widget), m_widget_arg(arg), m_widget_arg2(arg2) { }
+	void *m_widget_arg;
+	void *m_widget_arg2;
+
+	call_entry(ePyObject fnc, ePyObject arg)
+		: m_fnc(fnc)
+		, m_arg(arg)
+		, m_widget(nullptr)
+		, m_widget_arg(nullptr)
+		, m_widget_arg2(nullptr)
+	{ }
+	call_entry(eWidget *widget, void *arg, void *arg2)
+		: m_fnc()
+		, m_arg()
+		, m_widget(widget)
+		, m_widget_arg(arg)
+		, m_widget_arg2(arg2)
+	{ }
 };
 
 void eActionMap::keyPressed(const std::string &device, int key, int flags)


### PR DESCRIPTION
nothing special, just a warning about the m_widget_arg2 not being initialized. O btw, I may have falsely assumed that c++11 was available. So instead of NULL (which has some issues) I used nullptr instead.