### PR TITLE
fastscan: init multistream default values

### DIFF
--- a/lib/dvb/fastscan.cpp
+++ b/lib/dvb/fastscan.cpp
@@ -499,6 +499,9 @@ void eFastScan::parseResult()
 			fesat.modulation = (*it)->getModulation();
 			fesat.rolloff = (*it)->getRollOff();
 			fesat.pilot = eDVBFrontendParametersSatellite::Pilot_Unknown;
+			fesat.is_id = NO_STREAM_ID_FILTER;
+			fesat.pls_mode = eDVBFrontendParametersSatellite::PLS_Root;
+			fesat.pls_code = 1;
 
 			parm->setDVBS(fesat);
 			db->addChannelToList(chid, parm);

--- a/lib/python/Plugins/SystemPlugins/FastScan/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/FastScan/plugin.py
@@ -233,6 +233,9 @@ class FastScanScreen(ConfigListScreen, Screen):
 		transponderParameters.modulation = self.transponders[number][7]
 		transponderParameters.rolloff = self.transponders[number][8]
 		transponderParameters.pilot = self.transponders[number][9]
+		transponderParameters.is_id = -1
+		transponderParameters.pls_mode = eDVBFrontendParametersSatellite.PLS_Root
+		transponderParameters.pls_code = 1
 		return transponderParameters
 
 	def startScan(self):


### PR DESCRIPTION
Fastscan channels where greyed out because of uninitialized mis/pls values.
Initialize mis/pls default values to fix it.