### PR TITLE
Fixed chars in services and providers names and chars over 0xA0. conv…

### DIFF
--- a/lib/base/estring.cpp
+++ b/lib/base/estring.cpp
@@ -516,10 +516,11 @@ std::string convertDVBUTF8(const unsigned char *data, int len, int table, int ts
 
 	bool useTwoCharMapping = !table || (tsidonid && encodingHandler.getTransponderUseTwoCharMapping(tsidonid));
 
-	if (useTwoCharMapping) { // useTwoCharMapping using iso6937. Then must be table set to 0 for using in recode()
+	if (useTwoCharMapping && table == 5) { // i hope this dont break other transponders which realy use ISO8859-5 and two char byte mapping...
+//		eDebug("[convertDVBUTF8] Cyfra / Cyfrowy Polsat HACK... override given ISO8859-5 with ISO6937");
 		table = 0;
 	}
-	else if ( !table || table == -1 )
+	else if ( table == -1 )
 		table = defaultEncodingTable;
 
 	switch(table)

--- a/lib/base/estring.h
+++ b/lib/base/estring.h
@@ -15,7 +15,7 @@ std::string getNum(int num, int base=10);
 std::string GB18030ToUTF8(const char *szIn, int len,int *pconvertedLen=0);
 std::string Big5ToUTF8(const char *szIn, int len,int *pconvertedLen=0);
 
-std::string convertDVBUTF8(const unsigned char *data, int len, int table=0, int tsidonid=1,int *pconvertedLen=0); // with default encoding
+std::string convertDVBUTF8(const unsigned char *data, int len, int table=-1, int tsidonid=1,int *pconvertedLen=0);
 std::string convertLatin1UTF8(const std::string &string);
 int isUTF8(const std::string &string);
 unsigned int truncateUTF8(std::string &s, unsigned int newsize);
@@ -24,7 +24,7 @@ std::string removeDVBChars(const std::string &s);
 void makeUpper(std::string &s);
 std::string replace_all(const std::string &in, const std::string &entity, const std::string &symbol,int table=-1);
 
-inline std::string convertDVBUTF8(const std::string &string, int table=0, int tsidonid=1,int *pconvertedLen=0) // with default encoding
+inline std::string convertDVBUTF8(const std::string &string, int table=-1, int tsidonid=1,int *pconvertedLen=0)
 {
 	return convertDVBUTF8((const unsigned char*)string.c_str(), string.length(), table, tsidonid,pconvertedLen);
 }

--- a/lib/dvb/scan.cpp
+++ b/lib/dvb/scan.cpp
@@ -988,9 +988,9 @@ void eDVBScan::channelDone()
 			if( m_chid_current )
 				tsonid = ( m_chid_current.transport_stream_id.get() << 16 )
 					| m_chid_current.original_network_id.get();
-			service->m_service_name = convertDVBUTF8(sname,0,tsonid,0);
+			service->m_service_name = convertDVBUTF8(sname,-1,tsonid,0);
 			service->genSortName();
-			service->m_provider_name = convertDVBUTF8(pname,0,tsonid,0);
+			service->m_provider_name = convertDVBUTF8(pname,-1,tsonid,0);
 		}
 
 		if (!(m_flags & scanOnlyFree) || !m_pmt_in_progress->second.scrambled) {
@@ -1388,10 +1388,10 @@ RESULT eDVBScan::processSDT(eDVBNamespace dvbnamespace, const ServiceDescription
 
 					ref.setServiceType(servicetype);
 					int tsonid=(sdt.getTransportStreamId() << 16) | sdt.getOriginalNetworkId();
-					service->m_service_name = convertDVBUTF8(d.getServiceName(),0,tsonid,0);
+					service->m_service_name = convertDVBUTF8(d.getServiceName(),-1,tsonid,0);
 					service->genSortName();
 
-					service->m_provider_name = convertDVBUTF8(d.getServiceProviderName(),0,tsonid,0);
+					service->m_provider_name = convertDVBUTF8(d.getServiceProviderName(),-1,tsonid,0);
 					SCAN_eDebug("[eDVBScan]   name '%s', provider_name '%s'", service->m_service_name.c_str(), service->m_provider_name.c_str());
 					break;
 				}


### PR DESCRIPTION
…ertDVBUTF8 is declared with table=-1 now.

Declaration with table=0 was wrong, because table=0 is used for broadcast useTwoCharMapping (iso6937).
With table=-1 is possible to know again, if is broadcasted useTwoCharMapping or not.
Info about used table must then pass to calling recode routine, where are converted all chars up 0xA0.
In scan.cpp is called convertDVBUTF8 with -1 instead 0 too.