### PR TITLE
Update libsigc++ to 2.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,7 @@ AC_ARG_WITH(gstversion,
 	[GST_MAJORMINOR=$withval],[GST_MAJORMINOR=0.10])
 
 PKG_CHECK_MODULES(GSTREAMER, gstreamer-$GST_MAJORMINOR gstreamer-pbutils-$GST_MAJORMINOR)
-PKG_CHECK_MODULES(BASE, [freetype2 fribidi gstreamer-$GST_MAJORMINOR gstreamer-pbutils-$GST_MAJORMINOR libdvbsi++ libpng libxml-2.0 sigc++-1.2 libssl libcrypto])
+PKG_CHECK_MODULES(BASE, [freetype2 fribidi gstreamer-$GST_MAJORMINOR gstreamer-pbutils-$GST_MAJORMINOR libdvbsi++ libpng libxml-2.0 sigc++-2.0 libssl libcrypto])
 PKG_CHECK_MODULES(LIBDDVD, libdreamdvd, HAVE_LIBDDVD="yes", HAVE_LIBDDVD="no")
 AM_CONDITIONAL(HAVE_LIBDDVD, test "$HAVE_LIBDDVD" = "yes")
 PKG_CHECK_MODULES(AVAHI, avahi-client)

--- a/enigma2.pc.in
+++ b/enigma2.pc.in
@@ -7,4 +7,4 @@ Name: enigma2
 Description: Enigma2
 Version: @VERSION@
 Cflags: -I${includedir}/enigma2 @ENIGMA2_CFLAGS@
-Requires.private: sigc++-1.2
+Requires.private: sigc++-2.0

--- a/include/connection.h
+++ b/include/connection.h
@@ -4,12 +4,12 @@
 #include <libsig_comp.h>
 #include <lib/base/object.h>
 
-class eConnection: public iObject, public Connection
+class eConnection: public iObject, public sigc::connection
 {
 	DECLARE_REF(eConnection);
 	ePtr<iObject> m_owner;
 public:
-	eConnection(iObject *owner, const Connection &conn): Connection(conn), m_owner(owner) { };
+	eConnection(iObject *owner, const sigc::connection &conn): sigc::connection(conn), m_owner(owner) { };
 	virtual ~eConnection() { disconnect(); }
 };
 

--- a/include/libsig_comp.h
+++ b/include/libsig_comp.h
@@ -2,32 +2,8 @@
 #define __LIBSIG_COMP_H
 
 #include <sigc++/sigc++.h>
-#include <sigc++/bind.h>
 
-#ifdef SIGC_CXX_NAMESPACES
-using namespace SigC;
-#endif
-
-#define CONNECT(SENDER, EMPFAENGER) SENDER.connect(slot(*this, &EMPFAENGER))
-// use this Makro to connect with a method
-// void bla::foo(int x);
-// to an
-// Signal<void, int> testSig;
-//
-// CONNECT(testSig, bla::foo);
-// signal and method (slot) must have the same signature
-
-#define CONNECT_1_0(SENDER, EMPFAENGER, PARAM) SENDER.connect( bind( slot(*this, &EMPFAENGER) ,PARAM ) )
-// use this for connect with a method
-// void bla::foo(int);
-// to an
-// Signal0<void> testSig;
-// CONNECT_1_0(testSig, bla:foo, 0);
-// here the signal has no parameter, but the slot have an int
-// the last parameter of the CONNECT_1_0 makro is the value that given to the paramater of the Slot method
-
-#define CONNECT_2_0(SENDER, EMPFAENGER, PARAM1, PARAM2) SENDER.connect( bind( slot(*this, &EMPFAENGER) ,PARAM1, PARAM2 ) )
-
-#define CONNECT_2_1(SENDER, EMPFAENGER, PARAM) SENDER.connect( bind( slot(*this, &EMPFAENGER) ,PARAM ) )
+#define CONNECT(_signal, _slot) _signal.connect(sigc::mem_fun(*this, &_slot))
+#define CONNECT_EXTRA(_signal, _slot, extra_args...) _signal.connect(bind(sigc::mem_fun(*this, &_slot), extra_args))
 
 #endif // __LIBSIG_COMP_H

--- a/lib/base/console.h
+++ b/lib/base/console.h
@@ -19,7 +19,7 @@ struct queue_data
 	int dataSent;
 };
 
-class eConsoleAppContainer: public Object, public iObject
+class eConsoleAppContainer: public sigc::trackable, public iObject
 {
 	DECLARE_REF(eConsoleAppContainer);
 	int fd[3];

--- a/lib/base/e2avahi.cpp
+++ b/lib/base/e2avahi.cpp
@@ -15,7 +15,7 @@ static AvahiClient *avahi_client = NULL;
 /* API to the E2 event loop */
 static AvahiPoll avahi_poll_api;
 
-struct AvahiTimeout: public Object
+struct AvahiTimeout: public sigc::trackable
 {
 	ePtr<eTimer> timer;
 	AvahiTimeoutCallback callback;
@@ -36,7 +36,7 @@ struct AvahiTimeout: public Object
 	}
 };
 
