### PR TITLE
Refactor dvb text encoding handler

### DIFF
--- a/lib/base/encoding.cpp
+++ b/lib/base/encoding.cpp
@@ -48,8 +48,8 @@ eDVBTextEncodingHandler::eDVBTextEncodingHandler()
 		/* no personalized encoding.conf, fallback to the system default */
 		file = eEnv::resolve("${datadir}/enigma2/encoding.conf");
 	}
-	CFile f(file.c_str(), "rt");
 
+	CFile f(file, "rt");
 	if (f)
 	{
 		size_t bufsize = 256;

--- a/lib/base/encoding.cpp
+++ b/lib/base/encoding.cpp
@@ -1,26 +1,26 @@
 #include <cstdio>
 #include <cstdlib>
+
 #include <lib/base/cfile.h>
 #include <lib/base/encoding.h>
 #include <lib/base/eerror.h>
 #include <lib/base/eenv.h>
 
-eDVBTextEncodingHandler encodingHandler;  // the one and only instance
-int defaultEncodingTable = 1;   // the one and only instance
+static eDVBTextEncodingHandler encodingHandler;  // the one and only instance
 
 inline char tolower(char c)
 {
 	return (c >= 'A' && c <= 'Z') ? c + ('a' - 'A') : c;
 }
 
-int mapEncoding(char *s_table)
+int mapEncoding(const char *s_table)
 {
 	int encoding = 0;
 
 	// table name will be in lowercase!
 	if (sscanf(s_table, "iso8859-%d", &encoding) == 1)
 		return encoding;
-	if (sscanf(s_table, "iso%d", &encoding) == 1 and encoding == 6937)
+	if (sscanf(s_table, "iso%d", &encoding) == 1 && encoding == 6937)
 		return 0;
 	if (strcmp(s_table, "gb2312") == 0 || strcmp(s_table, "gbk") == 0
 		|| strcmp(s_table, "gb18030") == 0 || strcmp(s_table, "cp936") == 0)
@@ -41,65 +41,12 @@ int mapEncoding(char *s_table)
 }
 
 eDVBTextEncodingHandler::eDVBTextEncodingHandler()
+	: m_CountryCodeDefaultMapping()
+	, m_TransponderDefaultMapping()
+	, m_TransponderUseTwoCharMapping()
+	, m_DefaultEncodingTable(1)
 {
-	std::string file = eEnv::resolve("${sysconfdir}/enigma2/encoding.conf");
-	if (::access(file.c_str(), R_OK) < 0)
-	{
-		/* no personalized encoding.conf, fallback to the system default */
-		file = eEnv::resolve("${datadir}/enigma2/encoding.conf");
-	}
-
-	CFile f(file, "rt");
-	if (f)
-	{
-		size_t bufsize = 256;
-		char *line = (char*) malloc(bufsize);
-		char countrycode[bufsize];
-		char *s_table = (char*) malloc(bufsize);
-		while (getline(&line, &bufsize, f) != -1)
-		{
-			int i, j = 0;	   // remove leading whitespace and control chars, and comments
-			for (i = 0; line[i]; i++) {
-				if (line[i] == '#')
-					break; // skip rest of line
-				if (j == 0 && line[i] > 0 && line[i] <= ' ')
-					continue;       //skip non-printable char and whitespace in head
-				line[j++] = tolower(line[i]); // countrycodes are always lowercase, same as are used in event and epgcache !
-			}
-			if (j == 0)
-				continue;       // skip 'empty' lines
-			line[j] = 0;
-
-			int tsid, onid, encoding = -1;
-			if (sscanf(line, "0x%x 0x%x %s", &tsid, &onid, s_table) == 3
-				  || sscanf(line, "%d %d %s", &tsid, &onid, s_table) == 3 ) {
-				encoding = mapEncoding(s_table);
-				if (encoding != -1)
-					m_TransponderDefaultMapping[(tsid<<16)|onid] = encoding;
-			}
-			else if (sscanf(line, "0x%x 0x%x", &tsid, &onid) == 2
-					|| sscanf(line, "%d %d", &tsid, &onid) == 2 ) {
-				m_TransponderUseTwoCharMapping.insert((tsid<<16)|onid);
-				encoding = 0; // avoid spurious error message
-			}
-			else if (sscanf(line, "%s %s", countrycode, s_table) == 2 ) {
-				encoding = mapEncoding(s_table);
-				if (encoding != -1) {
-					if (countrycode[0] == '*')
-						defaultEncodingTable = encoding;
-					else
-						m_CountryCodeDefaultMapping[countrycode] = encoding;
-				}
-			}
-
-			if (encoding == -1)
-				eDebug("[eDVBTextEncodingHandler] encoding.conf: couldn't parse %s", line);
-		}
-		free(line);
-		free(s_table);
-	}
-	else
-		eDebug("[eDVBTextEncodingHandler] couldn't open %s: %m", file.c_str());
+	__loadEncodingQuirkConfiguration();
 }
 
 void eDVBTextEncodingHandler::getTransponderDefaultMapping(int tsidonid, int &table)
@@ -115,11 +62,80 @@ bool eDVBTextEncodingHandler::getTransponderUseTwoCharMapping(int tsidonid)
 	return m_TransponderUseTwoCharMapping.find(tsidonid) != m_TransponderUseTwoCharMapping.end();
 }
 
