### PR TITLE
fixed not working converting for iso6937 twochar coding

### DIFF
--- a/lib/base/estring.cpp
+++ b/lib/base/estring.cpp
@@ -516,8 +516,7 @@ std::string convertDVBUTF8(const unsigned char *data, int len, int table, int ts
 
 	bool useTwoCharMapping = !table || (tsidonid && encodingHandler.getTransponderUseTwoCharMapping(tsidonid));
 
-	if (useTwoCharMapping && table == 5) { // i hope this dont break other transponders which realy use ISO8859-5 and two char byte mapping...
-//		eDebug("[convertDVBUTF8] Cyfra / Cyfrowy Polsat HACK... override given ISO8859-5 with ISO6937");
+	if (useTwoCharMapping) { // useTwoCharMapping using iso6937. Then must be table set to 0 for using in recode()
 		table = 0;
 	}
 	else if ( !table || table == -1 )


### PR DESCRIPTION
again can works recode() for iso6937 (twochar epg coding)