### PR TITLE
dvb: detect usb adapters with ep_84 instead of ep_00

### DIFF
--- a/lib/dvb/dvb.cpp
+++ b/lib/dvb/dvb.cpp
@@ -244,6 +244,11 @@ bool eDVBAdapterLinux::isusb(int nr)
 {
 	char devicename[256];
 	snprintf(devicename, sizeof(devicename), "/sys/class/dvb/dvb%d.frontend0/device/ep_00", nr);
+	if (::access(devicename, X_OK) >= 0)
+	{
+		return true;
+	}
+	snprintf(devicename, sizeof(devicename), "/sys/class/dvb/dvb%d.frontend0/device/ep_84", nr);
 	return ::access(devicename, X_OK) >= 0;
 }
 


### PR DESCRIPTION
Based on: https://github.com/openatv/enigma2/commit/16c47dd2e78ca70c5ad2467d0d2952628050a3ec