-int eDVBTextEncodingHandler::getCountryCodeDefaultMapping( const std::string &country_code )
+int eDVBTextEncodingHandler::getCountryCodeDefaultMapping(const std::string &country_code)
 {
 	std::map<std::string, int>::iterator it =
 		m_CountryCodeDefaultMapping.find(country_code);
 	if ( it != m_CountryCodeDefaultMapping.end() )
 		return it->second;
-	return defaultEncodingTable;
+	return m_DefaultEncodingTable;
+}
+
+int eDVBTextEncodingHandler::getDefaultEncodingTable()
+{
+	return m_DefaultEncodingTable;
+}
+
+void eDVBTextEncodingHandler::__loadEncodingQuirkConfiguration()
+{
+	std::string file = eEnv::resolve("${sysconfdir}/enigma2/encoding.conf");
+	if (::access(file.c_str(), R_OK) < 0)
+	{
+		/* no personalized encoding.conf, fall back to the system default */
+		file = eEnv::resolve("${datadir}/enigma2/encoding.conf");
+	}
+
+	CFile f(file, "rt");
+	if (!f)
+	{
+		eDebug("[eDVBTextEncodingHandler] couldn't open %s: %m", file.c_str());
+		return;
+	}
+
+	size_t bufsize = 256;
+	char *line = (char*)malloc(bufsize);
+	char countrycode[bufsize];
+	char s_table[bufsize];
+
+	while (getline(&line, &bufsize, f) != -1)
+	{
+		int i, j = 0;	   // remove leading whitespace and control chars, and comments
+		for (i = 0; line[i]; i++) {
+			if (line[i] == '#')
+				break; // skip rest of line
+			if (j == 0 && line[i] > 0 && line[i] <= ' ')
+				continue;       //skip non-printable char and whitespace in head
+			line[j++] = tolower(line[i]); // countrycodes are always lowercase, same as are used in event and epgcache !
+		}
+		if (j == 0)
+			continue;       // skip 'empty' lines
+		line[j] = 0;
+
+		int tsid, onid, encoding = -1;
+		if (sscanf(line, "0x%x 0x%x %255s", &tsid, &onid, s_table) == 3
+			|| sscanf(line, "%d %d %255s", &tsid, &onid, s_table) == 3) {
+			encoding = mapEncoding(s_table);
+			if (encoding != -1)
+				m_TransponderDefaultMapping[(tsid << 16) | onid] = encoding;
+		}
+		else if (sscanf(line, "0x%x 0x%x", &tsid, &onid) == 2
+			|| sscanf(line, "%d %d", &tsid, &onid) == 2) {
+			m_TransponderUseTwoCharMapping.insert((tsid << 16) | onid);
+			encoding = 0; // avoid spurious error message
+		}
+		else if (sscanf(line, "%255s %255s", countrycode, s_table) == 2) {
+			encoding = mapEncoding(s_table);
+			if (encoding != -1) {
+				if (countrycode[0] == '*')
+					m_DefaultEncodingTable = encoding;
+				else
+					m_CountryCodeDefaultMapping[countrycode] = encoding;
+			}
+		}
+
+		if (encoding == -1)
+			eDebug("[eDVBTextEncodingHandler] encoding.conf: couldn't parse %s", line);
+	}
+
+	free(line);
 }

