### PR TITLE
[frontend] correct SNR value for AVL6211(hd51/vs1500)

### DIFF
--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -1243,7 +1243,7 @@ int eDVBFrontend::readFrontendData(int type)
 							{
 								return signalqualitydb;
 							}
-							if(!signalquality)
+							if(!signalquality || !strstr(m_description, "AVL6211"))
 							{
 								/* provide an estimated percentage when drivers lack this info */
 								calculateSignalPercentage(signalqualitydb, signalquality);


### PR DESCRIPTION
-we will remove it when the drivers are fixed