### PR TITLE
fastscan: limit results to package orbital position

### DIFF
--- a/lib/dvb/fastscan.cpp
+++ b/lib/dvb/fastscan.cpp
@@ -483,6 +483,13 @@ void eFastScan::parseResult()
 			eDVBChannelID chid;
 			int orbitalposbcd = (*it)->getOrbitalPosition();
 			int orbitalpos = (orbitalposbcd & 0x0f) + ((orbitalposbcd >> 4) & 0x0f) * 10 + ((orbitalposbcd >> 8) & 0x0f) * 100;
+
+			if (transponderParameters.orbital_position != orbitalpos)
+			{
+				eDebug("[eFastScan] dropping this transponder, it's on another satellite %d.", orbitalpos);
+				continue;
+			}
+
 			chid.dvbnamespace = eDVBNamespace(orbitalpos<<16);
 			chid.transport_stream_id = eTransportStreamID((*it)->getTransportStreamId());
 			chid.original_network_id = eOriginalNetworkID((*it)->getOriginalNetworkId());


### PR DESCRIPTION
When using fastscan we are getting other orbital positions making huge lists.
Limit results only on the orbital position of the package we are scanning for.

More info: https://forums.openpli.org/topic/50680-edvbscan-dropping-this-transponder-its-on-another-satellite/