--- a/lib/base/encoding.h
+++ b/lib/base/encoding.h
@@ -30,13 +30,16 @@ class eDVBTextEncodingHandler
 	std::map<std::string, int> m_CountryCodeDefaultMapping;
 	std::map<int, int> m_TransponderDefaultMapping;
 	std::set<int> m_TransponderUseTwoCharMapping;
+	int m_DefaultEncodingTable;
 public:
 	eDVBTextEncodingHandler();
 	void getTransponderDefaultMapping(int tsidonid, int &table);
 	bool getTransponderUseTwoCharMapping(int tsidonid);
-	int getCountryCodeDefaultMapping( const std::string &country_code );
+	int getCountryCodeDefaultMapping(const std::string &country_code);
+	int getDefaultEncodingTable();
+private:
+	void __loadEncodingQuirkConfiguration();
 };
 
 extern eDVBTextEncodingHandler encodingHandler;
-extern int defaultEncodingTable;
 #endif // __lib_base_encoding_h__

--- a/lib/base/estring.cpp
+++ b/lib/base/estring.cpp
@@ -521,7 +521,7 @@ std::string convertDVBUTF8(const unsigned char *data, int len, int table, int ts
 		table = 0;
 	}
 	else if ( !table || table == -1 )
-		table = defaultEncodingTable;
+		table = encodingHandler.getDefaultEncodingTable();
 
 	switch(table)
 	{
@@ -778,7 +778,7 @@ std::string replace_all(const std::string &in, const std::string &entity, const 
 	std::string out = in;
 	std::string::size_type loc = 0;
 	if( table == -1 )
-		table = defaultEncodingTable;
+		table = encodingHandler.getDefaultEncodingTable();
 
 	switch(table){
 	case UTF8_ENCODING:

--- a/lib/dvb/db.cpp
+++ b/lib/dvb/db.cpp
@@ -104,7 +104,7 @@ RESULT eBouquet::flushChanges()
 {
 	std::string filename = eEnv::resolve("${sysconfdir}/enigma2/" + m_filename);
 	{
-		CFile f((filename + ".writing").c_str(), "w");
+		CFile f(filename + ".writing", "w");
 		if (!f)
 			goto err;
 		if ( fprintf(f, "#NAME %s\r\n", m_bouquet_name.c_str()) < 0 )
@@ -698,11 +698,13 @@ void eDVBDB::saveServicelist(const char *file)
 	eDebug("[eDVBDB] ---- saving lame channel db");
 	std::string filename = file;
 
-	CFile f((filename + ".writing").c_str(), "w");
+
+	CFile f(filename + ".writing", "w");
+	{
 	int channels=0, services=0;
 	if (!f)
 		eFatal("[eDVBDB] couldn't save lame channel db!");
-	CFile g((filename + "5.writing").c_str(), "w");
+	CFile g(filename + "5.writing", "w");
 
 	fprintf(f, "eDVB services /4/\n");
 	fprintf(f, "transponders\n");

--- a/lib/dvb/metaparser.cpp
+++ b/lib/dvb/metaparser.cpp
@@ -66,7 +66,7 @@ int eDVBMetaParser::parseMeta(const std::string &tsname)
 {
 	/* if it's a PVR channel, recover service id. */
 	std::string filename = tsname + ".meta";
-	CFile f(filename.c_str(), "r");
+	CFile f(filename, "r");
 
 	if (!f)
 		return -ENOENT;
@@ -150,7 +150,7 @@ int eDVBMetaParser::parseRecordings(const std::string &filename)
 
 	std::string recordings = filename.substr(0, slash) + "/recordings.epl";
 
-	CFile f(recordings.c_str(), "r");
+	CFile f(recordings, "r");
 	if (!f)
 	{
 //		eDebug("[eDVBMetaParser] no recordings.epl found: %s: %m", recordings.c_str());
@@ -209,7 +209,7 @@ int eDVBMetaParser::updateMeta(const std::string &tsname)
 	eServiceReference ref = m_ref;
 	ref.path = "";
 
-	CFile f(filename.c_str(), "w");
+	CFile f(filename, "w");
 	if (!f)
 		return -ENOENT;
 

--- a/lib/dvb/pvrparse.cpp
+++ b/lib/dvb/pvrparse.cpp
@@ -60,7 +60,7 @@ int eMPEGStreamInformation::load(const char *filename)
 	m_access_points.clear();
 	m_pts_to_offset.clear();
 	m_timestamp_deltas.clear();
-	CFile f((s_filename + ".ap").c_str(), "rb");
+	CFile f(s_filename + ".ap", "rb");
 	if (!f)
 		return -1;
 	while (1)
@@ -648,7 +648,7 @@ int eMPEGStreamInformationWriter::stopSave(void)
 	std::string ap_filename(m_filename);
 	ap_filename += ".ap";
 	{
-		CFile f(ap_filename.c_str(), "wb");
+		CFile f(ap_filename, "wb");
 		if (!f)
 			return -1;
 		for (std::deque<AccessPoint>::const_iterator i(m_streamtime_access_points.begin()); i != m_streamtime_access_points.end(); ++i)


### PR DESCRIPTION
Note, this pr also includes the code from [pr 821](https://github.com/OpenPLi/enigma2/pull/821) simply because it depends on it.

Now this is a bit different, because I am working on a bigger overhaul of the character encoding system (see https://github.com/stevenhoving/dvb_utf8) I have spend this afternoon figuring out how to incorporate my newly developed code in the enigma code base. This also means that I have figure out how the dvb character encoding quirk overwrite system works.
Although looking at the code didn't really sparked any ideas, I did find a couple of things in the code that could be improved. Like moving the `defaultEncodingTable` global variable inside the `eDVBTextEncodingHandler` class. The way I see it, they belong to each other.

**But I do have 2 additional questions:**
- Why does this file have its own `inline char tolower(char c)` implementation? Why don't you just use the implementation provided by `#include <ctype.h>`?
- You guys are using GCC6 right? Last time I checked it changed the default C++ version to 14, so unless you guys changed it back to `-std=gnu++98`, I could replace those ugly iterator definitions with `auto`. Wait, before you start to `#resist` about `auto`... let me explain. I do not mean AAA (Almost Always Auto), I would only propose to allow `auto` to be used in those ugly iterator situations.
For example, code like this:
```C++
for (std::map<eServiceReferenceDVB, ePtr<eDVBService> >::iterator sit(m_services.begin());
		sit != m_services.end(); ++sit)
	{
		if (sit->first.getTransportStreamID() == Tsid &&
			sit->first.getOriginalNetworkID() == Onid &&
			sit->first.getServiceID() == Sid)
			return sit->first;
	}
```
could become
```C++
for (auto &sit : m_services)
{
    auto &ref = sit.first; // service reference
    if (   ref.getTransportStreamID() == Tsid
        && ref.getOriginalNetworkID() == Onid
        && ref.getServiceID() == Sid)
            return ref;
}
```

Which in the end, is exactly the same as the code above but a bit easier to read (I know the code is not from this file, but I choose it only to illustrate the advantage).