-struct AvahiWatch: public Object
+struct AvahiWatch: public sigc::trackable
 {
 	ePtr<eSocketNotifier> sn;
 	AvahiWatchCallback callback;

--- a/lib/base/httpstream.h
+++ b/lib/base/httpstream.h
@@ -6,7 +6,7 @@
 #include <lib/base/itssource.h>
 #include <lib/base/thread.h>
 
-class eHttpStream: public iTsSource, public Object, public eThread
+class eHttpStream: public iTsSource, public sigc::trackable, public eThread
 {
 	DECLARE_REF(eHttpStream);
 

--- a/lib/base/message.h
+++ b/lib/base/message.h
@@ -50,7 +50,7 @@ public:
  * Automatically creates a eSocketNotifier and gives you a callback.
  */
 template<class T>
-class eFixedMessagePump: public Object, FD
+class eFixedMessagePump: public sigc::trackable, FD
 {
 	eSingleLock lock;
 	ePtr<eSocketNotifier> sn;
@@ -96,7 +96,7 @@ class eFixedMessagePump: public Object, FD
 			eFatal("[eFixedMessagePump] write error %m");
 	}
 public:
-	Signal1<void,const T&> recv_msg;
+	sigc::signal1<void,const T&> recv_msg;
 	void send(const T &msg)
 	{
 		{
@@ -120,7 +120,7 @@ public:
 };
 #endif
 
-class ePythonMessagePump: public eMessagePumpMT, public Object
+class ePythonMessagePump: public eMessagePumpMT, public sigc::trackable
 {
 	ePtr<eSocketNotifier> sn;
 	void do_recv(int)

--- a/lib/components/file_eraser.h
+++ b/lib/components/file_eraser.h
@@ -5,7 +5,7 @@
 #include <lib/base/message.h>
 #include <lib/base/ebase.h>
 
-class eBackgroundFileEraser: public eMainloop, private eThread, public Object
+class eBackgroundFileEraser: public eMainloop, private eThread, public sigc::trackable
 {
 	struct Message
 	{

--- a/lib/components/scan.cpp
+++ b/lib/components/scan.cpp
@@ -113,7 +113,7 @@ int eComponentScan::start(int feid, int flags, int networkid)
 
 	std::list<ePtr<iDVBFrontendParameters> > list;
 	m_scan = new eDVBScan(channel);
-	m_scan->connectEvent(slot(*this, &eComponentScan::scanEvent), m_scan_event_connection);
+	m_scan->connectEvent(sigc::mem_fun(*this, &eComponentScan::scanEvent), m_scan_event_connection);
 
 	if (!(flags & scanRemoveServices))
 	{

--- a/lib/components/scan.h
+++ b/lib/components/scan.h
@@ -6,7 +6,7 @@
 
 class eDVBScan;
 
-class eComponentScan: public Object, public iObject
+class eComponentScan: public sigc::trackable, public iObject
 {
 	DECLARE_REF(eComponentScan);
 #ifndef SWIG

--- a/lib/components/tuxtxtapp.h
+++ b/lib/components/tuxtxtapp.h
@@ -8,7 +8,7 @@
 #include <lib/python/python.h>
 #include <lib/python/connections.h>
 
-class eTuxtxtApp: private eThread, public Object
+class eTuxtxtApp: private eThread, public sigc::trackable
 {
 #ifndef SWIG
 	int pid;

--- a/lib/driver/avswitch.h
+++ b/lib/driver/avswitch.h
@@ -6,7 +6,7 @@
 
 class eSocketNotifier;
 
-class eAVSwitch: public Object
+class eAVSwitch: public sigc::trackable
 {
 	static eAVSwitch *instance;
 	int m_video_mode;

--- a/lib/driver/rc.h
+++ b/lib/driver/rc.h
@@ -21,7 +21,7 @@ class eRCKey;
  *
  * Handles one remote control. Gets codes from a \ref eRCDriver. Produces events in \ref eRCInput.
  */
-class eRCDevice: public Object
+class eRCDevice: public sigc::trackable
 {
 protected:
 	eRCInput *input;
@@ -61,7 +61,7 @@ public:
 /**
  * Receives codes from one or more remote controls.
  */
-class eRCDriver: public Object
+class eRCDriver: public sigc::trackable
 {
 protected:
 	std::list<eRCDevice*> listeners;
@@ -182,7 +182,7 @@ public:
 
 #endif
 
-class eRCInput: public Object
+class eRCInput: public sigc::trackable
 {
 	int locked;
 	static eRCInput *instance;
@@ -203,7 +203,7 @@ public:
 protected:
 	std::map<std::string,eRCDevice*,lstr> devices;
 public:
-	Signal1<void, const eRCKey&> keyEvent;
+	sigc::signal1<void, const eRCKey&> keyEvent;
 	eRCInput();
 	~eRCInput();
 

--- a/lib/dvb/amldecoder.cpp
+++ b/lib/dvb/amldecoder.cpp
@@ -70,7 +70,7 @@ eAMLTSMPEGDecoder::eAMLTSMPEGDecoder(eDVBDemux *demux, int decoder)
 {
 	eDebug("[eAMLTSMPEGDecoder] SETTING UP DECODER                   ------------ WETEK");
 	if (m_demux)
-		m_demux->connectEvent(slot(*this, &eAMLTSMPEGDecoder::demux_event), m_demux_event_conn);
+		m_demux->connectEvent(sigc::mem_fun(*this, &eAMLTSMPEGDecoder::demux_event), m_demux_event_conn);
 	memset(&m_codec, 0, sizeof(codec_para_t ));
 	memset(&am_sysinfo, 0, sizeof(dec_sysinfo_t));
 	memset(&am_param, 0, sizeof(arm_audio_info));
@@ -697,7 +697,7 @@ void eAMLTSMPEGDecoder::parseVideoInfo()
 	}
 }
 
-RESULT eAMLTSMPEGDecoder::connectVideoEvent(const Slot1<void, struct videoEvent> &event, ePtr<eConnection> &conn)
+RESULT eAMLTSMPEGDecoder::connectVideoEvent(const sigc::slot1<void, struct videoEvent> &event, ePtr<eConnection> &conn)
 {
 	conn = new eConnection(this, m_video_event.connect(event));
 	return 0;

--- a/lib/dvb/amldecoder.h
+++ b/lib/dvb/amldecoder.h
@@ -35,7 +35,7 @@ extern "C" {
 class eSocketNotifier;
 
 
-class eAMLTSMPEGDecoder: public Object, public iTSMPEGDecoder
+class eAMLTSMPEGDecoder: public sigc::trackable, public iTSMPEGDecoder
 {
 	DECLARE_REF(eAMLTSMPEGDecoder);
 private:
@@ -69,7 +69,7 @@ private:
 
 	void demux_event(int event);
 	void video_event(struct videoEvent);
-	Signal1<void, struct videoEvent> m_video_event;
+	sigc::signal1<void, struct videoEvent> m_video_event;
 	int m_video_clip_fd;
 	ePtr<eTimer> m_showSinglePicTimer;
 	void finishShowSinglePic(); // called by timer
@@ -135,7 +135,7 @@ public:
 	RESULT setRadioPic(const std::string &filename);
 		/* what 0=auto, 1=video, 2=audio. */
 	RESULT getPTS(int what, pts_t &pts);
-	RESULT connectVideoEvent(const Slot1<void, struct videoEvent> &event, ePtr<eConnection> &connection);
+	RESULT connectVideoEvent(const sigc::slot1<void, struct videoEvent> &event, ePtr<eConnection> &connection);
 	int getVideoWidth();
 	int getVideoHeight();
 	int getVideoProgressive();

--- a/lib/dvb/cablescan.h
+++ b/lib/dvb/cablescan.h
@@ -9,7 +9,7 @@
 #include <lib/dvb/idemux.h>
 #include <lib/dvb/esection.h>
 
-class eCableScan: public Object, public iObject
+class eCableScan: public sigc::trackable, public iObject
 {
 	DECLARE_REF(eCableScan);
 

--- a/lib/dvb/decoder.cpp
+++ b/lib/dvb/decoder.cpp
@@ -559,7 +559,7 @@ void eDVBVideo::video_event(int)
 	}
 }
 
-RESULT eDVBVideo::connectEvent(const Slot1<void, struct iTSMPEGDecoder::videoEvent> &event, ePtr<eConnection> &conn)
+RESULT eDVBVideo::connectEvent(const sigc::slot1<void, struct iTSMPEGDecoder::videoEvent> &event, ePtr<eConnection> &conn)
 {
 	conn = new eConnection(this, m_event.connect(event));
 	return 0;
@@ -857,7 +857,7 @@ int eTSMPEGDecoder::setState()
 		if ((m_vpid >= 0) && (m_vpid < 0x1FFF))
 		{
 			m_video = new eDVBVideo(m_demux, m_decoder);
-			m_video->connectEvent(slot(*this, &eTSMPEGDecoder::video_event), m_video_event_conn);
+			m_video->connectEvent(sigc::mem_fun(*this, &eTSMPEGDecoder::video_event), m_video_event_conn);
 			if (m_video->startPid(m_vpid, m_vtype))
 				res = -1;
 		}
@@ -969,7 +969,7 @@ eTSMPEGDecoder::eTSMPEGDecoder(eDVBDemux *demux, int decoder)
 {
 	if (m_demux)
 	{
-		m_demux->connectEvent(slot(*this, &eTSMPEGDecoder::demux_event), m_demux_event_conn);
+		m_demux->connectEvent(sigc::mem_fun(*this, &eTSMPEGDecoder::demux_event), m_demux_event_conn);
 	}
 	CONNECT(m_showSinglePicTimer->timeout, eTSMPEGDecoder::finishShowSinglePic);
 	m_state = stateStop;
@@ -1274,7 +1274,7 @@ void eTSMPEGDecoder::finishShowSinglePic()
 	}
 }
 
-RESULT eTSMPEGDecoder::connectVideoEvent(const Slot1<void, struct videoEvent> &event, ePtr<eConnection> &conn)
+RESULT eTSMPEGDecoder::connectVideoEvent(const sigc::slot1<void, struct videoEvent> &event, ePtr<eConnection> &conn)
 {
 	conn = new eConnection(this, m_video_event.connect(event));
 	return 0;

--- a/lib/dvb/decoder.h
+++ b/lib/dvb/decoder.h
@@ -26,7 +26,7 @@ public:
 	virtual ~eDVBAudio();
 };
 
-class eDVBVideo: public iObject, public Object
+class eDVBVideo: public iObject, public sigc::trackable
 {
 	DECLARE_REF(eDVBVideo);
 private:
@@ -36,7 +36,7 @@ private:
 	int m_is_slow_motion, m_is_fast_forward, m_is_freezed;
 	ePtr<eSocketNotifier> m_sn;
 	void video_event(int what);
-	Signal1<void, struct iTSMPEGDecoder::videoEvent> m_event;
+	sigc::signal1<void, struct iTSMPEGDecoder::videoEvent> m_event;
 	int m_width, m_height, m_framerate, m_aspect, m_progressive;
 	static int readApiSize(int fd, int &xres, int &yres, int &aspect);
 public:
@@ -51,7 +51,7 @@ public:
 	void unfreeze();
 	int getPTS(pts_t &now);
 	virtual ~eDVBVideo();
-	RESULT connectEvent(const Slot1<void, struct iTSMPEGDecoder::videoEvent> &event, ePtr<eConnection> &conn);
+	RESULT connectEvent(const sigc::slot1<void, struct iTSMPEGDecoder::videoEvent> &event, ePtr<eConnection> &conn);
 	int getWidth();
 	int getHeight();
 	int getProgressive();
@@ -85,7 +85,7 @@ public:
 	virtual ~eDVBTText();
 };
 
-class eTSMPEGDecoder: public Object, public iTSMPEGDecoder
+class eTSMPEGDecoder: public sigc::trackable, public iTSMPEGDecoder
 {
 	DECLARE_REF(eTSMPEGDecoder);
 private:
@@ -117,7 +117,7 @@ private:
 
 	void demux_event(int event);
 	void video_event(struct videoEvent);
-	Signal1<void, struct videoEvent> m_video_event;
+	sigc::signal1<void, struct videoEvent> m_video_event;
 	int m_video_clip_fd;
 	ePtr<eTimer> m_showSinglePicTimer;
 	void finishShowSinglePic(); // called by timer
@@ -167,7 +167,7 @@ public:
 	RESULT setRadioPic(const std::string &filename);
 		/* what 0=auto, 1=video, 2=audio. */
 	RESULT getPTS(int what, pts_t &pts);
-	RESULT connectVideoEvent(const Slot1<void, struct videoEvent> &event, ePtr<eConnection> &connection);
+	RESULT connectVideoEvent(const sigc::slot1<void, struct videoEvent> &event, ePtr<eConnection> &connection);
 	int getVideoWidth();
 	int getVideoHeight();
 	int getVideoProgressive();

--- a/lib/dvb/demux.cpp
+++ b/lib/dvb/demux.cpp
@@ -178,7 +178,7 @@ RESULT eDVBDemux::flush()
 	return 0;
 }
 
-RESULT eDVBDemux::connectEvent(const Slot1<void,int> &event, ePtr<eConnection> &conn)
+RESULT eDVBDemux::connectEvent(const sigc::slot1<void,int> &event, ePtr<eConnection> &conn)
 {
 	conn = new eConnection(this, m_event.connect(event));
 	return 0;
@@ -288,7 +288,7 @@ RESULT eDVBSectionReader::stop()
 	return 0;
 }
 
-RESULT eDVBSectionReader::connectRead(const Slot1<void,const uint8_t*> &r, ePtr<eConnection> &conn)
+RESULT eDVBSectionReader::connectRead(const sigc::slot1<void,const uint8_t*> &r, ePtr<eConnection> &conn)
 {
 	conn = new eConnection(this, read.connect(r));
 	return 0;
@@ -392,7 +392,7 @@ RESULT eDVBPESReader::stop()
 	return 0;
 }
 
-RESULT eDVBPESReader::connectRead(const Slot2<void,const uint8_t*,int> &r, ePtr<eConnection> &conn)
+RESULT eDVBPESReader::connectRead(const sigc::slot2<void,const uint8_t*,int> &r, ePtr<eConnection> &conn)
 {
 	conn = new eConnection(this, m_read.connect(r));
 	return 0;
@@ -881,7 +881,7 @@ RESULT eDVBTSRecorder::getFirstPTS(pts_t &pts)
 	return m_thread->getFirstPTS(pts);
 }
 
-RESULT eDVBTSRecorder::connectEvent(const Slot1<void,int> &event, ePtr<eConnection> &conn)
+RESULT eDVBTSRecorder::connectEvent(const sigc::slot1<void,int> &event, ePtr<eConnection> &conn)
 {
 	conn = new eConnection(this, m_event.connect(event));
 	return 0;

--- a/lib/dvb/demux.h
+++ b/lib/dvb/demux.h
@@ -29,7 +29,7 @@ public:
 	RESULT getCADemuxID(uint8_t &id) { id = demux; return 0; }
 	RESULT getCAAdapterID(uint8_t &id) { id = adapter; return 0; }
 	RESULT flush();
-	RESULT connectEvent(const Slot1<void,int> &event, ePtr<eConnection> &conn);
+	RESULT connectEvent(const sigc::slot1<void,int> &event, ePtr<eConnection> &conn);
 	int openDVR(int flags);
 
 	int getRefCount() { return ref; }
@@ -50,16 +50,16 @@ private:
 	int m_pvr_fd;
 	friend class eAMLTSMPEGDecoder;
 #endif
-	Signal1<void, int> m_event;
+	sigc::signal1<void, int> m_event;
 
 	int openDemux(void);
 };
 
-class eDVBSectionReader: public iDVBSectionReader, public Object
+class eDVBSectionReader: public iDVBSectionReader, public sigc::trackable
 {
 	DECLARE_REF(eDVBSectionReader);
 	int fd;
-	Signal1<void, const uint8_t*> read;
+	sigc::signal1<void, const uint8_t*> read;
 	ePtr<eDVBDemux> demux;
 	int active;
 	int checkcrc;
@@ -71,14 +71,14 @@ public:
 	RESULT setBufferSize(int size);
 	RESULT start(const eDVBSectionFilterMask &mask);
 	RESULT stop();
-	RESULT connectRead(const Slot1<void,const uint8_t*> &read, ePtr<eConnection> &conn);
+	RESULT connectRead(const sigc::slot1<void,const uint8_t*> &read, ePtr<eConnection> &conn);
 };
 
-class eDVBPESReader: public iDVBPESReader, public Object
+class eDVBPESReader: public iDVBPESReader, public sigc::trackable
 {
 	DECLARE_REF(eDVBPESReader);
 	int m_fd;
-	Signal2<void, const uint8_t*, int> m_read;
+	sigc::signal2<void, const uint8_t*, int> m_read;
 	ePtr<eDVBDemux> m_demux;
 	int m_active;
 	void data(int);
@@ -89,7 +89,7 @@ public:
 	RESULT setBufferSize(int size);
 	RESULT start(int pid);
 	RESULT stop();
-	RESULT connectRead(const Slot2<void,const uint8_t*, int> &read, ePtr<eConnection> &conn);
+	RESULT connectRead(const sigc::slot2<void,const uint8_t*, int> &read, ePtr<eConnection> &conn);
 };
 
 class eDVBRecordFileThread: public eFilePushThreadRecorder
@@ -143,7 +143,7 @@ protected:
 	void flush();
 };
 
-class eDVBTSRecorder: public iDVBTSRecorder, public Object
+class eDVBTSRecorder: public iDVBTSRecorder, public sigc::trackable
 {
 	DECLARE_REF(eDVBTSRecorder);
 public:
@@ -167,7 +167,7 @@ public:
 	RESULT getCurrentPCR(pts_t &pcr);
 	RESULT getFirstPTS(pts_t &pts);
 
-	RESULT connectEvent(const Slot1<void,int> &event, ePtr<eConnection> &conn);
+	RESULT connectEvent(const sigc::slot1<void,int> &event, ePtr<eConnection> &conn);
 private:
 	RESULT startPID(int pid);
 	void stopPID(int pid);
@@ -175,7 +175,7 @@ private:
 	void filepushEvent(int event);
 
 	std::map<int,int> m_pids;
-	Signal1<void,int> m_event;
+	sigc::signal1<void,int> m_event;
 
 	ePtr<eDVBDemux> m_demux;
 

--- a/lib/dvb/dvb.cpp
+++ b/lib/dvb/dvb.cpp
@@ -1270,7 +1270,7 @@ RESULT eDVBResourceManager::removeChannel(eDVBChannel *ch)
 	return -ENOENT;
 }
 
-RESULT eDVBResourceManager::connectChannelAdded(const Slot1<void,eDVBChannel*> &channelAdded, ePtr<eConnection> &connection)
+RESULT eDVBResourceManager::connectChannelAdded(const sigc::slot1<void,eDVBChannel*> &channelAdded, ePtr<eConnection> &connection)
 {
 	connection = new eConnection((eDVBResourceManager*)this, m_channelAdded.connect(channelAdded));
 	return 0;
@@ -1534,7 +1534,7 @@ eDVBChannel::eDVBChannel(eDVBResourceManager *mgr, eDVBAllocatedFrontend *fronte
 	m_skipmode_n = m_skipmode_m = m_skipmode_frames = 0;
 
 	if (m_frontend)
-		m_frontend->get().connectStateChange(slot(*this, &eDVBChannel::frontendStateChanged), m_conn_frontendStateChanged);
+		m_frontend->get().connectStateChange(sigc::mem_fun(*this, &eDVBChannel::frontendStateChanged), m_conn_frontendStateChanged);
 }
 
 eDVBChannel::~eDVBChannel()
@@ -2003,13 +2003,13 @@ RESULT eDVBChannel::setChannel(const eDVBChannelID &channelid, ePtr<iDVBFrontend
 	return 0;
 }
 
-RESULT eDVBChannel::connectStateChange(const Slot1<void,iDVBChannel*> &stateChange, ePtr<eConnection> &connection)
+RESULT eDVBChannel::connectStateChange(const sigc::slot1<void,iDVBChannel*> &stateChange, ePtr<eConnection> &connection)
 {
 	connection = new eConnection((iDVBChannel*)this, m_stateChanged.connect(stateChange));
 	return 0;
 }
 
-RESULT eDVBChannel::connectEvent(const Slot2<void,iDVBChannel*,int> &event, ePtr<eConnection> &connection)
+RESULT eDVBChannel::connectEvent(const sigc::slot2<void,iDVBChannel*,int> &event, ePtr<eConnection> &connection)
 {
 	connection = new eConnection((iDVBChannel*)this, m_event.connect(event));
 	return 0;
@@ -2208,7 +2208,7 @@ void eDVBChannel::setCueSheet(eCueSheet *cuesheet)
 	m_conn_cueSheetEvent = 0;
 	m_cue = cuesheet;
 	if (m_cue)
-		m_cue->connectEvent(slot(*this, &eDVBChannel::cueSheetEvent), m_conn_cueSheetEvent);
+		m_cue->connectEvent(sigc::mem_fun(*this, &eDVBChannel::cueSheetEvent), m_conn_cueSheetEvent);
 }
 
 void eDVBChannel::setOfflineDecodeMode(int parityswitchdelay)
@@ -2333,7 +2333,7 @@ void eCueSheet::setDecodingDemux(iDVBDemux *demux, iTSMPEGDecoder *decoder)
 	m_decoder = decoder;
 }
 
-RESULT eCueSheet::connectEvent(const Slot1<void,int> &event, ePtr<eConnection> &connection)
+RESULT eCueSheet::connectEvent(const sigc::slot1<void,int> &event, ePtr<eConnection> &connection)
 {
 	connection = new eConnection(this, m_event.connect(event));
 	return 0;

--- a/lib/dvb/dvb.h
+++ b/lib/dvb/dvb.h
@@ -23,13 +23,13 @@ class eDVBChannel;
 	   (and how to deallocate it). */
 class iDVBAdapter;
 
-class eDVBRegisteredFrontend: public iObject, public Object
+class eDVBRegisteredFrontend: public iObject, public sigc::trackable
 {
 	DECLARE_REF(eDVBRegisteredFrontend);
 	ePtr<eTimer> disable;
 	void closeFrontend();
 public:
-	Signal0<void> stateChanged;
+	sigc::signal0<void> stateChanged;
 	eDVBRegisteredFrontend(eDVBFrontend *fe, iDVBAdapter *adap)
 		:disable(eTimer::create(eApp)), m_adapter(adap), m_frontend(fe), m_inuse(0)
 	{
@@ -154,7 +154,7 @@ public:
 #endif // SWIG
 
 SWIG_IGNORE(eDVBResourceManager);
-class eDVBResourceManager: public iObject, public Object
+class eDVBResourceManager: public iObject, public sigc::trackable
 {
 	DECLARE_REF(eDVBResourceManager);
 	int avail, busy;
@@ -184,10 +184,10 @@ class eDVBResourceManager: public iObject, public Object
 	RESULT addChannel(const eDVBChannelID &chid, eDVBChannel *ch);
 	RESULT removeChannel(eDVBChannel *ch);
 
-	Signal1<void,eDVBChannel*> m_channelAdded;
+	sigc::signal1<void,eDVBChannel*> m_channelAdded;
 
 	eUsePtr<iDVBChannel> m_cached_channel;
-	Connection m_cached_channel_state_changed_conn;
+	sigc::connection m_cached_channel_state_changed_conn;
 	ePtr<eTimer> m_releaseCachedChannelTimer;
 	void DVBChannelStateChanged(iDVBChannel*);
 	void feStateChanged();
@@ -211,7 +211,7 @@ public:
 		errNoSourceFound = -7,
 	};
 
-	RESULT connectChannelAdded(const Slot1<void,eDVBChannel*> &channelAdded, ePtr<eConnection> &connection);
+	RESULT connectChannelAdded(const sigc::slot1<void,eDVBChannel*> &channelAdded, ePtr<eConnection> &connection);
 	int canAllocateChannel(const eDVBChannelID &channelid, const eDVBChannelID &ignore, int &system, bool simulate=false);
 
 		/* allocate channel... */
@@ -258,7 +258,7 @@ SWIG_EXTEND(ePtr<eDVBResourceManager>,
 class eDVBChannelFilePush;
 
 	/* iDVBPVRChannel includes iDVBChannel. don't panic. */
-class eDVBChannel: public iDVBPVRChannel, public iFilePushScatterGather, public Object
+class eDVBChannel: public iDVBPVRChannel, public iFilePushScatterGather, public sigc::trackable
 {
 	DECLARE_REF(eDVBChannel);
 	friend class eDVBResourceManager;
@@ -271,8 +271,8 @@ public:
 	RESULT setChannel(const eDVBChannelID &id, ePtr<iDVBFrontendParameters> &feparam);
 	eDVBChannelID getChannelID() { return m_channel_id; }
 
-	RESULT connectStateChange(const Slot1<void,iDVBChannel*> &stateChange, ePtr<eConnection> &connection);
-	RESULT connectEvent(const Slot2<void,iDVBChannel*,int> &eventChange, ePtr<eConnection> &connection);
+	RESULT connectStateChange(const sigc::slot1<void,iDVBChannel*> &stateChange, ePtr<eConnection> &connection);
+	RESULT connectEvent(const sigc::slot2<void,iDVBChannel*,int> &eventChange, ePtr<eConnection> &connection);
 
 	RESULT getState(int &state);
 
@@ -302,8 +302,8 @@ private:
 
 	ePtr<iDVBFrontendParameters> m_current_frontend_parameters;
 	eDVBChannelID m_channel_id;
-	Signal1<void,iDVBChannel*> m_stateChanged;
-	Signal2<void,iDVBChannel*,int> m_event;
+	sigc::signal1<void,iDVBChannel*> m_stateChanged;
+	sigc::signal2<void,iDVBChannel*,int> m_event;
 	int m_state;
 	ePtr<iTsSource> m_source;
 

--- a/lib/dvb/dvbtime.cpp
+++ b/lib/dvb/dvbtime.cpp
@@ -213,7 +213,7 @@ eDVBLocalTimeHandler::eDVBLocalTimeHandler()
 		eDebug("[eDVBLocalTimerHandler] no resource manager !!!!!!!");
 	else
 	{
-		res_mgr->connectChannelAdded(slot(*this,&eDVBLocalTimeHandler::DVBChannelAdded), m_chanAddedConn);
+		res_mgr->connectChannelAdded(sigc::mem_fun(*this,&eDVBLocalTimeHandler::DVBChannelAdded), m_chanAddedConn);
 		time_t now = time(0);
 		if ( now < 1072224000 ) // 01.01.2004
 			eDebug("[eDVBLocalTimeHandler] RTC not ready... wait for transponder time");
@@ -579,7 +579,7 @@ void eDVBLocalTimeHandler::DVBChannelAdded(eDVBChannel *chan)
 		tmp.first->second.timetable = NULL;
 		tmp.first->second.channel = chan;
 		tmp.first->second.m_prevChannelState = -1;
-		chan->connectStateChange(slot(*this, &eDVBLocalTimeHandler::DVBChannelStateChanged), tmp.first->second.m_stateChangedConn);
+		chan->connectStateChange(sigc::mem_fun(*this, &eDVBLocalTimeHandler::DVBChannelStateChanged), tmp.first->second.m_stateChangedConn);
 	}
 }
 

--- a/lib/dvb/dvbtime.h
+++ b/lib/dvb/dvbtime.h
@@ -64,7 +64,7 @@ public:
 
 #endif  // SWIG
 
-class eDVBLocalTimeHandler: public Object
+class eDVBLocalTimeHandler: public sigc::trackable
 {
 	DECLARE_REF(eDVBLocalTimeHandler);
 	struct channel_data

--- a/lib/dvb/eit.cpp
+++ b/lib/dvb/eit.cpp
@@ -68,13 +68,13 @@ void eDVBServiceEITHandler::EITready(int error)
 							if (!a)
 							{
 								m_demux->createSectionReader(eApp, m_now_ETT);
-								m_now_ETT->connectRead(slot(*this, &eDVBServiceEITHandler::nowETTsection), m_now_conn);
+								m_now_ETT->connectRead(sigc::mem_fun(*this, &eDVBServiceEITHandler::nowETTsection), m_now_conn);
 								m_now_ETT->start(mask);
 							}
 							else
 							{
 								m_demux->createSectionReader(eApp, m_next_ETT);
-								m_next_ETT->connectRead(slot(*this, &eDVBServiceEITHandler::nextETTsection), m_next_conn);
+								m_next_ETT->connectRead(sigc::mem_fun(*this, &eDVBServiceEITHandler::nextETTsection), m_next_conn);
 								m_next_ETT->start(mask);
 							}
 						}

--- a/lib/dvb/eit.h
+++ b/lib/dvb/eit.h
@@ -7,7 +7,7 @@
 #include <dvbsi++/event_information_section.h>
 #include <lib/service/event.h>
 
-class eDVBServiceEITHandler: public Object
+class eDVBServiceEITHandler: public sigc::trackable
 {
 	int sourceId;
 	int ETTpid;

--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -427,7 +427,7 @@ eEPGCache::eEPGCache()
 	if (!res_mgr)
 		eDebug("[eEPGCache] no resource manager !!!!!!!");
 	else
-		res_mgr->connectChannelAdded(slot(*this,&eEPGCache::DVBChannelAdded), m_chanAddedConn);
+		res_mgr->connectChannelAdded(sigc::mem_fun(*this,&eEPGCache::DVBChannelAdded), m_chanAddedConn);
 
 	instance=this;
 }
@@ -487,7 +487,7 @@ void eEPGCache::DVBChannelAdded(eDVBChannel *chan)
 #endif
 		singleLock s(channel_map_lock);
 		m_knownChannels.insert( std::pair<iDVBChannel*, channel_data* >(chan, data) );
-		chan->connectStateChange(slot(*this, &eEPGCache::DVBChannelStateChanged), data->m_stateChangedConn);
+		chan->connectStateChange(sigc::mem_fun(*this, &eEPGCache::DVBChannelStateChanged), data->m_stateChangedConn);
 	}
 }
 
@@ -1595,7 +1595,7 @@ void eEPGCache::channel_data::startEPG()
 		mask.pid = 0xD3;
 		mask.data[0] = 0x91;
 		mask.mask[0] = 0xFF;
-		m_MHWReader->connectRead(slot(*this, &eEPGCache::channel_data::readMHWData), m_MHWConn);
+		m_MHWReader->connectRead(sigc::mem_fun(*this, &eEPGCache::channel_data::readMHWData), m_MHWConn);
 		m_MHWReader->start(mask);
 		isRunning |= MHW;
 		memcpy(&m_MHWFilterMask, &mask, sizeof(eDVBSectionFilterMask));
@@ -1605,7 +1605,7 @@ void eEPGCache::channel_data::startEPG()
 		mask.mask[0] = 0xFF;
 		mask.data[1] = 0;
 		mask.mask[1] = 0xFF;
-		m_MHWReader2->connectRead(slot(*this, &eEPGCache::channel_data::readMHWData2), m_MHWConn2);
+		m_MHWReader2->connectRead(sigc::mem_fun(*this, &eEPGCache::channel_data::readMHWData2), m_MHWConn2);
 		m_MHWReader2->start(mask);
 		isRunning |= MHW;
 		memcpy(&m_MHWFilterMask2, &mask, sizeof(eDVBSectionFilterMask));
@@ -1621,7 +1621,7 @@ void eEPGCache::channel_data::startEPG()
 		mask.flags = eDVBSectionFilterMask::rfCRC;
 		mask.data[0] = 0x60;
 		mask.mask[0] = 0xFE;
-		m_FreeSatScheduleOtherReader->connectRead(slot(*this, &eEPGCache::channel_data::readFreeSatScheduleOtherData), m_FreeSatScheduleOtherConn);
+		m_FreeSatScheduleOtherReader->connectRead(sigc::mem_fun(*this, &eEPGCache::channel_data::readFreeSatScheduleOtherData), m_FreeSatScheduleOtherConn);
 		m_FreeSatScheduleOtherReader->start(mask);
 
 		/*
@@ -1631,7 +1631,7 @@ void eEPGCache::channel_data::startEPG()
 		 * and status maps)
 		 */
 		mask.pid = 3003;
-		m_FreeSatScheduleOtherReader2->connectRead(slot(*this, &eEPGCache::channel_data::readFreeSatScheduleOtherData), m_FreeSatScheduleOtherConn2);
+		m_FreeSatScheduleOtherReader2->connectRead(sigc::mem_fun(*this, &eEPGCache::channel_data::readFreeSatScheduleOtherData), m_FreeSatScheduleOtherConn2);
 		m_FreeSatScheduleOtherReader2->start(mask);
 		isRunning |= FREESAT_SCHEDULE_OTHER;
 	}
@@ -1657,7 +1657,7 @@ void eEPGCache::channel_data::startEPG()
 	{
 		mask.data[0] = 0x4E;
 		mask.mask[0] = 0xFE;
-		m_NowNextReader->connectRead(bind(slot(*this, &eEPGCache::channel_data::readData), (int)eEPGCache::NOWNEXT), m_NowNextConn);
+		m_NowNextReader->connectRead(bind(sigc::mem_fun(*this, &eEPGCache::channel_data::readData), (int)eEPGCache::NOWNEXT), m_NowNextConn);
 		m_NowNextReader->start(mask);
 		isRunning |= NOWNEXT;
 	}
@@ -1666,7 +1666,7 @@ void eEPGCache::channel_data::startEPG()
 	{
 		mask.data[0] = 0x50;
 		mask.mask[0] = 0xF0;
-		m_ScheduleReader->connectRead(bind(slot(*this, &eEPGCache::channel_data::readData), (int)eEPGCache::SCHEDULE), m_ScheduleConn);
+		m_ScheduleReader->connectRead(bind(sigc::mem_fun(*this, &eEPGCache::channel_data::readData), (int)eEPGCache::SCHEDULE), m_ScheduleConn);
 		m_ScheduleReader->start(mask);
 		isRunning |= SCHEDULE;
 	}
@@ -1675,7 +1675,7 @@ void eEPGCache::channel_data::startEPG()
 	{
 		mask.data[0] = 0x60;
 		mask.mask[0] = 0xF0;
-		m_ScheduleOtherReader->connectRead(bind(slot(*this, &eEPGCache::channel_data::readData), (int)eEPGCache::SCHEDULE_OTHER), m_ScheduleOtherConn);
+		m_ScheduleOtherReader->connectRead(bind(sigc::mem_fun(*this, &eEPGCache::channel_data::readData), (int)eEPGCache::SCHEDULE_OTHER), m_ScheduleOtherConn);
 		m_ScheduleOtherReader->start(mask);
 		isRunning |= SCHEDULE_OTHER;
 	}
@@ -1686,7 +1686,7 @@ void eEPGCache::channel_data::startEPG()
 		mask.pid = 0x2bc;
 		mask.data[0] = 0x4E;
 		mask.mask[0] = 0xFE;
-		m_VirginNowNextReader->connectRead(bind(slot(*this, &eEPGCache::channel_data::readData), (int)eEPGCache::VIRGIN_NOWNEXT), m_VirginNowNextConn);
+		m_VirginNowNextReader->connectRead(bind(sigc::mem_fun(*this, &eEPGCache::channel_data::readData), (int)eEPGCache::VIRGIN_NOWNEXT), m_VirginNowNextConn);
 		m_VirginNowNextReader->start(mask);
 		isRunning |= VIRGIN_NOWNEXT;
 	}
@@ -1696,7 +1696,7 @@ void eEPGCache::channel_data::startEPG()
 		mask.pid = 0x2bc;
 		mask.data[0] = 0x50;
 		mask.mask[0] = 0xFE;
-		m_VirginScheduleReader->connectRead(bind(slot(*this, &eEPGCache::channel_data::readData), (int)eEPGCache::VIRGIN_SCHEDULE), m_VirginScheduleConn);
+		m_VirginScheduleReader->connectRead(bind(sigc::mem_fun(*this, &eEPGCache::channel_data::readData), (int)eEPGCache::VIRGIN_SCHEDULE), m_VirginScheduleConn);
 		m_VirginScheduleReader->start(mask);
 		isRunning |= VIRGIN_SCHEDULE;
 	}
@@ -1707,7 +1707,7 @@ void eEPGCache::channel_data::startEPG()
 		mask.pid = 0x1388;
 		mask.data[0] = 0x50;
 		mask.mask[0] = 0xF0;
-		m_NetmedScheduleReader->connectRead(bind(slot(*this, &eEPGCache::channel_data::readData), (int)eEPGCache::NETMED_SCHEDULE), m_NetmedScheduleConn);
+		m_NetmedScheduleReader->connectRead(bind(sigc::mem_fun(*this, &eEPGCache::channel_data::readData), (int)eEPGCache::NETMED_SCHEDULE), m_NetmedScheduleConn);
 		m_NetmedScheduleReader->start(mask);
 		isRunning |= NETMED_SCHEDULE;
 	}
@@ -1717,7 +1717,7 @@ void eEPGCache::channel_data::startEPG()
 		mask.pid = 0x1388;
 		mask.data[0] = 0x60;
 		mask.mask[0] = 0xF0;
-		m_NetmedScheduleOtherReader->connectRead(bind(slot(*this, &eEPGCache::channel_data::readData), (int)eEPGCache::NETMED_SCHEDULE_OTHER), m_NetmedScheduleOtherConn);
+		m_NetmedScheduleOtherReader->connectRead(bind(sigc::mem_fun(*this, &eEPGCache::channel_data::readData), (int)eEPGCache::NETMED_SCHEDULE_OTHER), m_NetmedScheduleOtherConn);
 		m_NetmedScheduleOtherReader->start(mask);
 		isRunning |= NETMED_SCHEDULE_OTHER;
 	}
@@ -1726,10 +1726,10 @@ void eEPGCache::channel_data::startEPG()
 	if (eEPGCache::getInstance()->getEpgSources() & eEPGCache::ATSC_EIT && m_ATSC_MGTReader)
 	{
 		m_atsc_eit_index = 0;
-		m_ATSC_MGTReader->connectRead(slot(*this, &eEPGCache::channel_data::ATSC_MGTsection), m_ATSC_MGTConn);
-		m_ATSC_VCTReader->connectRead(slot(*this, &eEPGCache::channel_data::ATSC_VCTsection), m_ATSC_VCTConn);
-		m_ATSC_EITReader->connectRead(slot(*this, &eEPGCache::channel_data::ATSC_EITsection), m_ATSC_EITConn);
-		m_ATSC_ETTReader->connectRead(slot(*this, &eEPGCache::channel_data::ATSC_ETTsection), m_ATSC_ETTConn);
+		m_ATSC_MGTReader->connectRead(sigc::mem_fun(*this, &eEPGCache::channel_data::ATSC_MGTsection), m_ATSC_MGTConn);
+		m_ATSC_VCTReader->connectRead(sigc::mem_fun(*this, &eEPGCache::channel_data::ATSC_VCTsection), m_ATSC_VCTConn);
+		m_ATSC_EITReader->connectRead(sigc::mem_fun(*this, &eEPGCache::channel_data::ATSC_EITsection), m_ATSC_EITConn);
+		m_ATSC_ETTReader->connectRead(sigc::mem_fun(*this, &eEPGCache::channel_data::ATSC_ETTsection), m_ATSC_ETTConn);
 		mask.pid = 0x1ffb;
 		mask.data[0] = 0xc7;
 		mask.mask[0] = 0xff;
@@ -1747,7 +1747,7 @@ void eEPGCache::channel_data::startEPG()
 
 		mask.data[0] = 0x40;
 		mask.mask[0] = 0x40;
-		m_ViasatReader->connectRead(bind(slot(*this, &eEPGCache::channel_data::readData), (int)eEPGCache::VIASAT), m_ViasatConn);
+		m_ViasatReader->connectRead(bind(sigc::mem_fun(*this, &eEPGCache::channel_data::readData), (int)eEPGCache::VIASAT), m_ViasatConn);
 		m_ViasatReader->start(mask);
 		isRunning |= VIASAT;
 	}
@@ -1776,7 +1776,7 @@ void eEPGCache::channel_data::ATSC_checkCompletion()
 		{
 			eDVBSectionFilterMask mask = {};
 			m_atsc_eit_index++;
-			m_ATSC_MGTReader->connectRead(slot(*this, &eEPGCache::channel_data::ATSC_MGTsection), m_ATSC_MGTConn);
+			m_ATSC_MGTReader->connectRead(sigc::mem_fun(*this, &eEPGCache::channel_data::ATSC_MGTsection), m_ATSC_MGTConn);
 			mask.pid = 0x1ffb;
 			mask.data[0] = 0xc7;
 			mask.mask[0] = 0xff;
@@ -1826,7 +1826,7 @@ void eEPGCache::channel_data::ATSC_MGTsection(const uint8_t *d)
 			mask.pid = (*table)->getPID();
 			mask.data[0] = 0xcb;
 			mask.mask[0] = 0xff;
-			m_ATSC_EITReader->connectRead(slot(*this, &eEPGCache::channel_data::ATSC_EITsection), m_ATSC_EITConn);
+			m_ATSC_EITReader->connectRead(sigc::mem_fun(*this, &eEPGCache::channel_data::ATSC_EITsection), m_ATSC_EITConn);
 			m_ATSC_EITReader->start(mask);
 		}
 		else if ((*table)->getTableType() == 0x0200 + m_atsc_eit_index)
@@ -1835,7 +1835,7 @@ void eEPGCache::channel_data::ATSC_MGTsection(const uint8_t *d)
 			mask.pid = (*table)->getPID();
 			mask.data[0] = 0xcc;
 			mask.mask[0] = 0xff;
-			m_ATSC_ETTReader->connectRead(slot(*this, &eEPGCache::channel_data::ATSC_ETTsection), m_ATSC_ETTConn);
+			m_ATSC_ETTReader->connectRead(sigc::mem_fun(*this, &eEPGCache::channel_data::ATSC_ETTsection), m_ATSC_ETTConn);
 			m_ATSC_ETTReader->start(mask);
 		}
 	}
@@ -3996,7 +3996,7 @@ void eEPGCache::channel_data::startPrivateReader()
 	}
 	seenPrivateSections.clear();
 	if (!m_PrivateConn)
-		m_PrivateReader->connectRead(slot(*this, &eEPGCache::channel_data::readPrivateData), m_PrivateConn);
+		m_PrivateReader->connectRead(sigc::mem_fun(*this, &eEPGCache::channel_data::readPrivateData), m_PrivateConn);
 	m_PrivateReader->start(mask);
 }
 

--- a/lib/dvb/epgcache.h
+++ b/lib/dvb/epgcache.h
@@ -129,11 +129,11 @@ public:
 };
 #endif
 
-class eEPGCache: public eMainloop, private eThread, public Object
+class eEPGCache: public eMainloop, private eThread, public sigc::trackable
 {
 #ifndef SWIG
 	DECLARE_REF(eEPGCache)
-	struct channel_data: public Object
+	struct channel_data: public sigc::trackable
 	{
 		pthread_mutex_t channel_active;
 		channel_data(eEPGCache*);

--- a/lib/dvb/esection.cpp
+++ b/lib/dvb/esection.cpp
@@ -62,7 +62,7 @@ RESULT eGTable::start(iDVBSectionReader *reader, const eDVBTableSpec &table)
 	m_table = table;
 
 	m_reader = reader;
-	m_reader->connectRead(slot(*this, &eGTable::sectionRead), m_sectionRead_conn);
+	m_reader->connectRead(sigc::mem_fun(*this, &eGTable::sectionRead), m_sectionRead_conn);
 
 	m_tries = 0;
 

--- a/lib/dvb/esection.h
+++ b/lib/dvb/esection.h
@@ -8,7 +8,7 @@
 #define TABLE_eDebugNoNewLineStart(x...) do { if (m_debug) eDebugNoNewLineStart(x); } while(0)
 #define TABLE_eDebugNoNewLine(x...) do { if (m_debug) eDebugNoNewLine(x); } while(0)
 
-class eGTable: public iObject, public Object
+class eGTable: public iObject, public sigc::trackable
 {
 	DECLARE_REF(eGTable);
 	ePtr<iDVBSectionReader> m_reader;
@@ -26,7 +26,7 @@ protected:
 	virtual int createTable(unsigned int nr, const uint8_t *data, unsigned int max)=0;
 	virtual unsigned int totalSections(unsigned int max) { return max + 1; }
 public:
-	Signal1<void, int> tableReady;
+	sigc::signal1<void, int> tableReady;
 	eGTable();
 	RESULT start(iDVBSectionReader *reader, const eDVBTableSpec &table);
 	RESULT start(iDVBDemux *reader, const eDVBTableSpec &table);
@@ -84,12 +84,12 @@ public:
 	}
 };
 
-class eAUGTable: public Object
+class eAUGTable: public sigc::trackable
 {
 protected:
 	void slotTableReady(int);
 public:
-	Signal1<void, int> tableReady;
+	sigc::signal1<void, int> tableReady;
 	virtual void getNext(int err)=0;
 };
 

--- a/lib/dvb/fastscan.h
+++ b/lib/dvb/fastscan.h
@@ -196,7 +196,7 @@ public:
 		tableProgress(seen.size(), max);
 		return eTable<Section>::createTable(nr, data, max);
 	}
-	Signal2<void, int, int> tableProgress;
+	sigc::signal2<void, int, int> tableProgress;
 };
 
 template <class Section>
@@ -219,7 +219,7 @@ public:
 
 #endif /* no SWIG */
 
-class eFastScan: public Object, public iObject
+class eFastScan: public sigc::trackable, public iObject
 {
 	DECLARE_REF(eFastScan);
 

--- a/lib/dvb/fbc.h
+++ b/lib/dvb/fbc.h
@@ -13,7 +13,7 @@ class eDVBResourceManager;
 class eDVBFrontend;
 class eDVBRegisteredFrontend;
 
-class eFBCTunerManager: public iObject, public Object
+class eFBCTunerManager: public iObject, public sigc::trackable
 {
 private:
 	typedef std::bitset<8> connect_choices_t;

--- a/lib/dvb/filepush.h
+++ b/lib/dvb/filepush.h
@@ -15,7 +15,7 @@ public:
 	virtual ~iFilePushScatterGather() {}
 };
 
-class eFilePushThread: public eThread, public Object
+class eFilePushThread: public eThread, public sigc::trackable
 {
 public:
 	eFilePushThread(int blocksize, size_t buffersize);
@@ -33,7 +33,7 @@ public:
 	void setScatterGather(iFilePushScatterGather *);
 
 	enum { evtEOF, evtReadError, evtWriteError, evtUser, evtStopped };
-	Signal1<void,int> m_event;
+	sigc::signal1<void,int> m_event;
 
 		/* you can send private events if you want */
 	void sendEvent(int evt);
@@ -60,7 +60,7 @@ private:
 	void recvEvent(const int &evt);
 };
 
-class eFilePushThreadRecorder: public eThread, public Object
+class eFilePushThreadRecorder: public eThread, public sigc::trackable
 {
 public:
 	eFilePushThreadRecorder(unsigned char* buffer, size_t buffersize);
@@ -69,7 +69,7 @@ public:
 	void start(int sourcefd);
 
 	enum { evtEOF, evtReadError, evtWriteError, evtUser, evtStopped };
-	Signal1<void,int> m_event;
+	sigc::signal1<void,int> m_event;
 
 	void sendEvent(int evt);
 protected:

--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -2444,7 +2444,7 @@ tune_error:
 	return res;
 }
 
-RESULT eDVBFrontend::connectStateChange(const Slot1<void,iDVBFrontend*> &stateChange, ePtr<eConnection> &connection)
+RESULT eDVBFrontend::connectStateChange(const sigc::slot1<void,iDVBFrontend*> &stateChange, ePtr<eConnection> &connection)
 {
 	connection = new eConnection(this, m_stateChanged.connect(stateChange));
 	return 0;

--- a/lib/dvb/frontend.h
+++ b/lib/dvb/frontend.h
@@ -48,7 +48,7 @@ public:
 #include <lib/dvb/sec.h>
 class eSecCommandList;
 
-class eDVBFrontend: public iDVBFrontend, public Object
+class eDVBFrontend: public iDVBFrontend, public sigc::trackable
 {
 public:
 	enum {
@@ -72,7 +72,7 @@ public:
 		DICTION,              // current "diction" (0 = normal, 1 = Unicable, 2 = JESS)
 		NUM_DATA_ENTRIES
 	};
-	Signal1<void,iDVBFrontend*> m_stateChanged;
+	sigc::signal1<void,iDVBFrontend*> m_stateChanged;
 private:
 	DECLARE_REF(eDVBFrontend);
 	bool m_simulate;
@@ -133,7 +133,7 @@ public:
 	RESULT prepare_cable(const eDVBFrontendParametersCable &);
 	RESULT prepare_terrestrial(const eDVBFrontendParametersTerrestrial &);
 	RESULT prepare_atsc(const eDVBFrontendParametersATSC &);
-	RESULT connectStateChange(const Slot1<void,iDVBFrontend*> &stateChange, ePtr<eConnection> &connection);
+	RESULT connectStateChange(const sigc::slot1<void,iDVBFrontend*> &stateChange, ePtr<eConnection> &connection);
 	RESULT getState(int &state);
 	RESULT setTone(int tone);
 	RESULT setVoltage(int voltage);

--- a/lib/dvb/idemux.h
+++ b/lib/dvb/idemux.h
@@ -9,7 +9,7 @@ public:
 	virtual RESULT setBufferSize(int size)=0;
 	virtual RESULT start(const eDVBSectionFilterMask &mask)=0;
 	virtual RESULT stop()=0;
-	virtual RESULT connectRead(const Slot1<void,const uint8_t*> &read, ePtr<eConnection> &conn)=0;
+	virtual RESULT connectRead(const sigc::slot1<void,const uint8_t*> &read, ePtr<eConnection> &conn)=0;
 	virtual ~iDVBSectionReader() { };
 };
 
@@ -19,7 +19,7 @@ public:
 	virtual RESULT setBufferSize(int size)=0;
 	virtual RESULT start(int pid)=0;
 	virtual RESULT stop()=0;
-	virtual RESULT connectRead(const Slot2<void,const uint8_t*, int> &read, ePtr<eConnection> &conn)=0;
+	virtual RESULT connectRead(const sigc::slot2<void,const uint8_t*, int> &read, ePtr<eConnection> &conn)=0;
 	virtual ~iDVBPESReader() { };
 };
 
@@ -56,7 +56,7 @@ public:
 				/* the programmed boundary was reached. you might set a new target fd. you can close the */
 				/* old one. */
 	};
-	virtual RESULT connectEvent(const Slot1<void,int> &event, ePtr<eConnection> &conn)=0;
+	virtual RESULT connectEvent(const sigc::slot1<void,int> &event, ePtr<eConnection> &conn)=0;
 };
 
 #endif

--- a/lib/dvb/idvb.h
+++ b/lib/dvb/idvb.h
@@ -517,7 +517,7 @@ public:
 	virtual int closeFrontend(bool force = false, bool no_delayed = false)=0;
 	virtual void reopenFrontend()=0;
 #ifndef SWIG
-	virtual RESULT connectStateChange(const Slot1<void,iDVBFrontend*> &stateChange, ePtr<eConnection> &connection)=0;
+	virtual RESULT connectStateChange(const sigc::slot1<void,iDVBFrontend*> &stateChange, ePtr<eConnection> &connection)=0;
 #endif
 	virtual RESULT getState(int &SWIG_OUTPUT)=0;
 	virtual RESULT setTone(int tone)=0;
@@ -585,8 +585,8 @@ public:
 	{
 		evtPreStart, evtEOF, evtSOF, evtFailed, evtStopped
 	};
-	virtual RESULT connectStateChange(const Slot1<void,iDVBChannel*> &stateChange, ePtr<eConnection> &connection)=0;
-	virtual RESULT connectEvent(const Slot2<void,iDVBChannel*,int> &eventChange, ePtr<eConnection> &connection)=0;
+	virtual RESULT connectStateChange(const sigc::slot1<void,iDVBChannel*> &stateChange, ePtr<eConnection> &connection)=0;
+	virtual RESULT connectEvent(const sigc::slot2<void,iDVBChannel*,int> &eventChange, ePtr<eConnection> &connection)=0;
 
 		/* demux capabilities */
 	enum
@@ -616,7 +616,7 @@ class iTSMPEGDecoder;
 	   everything is specified in pts and not file positions */
 
 	/* implemented in dvb.cpp */
-class eCueSheet: public iObject, public Object
+class eCueSheet: public iObject, public sigc::trackable
 {
 	DECLARE_REF(eCueSheet);
 public:
@@ -637,12 +637,12 @@ public:
 
 			/* backend */
 	enum { evtSeek, evtSkipmode, evtSpanChanged };
-	RESULT connectEvent(const Slot1<void, int> &event, ePtr<eConnection> &connection);
+	RESULT connectEvent(const sigc::slot1<void, int> &event, ePtr<eConnection> &connection);
 
 	std::list<std::pair<pts_t,pts_t> > m_spans;	/* begin, end */
 	std::list<std::pair<int, pts_t> > m_seek_requests; /* relative, delta */
 	pts_t m_skipmode_ratio;
-	Signal1<void,int> m_event;
+	sigc::signal1<void,int> m_event;
 	ePtr<iDVBDemux> m_decoding_demux;
 	ePtr<iTSMPEGDecoder> m_decoder;
 };
@@ -758,7 +758,7 @@ public:
 		unsigned short framerate;
 	};
 
-	virtual RESULT connectVideoEvent(const Slot1<void, struct videoEvent> &event, ePtr<eConnection> &connection) = 0;
+	virtual RESULT connectVideoEvent(const sigc::slot1<void, struct videoEvent> &event, ePtr<eConnection> &connection) = 0;
 
 	virtual int getVideoWidth() = 0;
 	virtual int getVideoHeight() = 0;

--- a/lib/dvb/isection.h
+++ b/lib/dvb/isection.h
@@ -8,7 +8,7 @@ class iDVBSectionReader: public iObject
 public:
 	virtual RESULT start(const eDVBSectionFilterMask &mask)=0;
 	virtual RESULT stop()=0;
-	virtual RESULT connectRead(const Slot1<void,const uint8_t*> &read, ePtr<eConnection> &conn)=0;
+	virtual RESULT connectRead(const sigc::slot1<void,const uint8_t*> &read, ePtr<eConnection> &conn)=0;
 	virtual ~iDVBSectionReader() { };
 };
 

--- a/lib/dvb/pmt.cpp
+++ b/lib/dvb/pmt.cpp
@@ -878,13 +878,13 @@ int eDVBServicePMTHandler::tuneExt(eServiceReferenceDVB &ref, ePtr<iTsSource> &s
 		if (m_channel)
 		{
 			m_channel->connectStateChange(
-				slot(*this, &eDVBServicePMTHandler::channelStateChanged),
+				sigc::mem_fun(*this, &eDVBServicePMTHandler::channelStateChanged),
 				m_channelStateChanged_connection);
 			m_last_channel_state = -1;
 			channelStateChanged(m_channel);
 
 			m_channel->connectEvent(
-				slot(*this, &eDVBServicePMTHandler::channelEvent),
+				sigc::mem_fun(*this, &eDVBServicePMTHandler::channelEvent),
 				m_channelEvent_connection);
 
 			if (ref.path.empty())
@@ -897,7 +897,7 @@ int eDVBServicePMTHandler::tuneExt(eServiceReferenceDVB &ref, ePtr<iTsSource> &s
 					 * refcount bug (channel?/demux?), so we always start a scan,
 					 * but ignore the results when background scanning is disabled
 					 */
-					m_dvb_scan->connectEvent(slot(*this, &eDVBServicePMTHandler::SDTScanEvent), m_scan_event_connection);
+					m_dvb_scan->connectEvent(sigc::mem_fun(*this, &eDVBServicePMTHandler::SDTScanEvent), m_scan_event_connection);
 				}
 			}
 		} else

--- a/lib/dvb/pmt.h
+++ b/lib/dvb/pmt.h
@@ -114,7 +114,7 @@ public:
 		eventStopped,
 	};
 #ifndef SWIG
