### PR TITLE
dvbci: restore checking CI slots before writing to tsmux

### DIFF
--- a/lib/dvb_ci/dvbci.cpp
+++ b/lib/dvb_ci/dvbci.cpp
@@ -169,7 +169,8 @@ eDVBCIInterfaces::eDVBCIInterfaces()
 	for (eSmartPtrList<eDVBCISlot>::iterator it(m_slots.begin()); it != m_slots.end(); ++it)
 		it->setSource("A");
 
-	for (int tuner_no = 0; tuner_no < num_ci; ++tuner_no)
+	// FIXME initiliaze all inputs by checking /proc/stb/tsmux/inputX instead of using fixed 2 / 4
+	for (int tuner_no = 0; tuner_no < (num_ci > 1 ? 4 : 2); ++tuner_no)
 		setInputSource(tuner_no, eDVBCISlot::getTunerLetter(tuner_no));
 
 	eDebug("[CI] done, found %d common interface slots", num_ci);
@@ -569,7 +570,11 @@ void eDVBCIInterfaces::recheckPMTHandlers()
 					eDebug("[CI] (1)Slot %d, usecount now %d", ci_it->getSlotID(), ci_it->use_count);
 
 					std::stringstream ci_source;
-					ci_source << "CI" << ci_it->getSlotID();
+					ci_source << "CI";
+					if (getNumOfSlots() > 1) // Only receivers with more that 1 CI expect number after CI
+					{
+						ci_source << ci_it->getSlotID();
+					}
 
 					if (!it->cislot)
 					{
@@ -1285,7 +1290,15 @@ int eDVBCISlot::setSource(const std::string &source)
 {
 	char buf[64];
 	current_source = source;
-	snprintf(buf, sizeof(buf), "/proc/stb/tsmux/ci%d_input", slotid);
+
+	if (eDVBCIInterfaces::getInstance()->getNumOfSlots() > 1) // FIXME .. we force DM8000 when more than one CI Slot is avail
+	{
+		snprintf(buf, sizeof(buf), "/proc/stb/tsmux/ci%d_input", slotid);
+	}
+	else // DM7025
+	{
+		snprintf(buf, sizeof(buf), "/proc/stb/tsmux/input2");
+	}
 
 	if(CFile::write(buf, source.c_str()) == -1)
 	{


### PR DESCRIPTION
If there is more that 1 CI nodes we use the DM8000 way (CI0 / CI1 ...)
If there is 1 CI node or none we use the DM7025 way (CI and writing /proc/stb/tsmux/input2).

Also initialize 2 inputs (dm7025) or 4 inputs (dm8000) like before.
Although the proper solution would be to initialize all inputs (with FBC we have way more than 4 inputs) by checking the existance of /proc/stb/tsmux/inputX nodes.
Or just initialize them, code will just produce a warning in setInputSource, not visible by default debug level.