### PR TITLE
removed unneeded c_str() when using CFile and a std::string as path.

### DIFF
--- a/lib/base/encoding.cpp
+++ b/lib/base/encoding.cpp
@@ -48,8 +48,8 @@ eDVBTextEncodingHandler::eDVBTextEncodingHandler()
 		/* no personalized encoding.conf, fallback to the system default */
 		file = eEnv::resolve("${datadir}/enigma2/encoding.conf");
 	}
-	CFile f(file.c_str(), "rt");
 
+	CFile f(file, "rt");
 	if (f)
 	{
 		size_t bufsize = 256;

--- a/lib/dvb/db.cpp
+++ b/lib/dvb/db.cpp
@@ -104,7 +104,7 @@ RESULT eBouquet::flushChanges()
 {
 	std::string filename = eEnv::resolve("${sysconfdir}/enigma2/" + m_filename);
 	{
-		CFile f((filename + ".writing").c_str(), "w");
+		CFile f(filename + ".writing", "w");
 		if (!f)
 			goto err;
 		if ( fprintf(f, "#NAME %s\r\n", m_bouquet_name.c_str()) < 0 )
@@ -698,11 +698,13 @@ void eDVBDB::saveServicelist(const char *file)
 	eDebug("[eDVBDB] ---- saving lame channel db");
 	std::string filename = file;
 
-	CFile f((filename + ".writing").c_str(), "w");
+
+	CFile f(filename + ".writing", "w");
+	{
 	int channels=0, services=0;
 	if (!f)
 		eFatal("[eDVBDB] couldn't save lame channel db!");
-	CFile g((filename + "5.writing").c_str(), "w");
+	CFile g(filename + "5.writing", "w");
 
 	fprintf(f, "eDVB services /4/\n");
 	fprintf(f, "transponders\n");

--- a/lib/dvb/metaparser.cpp
+++ b/lib/dvb/metaparser.cpp
@@ -66,7 +66,7 @@ int eDVBMetaParser::parseMeta(const std::string &tsname)
 {
 	/* if it's a PVR channel, recover service id. */
 	std::string filename = tsname + ".meta";
-	CFile f(filename.c_str(), "r");
+	CFile f(filename, "r");
 
 	if (!f)
 		return -ENOENT;
@@ -150,7 +150,7 @@ int eDVBMetaParser::parseRecordings(const std::string &filename)
 
 	std::string recordings = filename.substr(0, slash) + "/recordings.epl";
 
-	CFile f(recordings.c_str(), "r");
+	CFile f(recordings, "r");
 	if (!f)
 	{
 //		eDebug("[eDVBMetaParser] no recordings.epl found: %s: %m", recordings.c_str());
@@ -209,7 +209,7 @@ int eDVBMetaParser::updateMeta(const std::string &tsname)
 	eServiceReference ref = m_ref;
 	ref.path = "";
 
-	CFile f(filename.c_str(), "w");
+	CFile f(filename, "w");
 	if (!f)
 		return -ENOENT;
 

--- a/lib/dvb/pvrparse.cpp
+++ b/lib/dvb/pvrparse.cpp
@@ -60,7 +60,7 @@ int eMPEGStreamInformation::load(const char *filename)
 	m_access_points.clear();
 	m_pts_to_offset.clear();
 	m_timestamp_deltas.clear();
-	CFile f((s_filename + ".ap").c_str(), "rb");
+	CFile f(s_filename + ".ap", "rb");
 	if (!f)
 		return -1;
 	while (1)
@@ -648,7 +648,7 @@ int eMPEGStreamInformationWriter::stopSave(void)
 	std::string ap_filename(m_filename);
 	ap_filename += ".ap";
 	{
-		CFile f(ap_filename.c_str(), "wb");
+		CFile f(ap_filename, "wb");
 		if (!f)
 			return -1;
 		for (std::deque<AccessPoint>::const_iterator i(m_streamtime_access_points.begin()); i != m_streamtime_access_points.end(); ++i)


### PR DESCRIPTION
While browsing the last couple of commits I noticed that when CFile was used in combination with a std::string though the `const char *` constructor was used instead of the `const std::string &` constructor. Not that it is any big deal, because there was no additional copy but I do feel we shouldn't use the `.c_str()` function when it isn't really needed.