-	Signal1<void,int> serviceEvent;
+	sigc::signal1<void,int> serviceEvent;
 
 	int getProgramInfo(program &program);
 	int getDataDemux(ePtr<iDVBDemux> &demux);

--- a/lib/dvb/pmtparse.h
+++ b/lib/dvb/pmtparse.h
@@ -9,7 +9,7 @@
 #include <dvbsi++/program_association_section.h>
 #include <dvbsi++/application_information_section.h>
 
-class eDVBPMTParser: public Object
+class eDVBPMTParser: public sigc::trackable
 {
 protected:
 	eAUTable<eTable<ProgramMapSection> > m_PMT;

--- a/lib/dvb/radiotext.cpp
+++ b/lib/dvb/radiotext.cpp
@@ -18,9 +18,9 @@ eDVBRdsDecoder::eDVBRdsDecoder(iDVBDemux *demux, int type)
 	if (demux->createPESReader(eApp, m_pes_reader))
 		eDebug("failed to create PES reader!");
 	else if (type == 0)
-		m_pes_reader->connectRead(slot(*this, &eDVBRdsDecoder::processData), m_read_connection);
+		m_pes_reader->connectRead(sigc::mem_fun(*this, &eDVBRdsDecoder::processData), m_read_connection);
 	else
-		m_pes_reader->connectRead(slot(*this, &eDVBRdsDecoder::gotAncillaryData), m_read_connection);
+		m_pes_reader->connectRead(sigc::mem_fun(*this, &eDVBRdsDecoder::gotAncillaryData), m_read_connection);
 	CONNECT(m_abortTimer->timeout, eDVBRdsDecoder::abortNonAvail);
 }
 
