### PR TITLE
Undo remove of RedirectOutput import

### DIFF
--- a/mytest.py
+++ b/mytest.py
@@ -6,6 +6,7 @@ if os.path.isfile("/usr/lib/enigma2/python/enigma.zip"):
 from Tools.Profile import profile, profile_final
 profile("PYTHON_START")
 
+import Tools.RedirectOutput
 import enigma
 import eConsoleImpl
 import eBaseImpl


### PR DESCRIPTION
This reverts a part of this commit:
https://github.com/OpenPLi/enigma2/commit/7a77a4335dd29e30c5d7ca9c85395515f24bd4f0

Without the import the python output is not redirected to log mechanism any more. This leads to missing backtraces in the crashlogs.