### PR TITLE
dvbci: Initialize only two first inputs for legacy compatibility

### DIFF
--- a/lib/dvb_ci/dvbci.cpp
+++ b/lib/dvb_ci/dvbci.cpp
@@ -177,7 +177,7 @@ eDVBCIInterfaces::eDVBCIInterfaces()
 	for (eSmartPtrList<eDVBCISlot>::iterator it(m_slots.begin()); it != m_slots.end(); ++it)
 		it->setSource("A");
 
-	for (int tuner_no = 0; tuner_no < 26; ++tuner_no) // NOTE: this assumes tuners are A .. Z max.
+	for (int tuner_no = 0; tuner_no < (num_ci > 1 ? 26 : 2); ++tuner_no) // NOTE: this assumes tuners are A .. Z max.
 	{
 		path.str("");
 		path.clear();


### PR DESCRIPTION
It seems that machines with no CI or one CI still require to initilize up to two inputs.
Bring back legacy compatibility and investigate further.