@@ -95,7 +95,7 @@ static int frequency[3][4] = {
 	{ 11025,12000,8000,0 }
 };
 
-void eDVBRdsDecoder::connectEvent(const Slot1<void, int> &slot, ePtr<eConnection> &connection)
+void eDVBRdsDecoder::connectEvent(const sigc::slot1<void, int> &slot, ePtr<eConnection> &connection)
 {
 	connection = new eConnection(this, m_event.connect(slot));
 }

--- a/lib/dvb/radiotext.h
+++ b/lib/dvb/radiotext.h
@@ -6,7 +6,7 @@
 #include <lib/dvb/pesparse.h>
 #include <lib/gdi/gpixmap.h>
 
-class eDVBRdsDecoder: public iObject, public ePESParser, public Object
+class eDVBRdsDecoder: public iObject, public ePESParser, public sigc::trackable
 {
 	DECLARE_REF(eDVBRdsDecoder);
 	int msgPtr, bsflag, qdar_pos, t_ptr, qdarmvi_show;
@@ -25,7 +25,7 @@ public:
 	eDVBRdsDecoder(iDVBDemux *demux, int type);
 	~eDVBRdsDecoder();
 	int start(int pid);
-	void connectEvent(const Slot1<void, int> &slot, ePtr<eConnection> &connection);
+	void connectEvent(const sigc::slot1<void, int> &slot, ePtr<eConnection> &connection);
 	const char *getRadioText() { return (const char*)message; }
 	const char *getRtpText() { return (const char*)rtplus_osd; }
 	ePyObject getRassPictureMask();
@@ -39,7 +39,7 @@ private:
 	void process_qdar(unsigned char*);
 	ePtr<iDVBPESReader> m_pes_reader;
 	ePtr<eConnection> m_read_connection;
-	Signal1<void, int> m_event;
+	sigc::signal1<void, int> m_event;
 	ePtr<eTimer> m_abortTimer;
 };
 

