### PR TITLE
dvbci: drop DM7025 CI handling

### DIFF
--- a/lib/dvb_ci/dvbci.cpp
+++ b/lib/dvb_ci/dvbci.cpp
@@ -586,11 +586,7 @@ void eDVBCIInterfaces::recheckPMTHandlers()
 					eDebug("[CI] (1)Slot %d, usecount now %d", ci_it->getSlotID(), ci_it->use_count);
 
 					std::stringstream ci_source;
-					ci_source << "CI";
-					if (getNumOfSlots() > 1) // Only receivers with more that 1 CI expect number after CI
-					{
-						ci_source << ci_it->getSlotID();
-					}
+					ci_source << "CI" << ci_it->getSlotID();
 
 					if (!it->cislot)
 					{
@@ -1306,15 +1302,7 @@ int eDVBCISlot::setSource(const std::string &source)
 {
 	char buf[64];
 	current_source = source;
-
-	if (eDVBCIInterfaces::getInstance()->getNumOfSlots() > 1) // FIXME .. we force DM8000 when more than one CI Slot is avail
-	{
-		snprintf(buf, sizeof(buf), "/proc/stb/tsmux/ci%d_input", slotid);
-	}
-	else // DM7025
-	{
-		snprintf(buf, sizeof(buf), "/proc/stb/tsmux/input2");
-	}
+	snprintf(buf, sizeof(buf), "/proc/stb/tsmux/ci%d_input", slotid);
 
 	if(CFile::write(buf, source.c_str()) == -1)
 	{


### PR DESCRIPTION
Now all modern boxes follow DM8000 CI handling where node tsmux/ciX_input and CI followed with the number of CI slot.
Drop DM7025 CI handling in flavor of simpicity and for unified interface between all E2 boxes without making assumptions based on CI devices each box has.