### PR TITLE
add symbol_recording hd51/vs1500 for SystemInfo["LCDsymbol_circle_rec…

### DIFF
--- a/lib/python/Components/Sources/RecordState.py
+++ b/lib/python/Components/Sources/RecordState.py
@@ -15,8 +15,8 @@ class RecordState(Source):
 		prev_records = self.records_running
 		if event in (iRecordableService.evEnd, iRecordableService.evStart, None):
 			recs = self.session.nav.getRecordings()
-			if SystemInfo["LCDsymbol_circle"]:
-				open(SystemInfo["LCDsymbol_circle"], "w").write(recs and "1" or "0")
+			if SystemInfo["LCDsymbol_circle_recording"]:
+				open(SystemInfo["LCDsymbol_circle_recording"], "w").write(recs and "1" or "0")
 			self.records_running = len(recs)
 			if self.records_running != prev_records:
 				self.changed((self.CHANGED_ALL,))

--- a/lib/python/Components/SystemInfo.py
+++ b/lib/python/Components/SystemInfo.py
@@ -23,7 +23,7 @@ SystemInfo["12V_Output"] = Misc_Options.getInstance().detected_12V_output()
 SystemInfo["ZapMode"] = fileCheck("/proc/stb/video/zapmode") or fileCheck("/proc/stb/video/zapping_mode")
 SystemInfo["NumFrontpanelLEDs"] = countFrontpanelLEDs()
 SystemInfo["FrontpanelDisplay"] = fileExists("/dev/dbox/oled0") or fileExists("/dev/dbox/lcd0")
-SystemInfo["LCDsymbol_circle"] = fileCheck("/proc/stb/lcd/symbol_circle")
+SystemInfo["LCDsymbol_circle_recording"] = fileCheck("/proc/stb/lcd/symbol_circle") or HardwareInfo().get_device_model() in ("hd51", "vs1500") and fileCheck("/proc/stb/lcd/symbol_recording")
 SystemInfo["LCDsymbol_timeshift"] = fileCheck("/proc/stb/lcd/symbol_timeshift")
 SystemInfo["FrontpanelDisplayGrayscale"] = fileExists("/dev/dbox/oled0")
 SystemInfo["DeepstandbySupport"] = HardwareInfo().get_device_name() != "dm800"


### PR DESCRIPTION
…ording"]

-Previously, it was controlled by the driver.
Therefore, streaming was considered as a record.
We pass control to the image.