--- a/lib/dvb/scan.cpp
+++ b/lib/dvb/scan.cpp
@@ -42,7 +42,7 @@ eDVBScan::eDVBScan(iDVBChannel *channel, bool usePAT, bool debug)
 {
 	if (m_channel->getDemux(m_demux))
 		SCAN_eDebug("[eDVBScan] failed to allocate demux!");
-	m_channel->connectStateChange(slot(*this, &eDVBScan::stateChange), m_stateChanged_connection);
+	m_channel->connectStateChange(sigc::mem_fun(*this, &eDVBScan::stateChange), m_stateChanged_connection);
 }
 
 eDVBScan::~eDVBScan()
@@ -1542,7 +1542,7 @@ RESULT eDVBScan::processVCT(eDVBNamespace dvbnamespace, const VirtualChannelTabl
 	return 0;
 }
 
-RESULT eDVBScan::connectEvent(const Slot1<void,int> &event, ePtr<eConnection> &connection)
+RESULT eDVBScan::connectEvent(const sigc::slot1<void,int> &event, ePtr<eConnection> &connection)
 {
 	connection = new eConnection(this, m_event.connect(event));
 	return 0;

--- a/lib/dvb/scan.h
+++ b/lib/dvb/scan.h
@@ -23,7 +23,7 @@ struct service
 	bool scrambled;
 };
 
-class eDVBScan: public Object, public iObject
+class eDVBScan: public sigc::trackable, public iObject
 {
 	DECLARE_REF(eDVBScan);
 		/* chid helper functions: */
@@ -89,7 +89,7 @@ class eDVBScan: public Object, public iObject
 
 	void channelDone();
 
-	Signal1<void,int> m_event;
+	sigc::signal1<void,int> m_event;
 	RESULT processSDT(eDVBNamespace dvbnamespace, const ServiceDescriptionSection &sdt);
 	RESULT processVCT(eDVBNamespace dvbnamespace, const VirtualChannelTableSection &vct, int onid);
 
@@ -110,7 +110,7 @@ public:
 	void start(const eSmartPtrList<iDVBFrontendParameters> &known_transponders, int flags, int networkid = 0);
 
 	enum { evtUpdate, evtNewService, evtFinish, evtFail };
-	RESULT connectEvent(const Slot1<void,int> &event, ePtr<eConnection> &connection);
+	RESULT connectEvent(const sigc::slot1<void,int> &event, ePtr<eConnection> &connection);
 	void insertInto(iDVBChannelList *db, bool backgroundscanresult=false);
 
 	void getStats(int &transponders_done, int &transponders_total, int &services);

--- a/lib/dvb/subtitle.cpp
+++ b/lib/dvb/subtitle.cpp
@@ -1094,7 +1094,7 @@ eDVBSubtitleParser::eDVBSubtitleParser(iDVBDemux *demux)
 	if (demux->createPESReader(eApp, m_pes_reader))
 		eDebug("[eDVBSubtitleParser] failed to create PES reader!");
 	else
-		m_pes_reader->connectRead(slot(*this, &eDVBSubtitleParser::processData), m_read_connection);
+		m_pes_reader->connectRead(sigc::mem_fun(*this, &eDVBSubtitleParser::processData), m_read_connection);
 }
 
 eDVBSubtitleParser::~eDVBSubtitleParser()
@@ -1125,7 +1125,7 @@ int eDVBSubtitleParser::start(int pid, int composition_page_id, int ancillary_pa
 	return -1;
 }
 
-void eDVBSubtitleParser::connectNewPage(const Slot1<void, const eDVBSubtitlePage&> &slot, ePtr<eConnection> &connection)
+void eDVBSubtitleParser::connectNewPage(const sigc::slot1<void, const eDVBSubtitlePage&> &slot, ePtr<eConnection> &connection)
 {
 	connection = new eConnection(this, m_new_subtitle_page.connect(slot));
 }

--- a/lib/dvb/subtitle.h
+++ b/lib/dvb/subtitle.h
@@ -109,14 +109,14 @@ struct eDVBSubtitlePage
 };
 
 class eDVBSubtitleParser
-	:public iObject, public ePESParser, public Object
+	:public iObject, public ePESParser, public sigc::trackable
 {
 	DECLARE_REF(eDVBSubtitleParser);
 	subtitle_page *m_pages;
 	ePtr<iDVBPESReader> m_pes_reader;
 	ePtr<eConnection> m_read_connection;
 	pts_t m_show_time;
-	Signal1<void,const eDVBSubtitlePage&> m_new_subtitle_page;
+	sigc::signal1<void,const eDVBSubtitlePage&> m_new_subtitle_page;
 	int m_composition_page_id, m_ancillary_page_id;
 	bool m_seen_eod;
 	eSize m_display_size;
@@ -125,7 +125,7 @@ public:
 	virtual ~eDVBSubtitleParser();
 	int start(int pid, int composition_page_id, int ancillary_page_id);
 	int stop();
-	void connectNewPage(const Slot1<void, const eDVBSubtitlePage&> &slot, ePtr<eConnection> &connection);
+	void connectNewPage(const sigc::slot1<void, const eDVBSubtitlePage&> &slot, ePtr<eConnection> &connection);
 private:
 	void subtitle_process_line(subtitle_region *region, subtitle_region_object *object, int line, uint8_t *data, int len);
 	int subtitle_process_pixel_data(subtitle_region *region, subtitle_region_object *object, int *linenr, int *linep, uint8_t *data);

--- a/lib/dvb/teletext.cpp
+++ b/lib/dvb/teletext.cpp
@@ -228,7 +228,7 @@ eDVBTeletextParser::eDVBTeletextParser(iDVBDemux *demux) : m_pid(-1)
 		eDebug("[eDVBTeletextParser] failed to create teletext subtitle PES reader!");
 	else {
 		eDebug("[eDVBTeletextParser] created teletext subtitle PES reader!");
-		m_pes_reader->connectRead(slot(*this, &eDVBTeletextParser::processData), m_read_connection);
+		m_pes_reader->connectRead(sigc::mem_fun(*this, &eDVBTeletextParser::processData), m_read_connection);
 	}
 }
 
@@ -646,12 +646,12 @@ void eDVBTeletextParser::setPageAndMagazine(int page, int magazine, const char *
 		m_page_X &= 0xFF;
 }
 
