### PR TITLE
About: Fix missing CPU Temperature

### DIFF
--- a/lib/python/Components/About.py
+++ b/lib/python/Components/About.py
@@ -77,10 +77,10 @@ def getCPUInfoString():
 		if os.path.isfile("/sys/devices/virtual/thermal/thermal_zone0/temp"):
 			try:
 				temperature = int(open("/sys/devices/virtual/thermal/thermal_zone0/temp").read().strip())/1000
-				if temperature:
-					return "%s %s MHz (%s) %s°C" % (processor, cpu_speed, ngettext("%d core", "%d cores", cpu_count) % cpu_count, temperature)
 			except:
 				pass
+		if temperature:
+			return "%s %s MHz (%s) %s°C" % (processor, cpu_speed, ngettext("%d core", "%d cores", cpu_count) % cpu_count, temperature)
 		return "%s %s MHz (%s)" % (processor, cpu_speed, ngettext("%d core", "%d cores", cpu_count) % cpu_count)
 	except:
 		return _("undefined")


### PR DESCRIPTION
Displaying CPU temperature on macihnes having /proc/stb/fp/temp_sensor_avs
proc node was broken since d5a8acf2e731a411e243f137293e0bffc6236328.