-void eDVBTeletextParser::connectNewStream(const Slot0<void> &slot, ePtr<eConnection> &connection)
+void eDVBTeletextParser::connectNewStream(const sigc::slot0<void> &slot, ePtr<eConnection> &connection)
 {
 	connection = new eConnection(this, m_new_subtitle_stream.connect(slot));
 }
 
-void eDVBTeletextParser::connectNewPage(const Slot1<void, const eDVBTeletextSubtitlePage&> &slot, ePtr<eConnection> &connection)
+void eDVBTeletextParser::connectNewPage(const sigc::slot1<void, const eDVBTeletextSubtitlePage&> &slot, ePtr<eConnection> &connection)
 {
 	connection = new eConnection(this, m_new_subtitle_page.connect(slot));
 }

--- a/lib/dvb/teletext.h
+++ b/lib/dvb/teletext.h
@@ -33,7 +33,7 @@ struct eDVBTeletextSubtitlePage
 	void clear() { m_elements.clear(); }
 };
 
-class eDVBTeletextParser: public iObject, public ePESParser, public Object
+class eDVBTeletextParser: public iObject, public ePESParser, public sigc::trackable
 {
 	DECLARE_REF(eDVBTeletextParser);
 public:
@@ -44,8 +44,8 @@ public:
 	int start(int pid);
 	void setPageAndMagazine(int page, int magazine, const char * lang);
 	void setMagazine(int magazine);
-	void connectNewStream(const Slot0<void> &slot, ePtr<eConnection> &connection);
-	void connectNewPage(const Slot1<void,const eDVBTeletextSubtitlePage &> &slot, ePtr<eConnection> &connection);
+	void connectNewStream(const sigc::slot0<void> &slot, ePtr<eConnection> &connection);
+	void connectNewPage(const sigc::slot1<void,const eDVBTeletextSubtitlePage &> &slot, ePtr<eConnection> &connection);
 	std::set<eDVBServicePMTHandler::subtitleStream> m_found_subtitle_pages;
 private:
 	std::map<int, unsigned int> m_modifications;
@@ -66,8 +66,8 @@ private:
 
 	void addSubtitleString(int color, std::string string, int source_line);
 
-	Signal0<void> m_new_subtitle_stream;
-	Signal1<void,const eDVBTeletextSubtitlePage&> m_new_subtitle_page;
+	sigc::signal0<void> m_new_subtitle_stream;
+	sigc::signal1<void,const eDVBTeletextSubtitlePage&> m_new_subtitle_page;
 };
 
 #endif

--- a/lib/dvb/tstools.cpp
+++ b/lib/dvb/tstools.cpp
@@ -46,7 +46,7 @@ RESULT eTSFileSectionReader::stop()
 	return 0;
 }
 
-RESULT eTSFileSectionReader::connectRead(const Slot1<void,const uint8_t*> &r, ePtr<eConnection> &conn)
+RESULT eTSFileSectionReader::connectRead(const sigc::slot1<void,const uint8_t*> &r, ePtr<eConnection> &conn)
 {
 	conn = new eConnection(this, read.connect(r));
 	return 0;

--- a/lib/dvb/tstools.h
+++ b/lib/dvb/tstools.h
@@ -15,12 +15,12 @@
 
 typedef long long pts_t;
 
-class eTSFileSectionReader: public iDVBSectionReader, public Object
+class eTSFileSectionReader: public iDVBSectionReader, public sigc::trackable
 {
 	DECLARE_REF(eTSFileSectionReader);
 	unsigned char sectionData[4096];
 	unsigned int sectionSize;
-	Signal1<void, const uint8_t*> read;
+	sigc::signal1<void, const uint8_t*> read;
 
 public:
 	eTSFileSectionReader(eMainloop *context);
@@ -29,7 +29,7 @@ public:
 	RESULT setBufferSize(int size) { return 0; }
 	RESULT start(const eDVBSectionFilterMask &mask);
 	RESULT stop();
-	RESULT connectRead(const Slot1<void,const uint8_t*> &read, ePtr<eConnection> &conn);
+	RESULT connectRead(const sigc::slot1<void,const uint8_t*> &read, ePtr<eConnection> &conn);
 };
 
 class eDVBTSTools : public eDVBPMTParser

--- a/lib/dvb_ci/dvbci.h
+++ b/lib/dvb_ci/dvbci.h
@@ -40,7 +40,7 @@ typedef std::set<providerPair> providerSet;
 typedef std::set<uint16_t> caidSet;
 typedef std::set<eServiceReference> serviceSet;
 
-class eDVBCISlot: public iObject, public Object
+class eDVBCISlot: public iObject, public sigc::trackable
 {
 	friend class eDVBCIInterfaces;
 	DECLARE_REF(eDVBCISlot);

--- a/lib/dvb_ci/dvbci_datetimemgr.cpp
+++ b/lib/dvb_ci/dvbci_datetimemgr.cpp
@@ -7,7 +7,7 @@ eDVBCIDateTimeSession::eDVBCIDateTimeSession():
 	m_timer(eTimer::create(eApp)), m_interval(0)
 {
 	//CONNECT(m_timer->timeout, eDVBCIDateTimeSession::sendDateTime);
-	m_timer->timeout.connect(SigC::slot(*this, &eDVBCIDateTimeSession::sendDateTime));
+	m_timer->timeout.connect(sigc::mem_fun(*this, &eDVBCIDateTimeSession::sendDateTime));
 }
 
 int eDVBCIDateTimeSession::receivedAPDU(const unsigned char *tag,const void *data, int len)

--- a/lib/dvb_ci/dvbci_datetimemgr.h
+++ b/lib/dvb_ci/dvbci_datetimemgr.h
@@ -3,7 +3,7 @@
 
 #include <lib/dvb_ci/dvbci_session.h>
 
-class eDVBCIDateTimeSession: public eDVBCISession, public Object
+class eDVBCIDateTimeSession: public eDVBCISession, public sigc::trackable
 {
 	enum {
 		stateFinal=statePrivate, stateSendDateTime

--- a/lib/gdi/compositing.h
+++ b/lib/gdi/compositing.h
@@ -21,7 +21,7 @@ struct gCompositingElement
 	gContext m_context;
 };
 
-class gCompositingData: public Object
+class gCompositingData: public sigc::trackable
 {
 DECLARE_REF(gCompositingData);
 public:

--- a/lib/gdi/grc.h
+++ b/lib/gdi/grc.h
@@ -150,7 +150,7 @@ struct gOpcode
 #define MAXSIZE 2048
 
 		/* gRC is the singleton which controls the fifo and dispatches commands */
-class gRC: public iObject, public Object
+class gRC: public iObject, public sigc::trackable
 {
 	DECLARE_REF(gRC);
 	friend class gPainter;
@@ -187,7 +187,7 @@ public:
 
 	void submit(const gOpcode &o);
 
-	Signal0<void> notify;
+	sigc::signal0<void> notify;
 
 	void setSpinnerDC(gDC *dc) { m_spinner_dc = dc; }
 	void setSpinnerOnOff(int onoff) { m_spinneronoff = onoff; }

--- a/lib/gdi/picload.h
+++ b/lib/gdi/picload.h
@@ -48,7 +48,7 @@ struct Cfilepara
 };
 #endif
 
-class ePicLoad: public eMainloop, public eThread, public Object, public iObject
+class ePicLoad: public eMainloop, public eThread, public sigc::trackable, public iObject
 {
 	DECLARE_REF(ePicLoad);
 

--- a/lib/gdi/sdl.h
+++ b/lib/gdi/sdl.h
@@ -6,7 +6,7 @@
 
 #include <SDL.h>
 
-class gSDLDC: public gMainDC, public eThread, public Object
+class gSDLDC: public gMainDC, public eThread, public sigc::trackable
 {
 private:
 	SDL_Surface *m_screen;

--- a/lib/gui/elistboxcontent.h
+++ b/lib/gui/elistboxcontent.h
@@ -31,7 +31,7 @@ protected:
 	void cursorRestore();
 	int size();
 
-	RESULT connectItemChanged(const Slot0<void> &itemChanged, ePtr<eConnection> &connection);
+	RESULT connectItemChanged(const sigc::slot0<void> &itemChanged, ePtr<eConnection> &connection);
 
 	// void setOutputDevice ? (for allocating colors, ...) .. requires some work, though
 	void setSize(const eSize &size);

--- a/lib/gui/esubtitle.h
+++ b/lib/gui/esubtitle.h
@@ -40,7 +40,7 @@ struct eVobSubtitlePage
 class eDVBTeletextSubtitlePage;
 class eDVBSubtitlePage;
 
-class eSubtitleWidget: public eWidget, public iSubtitleUser, public Object
+class eSubtitleWidget: public eWidget, public iSubtitleUser, public sigc::trackable
 {
 public:
 	eSubtitleWidget(eWidget *parent);

--- a/lib/gui/evideo.cpp
+++ b/lib/gui/evideo.cpp
@@ -15,7 +15,7 @@ eVideoWidget::eVideoWidget(eWidget *parent)
 	if (!fullsizeTimer)
 	{
 		fullsizeTimer = eTimer::create(eApp);
-		fullsizeTimer->timeout.connect(bind(slot(eVideoWidget::setFullsize), false));
+		fullsizeTimer->timeout.connect(sigc::bind(sigc::ptr_fun(&eVideoWidget::setFullsize), false));
 	}
 	parent->setPositionNotifyChild(1);
 }

--- a/lib/gui/ewidgetdesktop.h
+++ b/lib/gui/ewidgetdesktop.h
@@ -28,7 +28,7 @@ struct eWidgetDesktopCompBuffer
 	gRGB m_background_color;
 };
 
-class eWidgetDesktop: public Object
+class eWidgetDesktop: public sigc::trackable
 {
 public:
 	eWidgetDesktop(eSize screen);

--- a/lib/mmi/mmi_ui.h
+++ b/lib/mmi/mmi_ui.h
@@ -18,7 +18,7 @@ struct slot_ui_data
 };
 #endif
 
-class eMMI_UI: public Object
+class eMMI_UI: public sigc::trackable
 {
 	int m_max_slots;
 	virtual void stateChanged(int)=0;

--- a/lib/nav/core.cpp
+++ b/lib/nav/core.cpp
@@ -33,19 +33,19 @@ RESULT eNavigation::playService(const eServiceReference &service)
 	if (m_runningService)
 	{
 		m_runningService->setTarget(m_decoder);
-		m_runningService->connectEvent(slot(*this, &eNavigation::serviceEvent), m_service_event_conn);
+		m_runningService->connectEvent(sigc::mem_fun(*this, &eNavigation::serviceEvent), m_service_event_conn);
 		res = m_runningService->start();
 	}
 	return res;
 }
 
-RESULT eNavigation::connectEvent(const Slot1<void,int> &event, ePtr<eConnection> &connection)
+RESULT eNavigation::connectEvent(const sigc::slot1<void,int> &event, ePtr<eConnection> &connection)
 {
 	connection = new eConnection(this, m_event.connect(event));
 	return 0;
 }
 
-RESULT eNavigation::connectRecordEvent(const Slot2<void,ePtr<iRecordableService>,int> &event, ePtr<eConnection> &connection)
+RESULT eNavigation::connectRecordEvent(const sigc::slot2<void,ePtr<iRecordableService>,int> &event, ePtr<eConnection> &connection)
 {
 	connection = new eConnection(this, m_record_event.connect(event));
 	return 0;
@@ -91,7 +91,7 @@ RESULT eNavigation::recordService(const eServiceReference &ref, ePtr<iRecordable
 		else
 		{
 			ePtr<eConnection> conn;
-			service->connectEvent(slot(*this, &eNavigation::recordEvent), conn);
+			service->connectEvent(sigc::mem_fun(*this, &eNavigation::recordEvent), conn);
 			m_recordings[service]=conn;
 			m_recordings_services[service]=ref;
 		}

--- a/lib/nav/core.h
+++ b/lib/nav/core.h
@@ -7,7 +7,7 @@
 #include <map>
 #include <set>
 
-class eNavigation: public iObject, public Object
+class eNavigation: public iObject, public sigc::trackable
 {
 	static eNavigation *instance;
 	DECLARE_REF(eNavigation);
@@ -15,7 +15,7 @@ class eNavigation: public iObject, public Object
 	ePtr<iServiceHandler> m_servicehandler;
 
 	ePtr<iPlayableService> m_runningService;
-	Signal1<void,int> m_event;
+	sigc::signal1<void,int> m_event;
 	ePtr<eConnection> m_service_event_conn;
 	void serviceEvent(iPlayableService* service, int event);
 
@@ -23,14 +23,14 @@ class eNavigation: public iObject, public Object
 	std::map<ePtr<iRecordableService>, eServiceReference, std::less<iRecordableService*> > m_recordings_services;
 	std::set<ePtr<iRecordableService>, std::less<iRecordableService*> > m_simulate_recordings;
 
-	Signal2<void,ePtr<iRecordableService>,int> m_record_event;
+	sigc::signal2<void,ePtr<iRecordableService>,int> m_record_event;
 	void recordEvent(iRecordableService* service, int event);
 public:
 
 	RESULT playService(const eServiceReference &service);
-	RESULT connectEvent(const Slot1<void,int> &event, ePtr<eConnection> &connection);
-	RESULT connectRecordEvent(const Slot2<void,ePtr<iRecordableService>,int> &event, ePtr<eConnection> &connection);
-/*	int connectServiceEvent(const Slot1<void,iPlayableService*,int> &event, ePtr<eConnection> &connection); */
+	RESULT connectEvent(const sigc::slot1<void,int> &event, ePtr<eConnection> &connection);
+	RESULT connectRecordEvent(const sigc::slot2<void,ePtr<iRecordableService>,int> &event, ePtr<eConnection> &connection);
+/*	int connectServiceEvent(const sigc::slot1<void,iPlayableService*,int> &event, ePtr<eConnection> &connection); */
 	RESULT getCurrentService(ePtr<iPlayableService> &service);
 	RESULT stopService(void);
 

--- a/lib/nav/pcore.cpp
+++ b/lib/nav/pcore.cpp
@@ -13,8 +13,8 @@ pNavigation::pNavigation(int decoder)
 	ASSERT(service_center);
 	m_core = new eNavigation(service_center, decoder);
 
-	m_core->connectEvent(slot(*this, &pNavigation::navEvent), m_nav_event_connection);
-	m_core->connectRecordEvent(slot(*this, &pNavigation::navRecordEvent), m_nav_record_event_connection);
+	m_core->connectEvent(sigc::mem_fun(*this, &pNavigation::navEvent), m_nav_event_connection);
+	m_core->connectRecordEvent(sigc::mem_fun(*this, &pNavigation::navRecordEvent), m_nav_record_event_connection);
 }
 
 RESULT pNavigation::playService(const eServiceReference &service)

--- a/lib/nav/pcore.h
+++ b/lib/nav/pcore.h
@@ -6,7 +6,7 @@
 
 /* a subset of eNavigation */
 
-class pNavigation: public iObject, public Object
+class pNavigation: public iObject, public sigc::trackable
 {
 	DECLARE_REF(pNavigation);
 public:

--- a/lib/network/socket.h
+++ b/lib/network/socket.h
@@ -15,7 +15,7 @@
 #include <libsig_comp.h>
 #include <lib/base/buffer.h>
 
-class eSocket: public Object
+class eSocket: public sigc::trackable
 {
 private:
 	int issocket;
@@ -54,12 +54,12 @@ public:
 			Listening, Connection, Closing };
 	int state();
 
-	Signal0<void> connectionClosed_;
-	Signal0<void> connected_;
-	Signal0<void> readyRead_;
-	Signal0<void> hangup;
-	Signal1<void,int> bytesWritten_;
-	Signal1<void,int> error_;
+	sigc::signal0<void> connectionClosed_;
+	sigc::signal0<void> connected_;
+	sigc::signal0<void> readyRead_;
+	sigc::signal0<void> hangup;
+	sigc::signal1<void,int> bytesWritten_;
+	sigc::signal1<void,int> error_;
 };
 
 class eUnixDomainSocket: public eSocket

--- a/lib/python/Plugins/Extensions/SocketMMI/src/socket_mmi.h
+++ b/lib/python/Plugins/Extensions/SocketMMI/src/socket_mmi.h
@@ -11,7 +11,7 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/un.h>
-class eSocketMMIHandler: public Object
+class eSocketMMIHandler: public sigc::trackable
 {
 	eIOBuffer buffer;
 	int listenfd, connfd, clilen;
@@ -24,7 +24,7 @@ class eSocketMMIHandler: public Object
 	char *name;
 public:
 	const char *getName() const { return name; }
-	Signal4<int, int, const unsigned char*, const void *, int> mmi_progress;
+	sigc::signal4<int, int, const unsigned char*, const void *, int> mmi_progress;
 	int send_to_mmisock( void *, size_t );
 	bool connected() { return !!connsn; }
 	eSocketMMIHandler();

--- a/lib/python/connections.h
+++ b/lib/python/connections.h
@@ -36,7 +36,7 @@ inline PyObject *PyFrom(std::pair<const char*, int>& p)
 }
 
 template <class R>
-class PSignal0: public PSignal, public Signal0<R>
+class PSignal0: public PSignal, public sigc::signal0<R>
 {
 public:
 	R operator()()
@@ -47,12 +47,12 @@ public:
 			callPython(pArgs);
 			Org_Py_DECREF(pArgs);
 		}
-		return Signal0<R>::operator()();
+		return sigc::signal0<R>::operator()();
 	}
 };
 
 template <class R, class V0>
-class PSignal1: public PSignal, public Signal1<R,V0>
+class PSignal1: public PSignal, public sigc::signal1<R,V0>
 {
 public:
 	R operator()(V0 a0)
@@ -64,12 +64,12 @@ public:
 			callPython(pArgs);
 			Org_Py_DECREF(pArgs);
 		}
-		return Signal1<R,V0>::operator()(a0);
+		return sigc::signal1<R,V0>::operator()(a0);
 	}
 };
 
 template <class R, class V0, class V1>
-class PSignal2: public PSignal, public Signal2<R,V0,V1>
+class PSignal2: public PSignal, public sigc::signal2<R,V0,V1>
 {
 public:
 	R operator()(V0 a0, V1 a1)
@@ -82,12 +82,12 @@ public:
 			callPython(pArgs);
 			Org_Py_DECREF(pArgs);
 		}
-		return Signal2<R,V0,V1>::operator()(a0, a1);
+		return sigc::signal2<R,V0,V1>::operator()(a0, a1);
 	}
 };
 
 template <class R, class V0, class V1, class V2>
-class PSignal3: public PSignal, public Signal3<R,V0,V1,V2>
+class PSignal3: public PSignal, public sigc::signal3<R,V0,V1,V2>
 {
 public:
 	R operator()(V0 a0, V1 a1, V2 a2)
@@ -101,7 +101,7 @@ public:
 			callPython(pArgs);
 			Org_Py_DECREF(pArgs);
 		}
-		return Signal3<R,V0,V1,V2>::operator()(a0, a1, a2);
+		return sigc::signal3<R,V0,V1,V2>::operator()(a0, a1, a2);
 	}
 };
 

--- a/lib/service/iservice.h
+++ b/lib/service/iservice.h
@@ -943,7 +943,7 @@ class iPlayableService: public iPlayableService_ENUMS, public iObject
 	friend class iServiceHandler;
 public:
 #ifndef SWIG
-	virtual RESULT connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection)=0;
+	virtual RESULT connectEvent(const sigc::slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection)=0;
 #endif
 	virtual RESULT start()=0;
 	virtual RESULT stop()=0;
@@ -1009,7 +1009,7 @@ class iRecordableService: public iRecordableService_ENUMS, public iObject
 #endif
 public:
 #ifndef SWIG
-	virtual RESULT connectEvent(const Slot2<void,iRecordableService*,int> &event, ePtr<eConnection> &connection)=0;
+	virtual RESULT connectEvent(const sigc::slot2<void,iRecordableService*,int> &event, ePtr<eConnection> &connection)=0;
 #endif
 	virtual SWIG_VOID(RESULT) getError(int &SWIG_OUTPUT)=0;
 	virtual RESULT prepare(const char *filename, time_t begTime=-1, time_t endTime=-1, int eit_event_id=-1, const char *name=0, const char *descr=0, const char *tags=0, bool descramble = true, bool recordecm = false)=0;

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -1440,7 +1440,7 @@ RESULT eDVBServicePlay::setTarget(int target, bool noaudio = false)
 	return 0;
 }
 
-RESULT eDVBServicePlay::connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection)
+RESULT eDVBServicePlay::connectEvent(const sigc::slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection)
 {
 	connection = new eConnection((iPlayableService*)this, m_event.connect(event));
 	return 0;
@@ -2188,7 +2188,7 @@ int eDVBServicePlay::selectAudioStream(int i)
 			if (!h.getDataDemux(data_demux))
 			{
 				m_rds_decoder = new eDVBRdsDecoder(data_demux, different_pid);
-				m_rds_decoder->connectEvent(slot(*this, &eDVBServicePlay::rdsDecoderEvent), m_rds_decoder_event_connection);
+				m_rds_decoder->connectEvent(sigc::mem_fun(*this, &eDVBServicePlay::rdsDecoderEvent), m_rds_decoder_event_connection);
 				m_rds_decoder->start(rdsPid);
 			}
 		}
@@ -2859,7 +2859,7 @@ void eDVBServicePlay::updateDecoder(bool sendSeekableStateChanged)
 		{
 			m_decode_demux->getMPEGDecoder(m_decoder, m_decoder_index);
 			if (m_decoder)
-				m_decoder->connectVideoEvent(slot(*this, &eDVBServicePlay::video_event), m_video_event_connection);
+				m_decoder->connectVideoEvent(sigc::mem_fun(*this, &eDVBServicePlay::video_event), m_video_event_connection);
 		}
 		if (m_cue)
 			m_cue->setDecodingDemux(m_decode_demux, m_decoder);
@@ -2948,10 +2948,10 @@ void eDVBServicePlay::updateDecoder(bool sendSeekableStateChanged)
 		if (mustPlay && m_decode_demux && m_decoder_index == 0)
 		{
 			m_teletext_parser = new eDVBTeletextParser(m_decode_demux);
-			m_teletext_parser->connectNewStream(slot(*this, &eDVBServicePlay::newSubtitleStream), m_new_subtitle_stream_connection);
-			m_teletext_parser->connectNewPage(slot(*this, &eDVBServicePlay::newSubtitlePage), m_new_subtitle_page_connection);
+			m_teletext_parser->connectNewStream(sigc::mem_fun(*this, &eDVBServicePlay::newSubtitleStream), m_new_subtitle_stream_connection);
+			m_teletext_parser->connectNewPage(sigc::mem_fun(*this, &eDVBServicePlay::newSubtitlePage), m_new_subtitle_page_connection);
 			m_subtitle_parser = new eDVBSubtitleParser(m_decode_demux);
-			m_subtitle_parser->connectNewPage(slot(*this, &eDVBServicePlay::newDVBSubtitlePage), m_new_dvb_subtitle_page_connection);
+			m_subtitle_parser->connectNewPage(sigc::mem_fun(*this, &eDVBServicePlay::newDVBSubtitlePage), m_new_dvb_subtitle_page_connection);
 			if (m_timeshift_changed)
 			{
 				struct SubtitleTrack track;

--- a/lib/service/servicedvb.h
+++ b/lib/service/servicedvb.h
@@ -84,7 +84,7 @@ public:
 
 class eDVBServicePlay: public eDVBServiceBase,
 		public iPlayableService, public iPauseableService,
-		public iSeekableService, public Object, public iServiceInformation,
+		public iSeekableService, public sigc::trackable, public iServiceInformation,
 		public iAudioTrackSelection, public iAudioChannelSelection,
 		public iSubserviceList, public iTimeshiftService,
 		public iCueSheet, public iSubtitleOutput, public iAudioDelay,
@@ -96,7 +96,7 @@ public:
 	virtual ~eDVBServicePlay();
 
 		// iPlayableService
-	RESULT connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
+	RESULT connectEvent(const sigc::slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
 	RESULT setTarget(int target, bool noaudio);
@@ -220,7 +220,7 @@ protected:
 
 	void serviceEvent(int event);
 	void serviceEventTimeshift(int event);
-	Signal2<void,iPlayableService*,int> m_event;
+	sigc::signal2<void,iPlayableService*,int> m_event;
 
 	bool m_is_stream;
 

--- a/lib/service/servicedvbrecord.cpp
+++ b/lib/service/servicedvbrecord.cpp
@@ -314,7 +314,7 @@ int eDVBServiceRecord::doRecord()
 		}
 		m_record->setTargetFD(fd);
 		m_record->setTargetFilename(m_filename);
-		m_record->connectEvent(slot(*this, &eDVBServiceRecord::recordEvent), m_con_record_event);
+		m_record->connectEvent(sigc::mem_fun(*this, &eDVBServiceRecord::recordEvent), m_con_record_event);
 
 		m_target_fd = fd;
 	}
@@ -498,7 +498,7 @@ RESULT eDVBServiceRecord::frontendInfo(ePtr<iFrontendInformation> &ptr)
 	return 0;
 }
 
-RESULT eDVBServiceRecord::connectEvent(const Slot2<void,iRecordableService*,int> &event, ePtr<eConnection> &connection)
+RESULT eDVBServiceRecord::connectEvent(const sigc::slot2<void,iRecordableService*,int> &event, ePtr<eConnection> &connection)
 {
 	connection = new eConnection((iRecordableService*)this, m_event.connect(event));
 	return 0;

--- a/lib/service/servicedvbrecord.h
+++ b/lib/service/servicedvbrecord.h
@@ -14,11 +14,11 @@ class eDVBServiceRecord: public eDVBServiceBase,
 	public iRecordableService,
 	public iStreamableService,
 	public iSubserviceList,
-	public Object
+	public sigc::trackable
 {
 	DECLARE_REF(eDVBServiceRecord);
 public:
-	RESULT connectEvent(const Slot2<void,iRecordableService*,int> &event, ePtr<eConnection> &connection);
+	RESULT connectEvent(const sigc::slot2<void,iRecordableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT prepare(const char *filename, time_t begTime, time_t endTime, int eit_event_id, const char *name, const char *descr, const char *tags, bool descramble, bool recordecm);
 	RESULT prepareStreaming(bool descramble, bool includeecm);
 	RESULT start(bool simulate=false);
@@ -67,7 +67,7 @@ private:
 
 			/* events */
 	void serviceEvent(int event);
-	Signal2<void,iRecordableService*,int> m_event;
+	sigc::signal2<void,iRecordableService*,int> m_event;
 
 			/* recorder events */
 	void recordEvent(int event);

--- a/lib/service/servicedvbstream.cpp
+++ b/lib/service/servicedvbstream.cpp
@@ -143,7 +143,7 @@ int eDVBServiceStream::doRecord()
 			return -1;
 		}
 		m_record->setTargetFD(m_target_fd);
-		m_record->connectEvent(slot(*this, &eDVBServiceStream::recordEvent), m_con_record_event);
+		m_record->connectEvent(sigc::mem_fun(*this, &eDVBServiceStream::recordEvent), m_con_record_event);
 	}
 
 	eDebug("[eDVBServiceStream] start streaming...");

--- a/lib/service/servicedvbstream.h
+++ b/lib/service/servicedvbstream.h
@@ -9,7 +9,7 @@
 
 #include <lib/service/servicedvb.h>
 
-class eDVBServiceStream: public eDVBServiceBase, public Object
+class eDVBServiceStream: public eDVBServiceBase, public sigc::trackable
 {
 	DECLARE_REF(eDVBServiceStream);
 public:

--- a/lib/service/servicedvd.cpp
+++ b/lib/service/servicedvd.cpp
@@ -438,7 +438,7 @@ eServiceDVD::~eServiceDVD()
 	disableSubtitles();
 }
 
-RESULT eServiceDVD::connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection)
+RESULT eServiceDVD::connectEvent(const sigc::slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection)
 {
 	connection = new eConnection((iPlayableService*)this, m_event.connect(event));
 	return 0;

--- a/lib/service/servicedvd.h
+++ b/lib/service/servicedvd.h
@@ -58,7 +58,7 @@ public:
 };
 
 class eServiceDVD: public iPlayableService, public iPauseableService, public iSeekableService, public iAudioTrackSelection,
-	public iServiceInformation, public iSubtitleOutput, public iServiceKeys, public iCueSheet, public eThread, public Object
+	public iServiceInformation, public iSubtitleOutput, public iServiceKeys, public iCueSheet, public eThread, public sigc::trackable
 {
 	friend class eServiceFactoryDVD;
 	DECLARE_REF(eServiceDVD);
@@ -78,7 +78,7 @@ public:
 	RESULT cueSheet(ePtr<iCueSheet> &ptr);
 
 		// iPlayableService
-	RESULT connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
+	RESULT connectEvent(const sigc::slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
 	RESULT info(ePtr<iServiceInformation> &ptr);
@@ -141,7 +141,7 @@ private:
 
 	eServiceReference m_ref;
 
-	Signal2<void,iPlayableService*,int> m_event;
+	sigc::signal2<void,iPlayableService*,int> m_event;
 
 	struct ddvd *m_ddvdconfig;
 	ePtr<gPixmap> m_pixmap;

--- a/lib/service/servicehdmi.cpp
+++ b/lib/service/servicehdmi.cpp
@@ -114,7 +114,7 @@ eServiceHDMI::~eServiceHDMI()
 
 DEFINE_REF(eServiceHDMI);
 
-RESULT eServiceHDMI::connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection)
+RESULT eServiceHDMI::connectEvent(const sigc::slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection)
 {
 	connection = new eConnection((iPlayableService*)this, m_event.connect(event));
 	return 0;
@@ -320,7 +320,7 @@ RESULT eServiceHDMIRecord::frontendInfo(ePtr<iFrontendInformation> &ptr)
 	return 0;
 }
 
-RESULT eServiceHDMIRecord::connectEvent(const Slot2<void,iRecordableService*,int> &event, ePtr<eConnection> &connection)
+RESULT eServiceHDMIRecord::connectEvent(const sigc::slot2<void,iRecordableService*,int> &event, ePtr<eConnection> &connection)
 {
 	connection = new eConnection((iRecordableService*)this, m_event.connect(event));
 	return 0;

--- a/lib/service/servicehdmi.h
+++ b/lib/service/servicehdmi.h
@@ -37,13 +37,13 @@ public:
 	long long getFileSize(const eServiceReference &ref);
 };
 
-class eServiceHDMI: public iPlayableService, public iServiceInformation, public Object
+class eServiceHDMI: public iPlayableService, public iServiceInformation, public sigc::trackable
 {
 	DECLARE_REF(eServiceHDMI);
 public:
 	virtual ~eServiceHDMI();
 
-	RESULT connectEvent(const Slot2<void, iPlayableService*, int> &event, ePtr<eConnection> &connection);
+	RESULT connectEvent(const sigc::slot2<void, iPlayableService*, int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
 	RESULT setTarget(int target, bool noaudio);
@@ -75,19 +75,19 @@ public:
 private:
 	friend class eServiceFactoryHDMI;
 	eServiceHDMI(eServiceReference ref);
-	Signal2<void,iPlayableService*, int> m_event;
+	sigc::signal2<void,iPlayableService*, int> m_event;
 	eServiceReference m_ref;
 	int m_decoder_index;
 	bool m_noaudio;
 	ePtr<iTSMPEGDecoder> m_decoder;
 };
 
-class eServiceHDMIRecord: public eDVBServiceBase, public iRecordableService, public Object
+class eServiceHDMIRecord: public eDVBServiceBase, public iRecordableService, public sigc::trackable
 {
 	DECLARE_REF(eServiceHDMIRecord);
 public:
 	eServiceHDMIRecord(const eServiceReference &ref);
-	RESULT connectEvent(const Slot2<void,iRecordableService*,int> &event, ePtr<eConnection> &connection);
+	RESULT connectEvent(const sigc::slot2<void,iRecordableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT prepare(const char *filename, time_t begTime, time_t endTime, int eit_event_id, const char *name, const char *descr, const char *tags, bool descramble, bool recordecm);
 	RESULT prepareStreaming(bool descramble = true, bool includeecm = false);
 	RESULT start(bool simulate=false);
@@ -115,7 +115,7 @@ private:
 	int doRecord();
 
 	/* events */
-	Signal2<void,iRecordableService*,int> m_event;
+	sigc::signal2<void,iRecordableService*,int> m_event;
 
 	/* recorder events */
 	void recordEvent(int event);

--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -751,7 +751,7 @@ DEFINE_REF(eServiceMP3);
 
 DEFINE_REF(GstMessageContainer);
 
-RESULT eServiceMP3::connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection)
+RESULT eServiceMP3::connectEvent(const sigc::slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection)
 {
 	connection = new eConnection((iPlayableService*)this, m_event.connect(event));
 	return 0;

--- a/lib/service/servicemp3.h
+++ b/lib/service/servicemp3.h
@@ -122,14 +122,14 @@ typedef enum { ctNone, ctMPEGTS, ctMPEGPS, ctMKV, ctAVI, ctMP4, ctVCD, ctCDA, ct
 
 class eServiceMP3: public iPlayableService, public iPauseableService,
 	public iServiceInformation, public iSeekableService, public iAudioTrackSelection, public iAudioChannelSelection,
-	public iSubtitleOutput, public iStreamedService, public iAudioDelay, public Object, public iCueSheet
+	public iSubtitleOutput, public iStreamedService, public iAudioDelay, public sigc::trackable, public iCueSheet
 {
 	DECLARE_REF(eServiceMP3);
 public:
 	virtual ~eServiceMP3();
 
 		// iPlayableService
-	RESULT connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
+	RESULT connectEvent(const sigc::slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
 
@@ -317,7 +317,7 @@ private:
 	errorInfo m_errorInfo;
 	std::string m_download_buffer_path;
 	eServiceMP3(eServiceReference ref);
-	Signal2<void,iPlayableService*,int> m_event;
+	sigc::signal2<void,iPlayableService*,int> m_event;
 	enum
 	{
 		stIdle, stRunning, stStopped,

--- a/lib/service/servicemp3record.cpp
+++ b/lib/service/servicemp3record.cpp
@@ -490,7 +490,7 @@ RESULT eServiceMP3Record::frontendInfo(ePtr<iFrontendInformation> &ptr)
 	return -1;
 }
 
-RESULT eServiceMP3Record::connectEvent(const Slot2<void,iRecordableService*,int> &event, ePtr<eConnection> &connection)
+RESULT eServiceMP3Record::connectEvent(const sigc::slot2<void,iRecordableService*,int> &event, ePtr<eConnection> &connection)
 {
 	connection = new eConnection((iRecordableService*)this, m_event.connect(event));
 	return 0;

--- a/lib/service/servicemp3record.h
+++ b/lib/service/servicemp3record.h
@@ -8,11 +8,11 @@
 
 class eServiceMP3Record:
 	public iRecordableService,
-	public Object
+	public sigc::trackable
 {
 	DECLARE_REF(eServiceMP3Record);
 public:
-	RESULT connectEvent(const Slot2<void,iRecordableService*,int> &event, ePtr<eConnection> &connection);
+	RESULT connectEvent(const sigc::slot2<void,iRecordableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT prepare(const char *filename, time_t begTime, time_t endTime, int eit_event_id, const char *name, const char *descr, const char *tags, bool descramble, bool recordecm);
 	RESULT prepareStreaming(bool descramble, bool includeecm);
 	RESULT start(bool simulate=false);
@@ -54,7 +54,7 @@ private:
 	static gboolean handleAutoPlugCont(GstElement *bin, GstPad *pad, GstCaps *caps, gpointer user_data);
 
 			/* events */
-	Signal2<void,iRecordableService*,int> m_event;
+	sigc::signal2<void,iRecordableService*,int> m_event;
 };
 
 #endif

--- a/lib/service/servicets.cpp
+++ b/lib/service/servicets.cpp
@@ -228,7 +228,7 @@ int eServiceTS::openHttpConnection(std::string url)
 	return fd;
 }
 
-RESULT eServiceTS::connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection)
+RESULT eServiceTS::connectEvent(const sigc::slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection)
 {
 	connection = new eConnection((iPlayableService*)this, m_event.connect(event));
 	return 0;

--- a/lib/service/servicets.h
+++ b/lib/service/servicets.h
@@ -41,14 +41,14 @@ public:
 class eStreamThread;
 class eServiceTS: public iPlayableService, public iPauseableService,
 	public iServiceInformation, public iSeekableService,
-	public iAudioTrackSelection, public iAudioChannelSelection, public Object
+	public iAudioTrackSelection, public iAudioChannelSelection, public sigc::trackable
 {
 DECLARE_REF(eServiceTS);
 public:
 	virtual ~eServiceTS();
 
 	// iPlayableService
-	RESULT connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
+	RESULT connectEvent(const sigc::slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
 	RESULT pause(ePtr<iPauseableService> &ptr);
@@ -112,13 +112,13 @@ private:
 	eServiceTS(const eServiceReference &url);
 	int openHttpConnection(std::string url);
 
-	Signal2<void,iPlayableService*,int> m_event;
+	sigc::signal2<void,iPlayableService*,int> m_event;
 	eFixedMessagePump<int> m_pump;
 	void recv_event(int evt);
 	void setAudioPid(int pid, int type);
 };
 
-class eStreamThread: public eThread, public Object {
+class eStreamThread: public eThread, public sigc::trackable {
 DECLARE_REF(eStreamThread);
 public:
 	eStreamThread();
@@ -133,7 +133,7 @@ public:
 	RESULT getAudioInfo(ePtr<TSAudioInfo> &ptr);
 
 	enum { evtEOS, evtSOS, evtReadError, evtWriteError, evtUser, evtStreamInfo };
-	Signal1<void,int> m_event;
+	sigc::signal1<void,int> m_event;
 private:
 	bool m_stop;
 	bool m_running;

--- a/lib/service/servicewebts.cpp
+++ b/lib/service/servicewebts.cpp
@@ -301,7 +301,7 @@ int eServiceWebTS::openHttpConnection(std::string url)
 	return fd;
 }
 
-RESULT eServiceWebTS::connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection)
+RESULT eServiceWebTS::connectEvent(const sigc::slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection)
 {
 	connection = new eConnection((iPlayableService*)this, m_event.connect(event));
 	return 0;

--- a/lib/service/servicewebts.h
+++ b/lib/service/servicewebts.h
@@ -72,14 +72,14 @@ public:
 class eStreamThreadWeb;
 class eServiceWebTS: public iPlayableService, public iPauseableService,
 	public iServiceInformation, public iSeekableService,
-	public iAudioTrackSelection, public iAudioChannelSelection, public Object
+	public iAudioTrackSelection, public iAudioChannelSelection, public sigc::trackable
 {
 DECLARE_REF(eServiceWebTS);
 public:
 	virtual ~eServiceWebTS();
 
 	// iPlayableService
-	RESULT connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
+	RESULT connectEvent(const sigc::slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
 	RESULT pause(ePtr<iPauseableService> &ptr);
@@ -145,13 +145,13 @@ private:
 	eServiceWebTS(const eServiceReference &url);
 	int openHttpConnection(std::string url);
 
-	Signal2<void,iPlayableService*,int> m_event;
+	sigc::signal2<void,iPlayableService*,int> m_event;
 	eFixedMessagePump<int> m_pump;
 	void recv_event(int evt);
 	void setAudioPid(int pid, int type);
 };
 
-class eStreamThreadWeb: public eThread, public Object {
+class eStreamThreadWeb: public eThread, public sigc::trackable {
 DECLARE_REF(eStreamThreadWeb);
 public:
 	eStreamThreadWeb();
@@ -166,7 +166,7 @@ public:
 	RESULT getAudioInfo(ePtr<TSAudioInfoWeb> &ptr);
 
 	enum { evtEOS, evtSOS, evtReadError, evtWriteError, evtUser, evtStreamInfo };
-	Signal1<void,int> m_event;
+	sigc::signal1<void,int> m_event;
 private:
 	bool m_stop;
 	bool m_running;

--- a/lib/service/servicexine.cpp
+++ b/lib/service/servicexine.cpp
@@ -164,7 +164,7 @@ void eServiceXine::eventListener(const xine_event_t *event)
 	}
 }
 
-RESULT eServiceXine::connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection)
+RESULT eServiceXine::connectEvent(const sigc::slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection)
 {
 	connection = new eConnection((iPlayableService*)this, m_event.connect(event));
 	return 0;

--- a/lib/service/servicexine.h
+++ b/lib/service/servicexine.h
@@ -42,14 +42,14 @@ public:
 typedef struct _GstElement GstElement;
 
 class eServiceXine: public iPlayableService, public iPauseableService,
-	public iServiceInformation, public iSeekableService, public Object
+	public iServiceInformation, public iSeekableService, public sigc::trackable
 {
 	DECLARE_REF(eServiceXine);
 public:
 	virtual ~eServiceXine();
 
 		// iPlayableService
-	RESULT connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
+	RESULT connectEvent(const sigc::slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
 
@@ -94,7 +94,7 @@ private:
 	friend class eServiceFactoryXine;
 	std::string m_filename;
 	eServiceXine(const char *filename);
-	Signal2<void,iPlayableService*,int> m_event;
+	sigc::signal2<void,iPlayableService*,int> m_event;
 
 	xine_stream_t *stream;
 	xine_video_port_t *vo_port;

--- a/main/enigma.cpp
+++ b/main/enigma.cpp
@@ -100,7 +100,7 @@ void keyEvent(const eRCKey &key)
 /* Defined in eerror.cpp */
 void setDebugTime(bool enable);
 
-class eMain: public eApplication, public Object
+class eMain: public eApplication, public sigc::trackable
 {
 	eInit init;
 	ePythonConfigQuery config;
@@ -278,7 +278,7 @@ int main(int argc, char **argv)
 
 	gRC::getInstance()->setSpinnerDC(my_dc);
 
-	eRCInput::getInstance()->keyEvent.connect(slot(keyEvent));
+	eRCInput::getInstance()->keyEvent.connect(sigc::ptr_fun(&keyEvent));
 
 	printf("[MAIN] executing main\n");
 


### PR DESCRIPTION
Porting was done mostly using instructions found here: https://mail.gnome.org/archives/libsigc-list/2005-July/msg00010.html

The Object typedef was changed to sigc::trackable to identify that sigc++ is used, instead of generic "Object".
The Connection typedef was changed to sigc::connection as well.

Most defines in libsig_comp.h deleted, only CONNECT and CONNECT_EXTRA left.

Closes: #422 