### PR TITLE
fastscan: limit results to configured orbital position

### DIFF
--- a/lib/dvb/fastscan.cpp
+++ b/lib/dvb/fastscan.cpp
@@ -4,6 +4,7 @@
 
 #include <lib/dvb/db.h>
 #include <lib/dvb/dvb.h>
+#include <lib/dvb/sec.h>
 #include <lib/dvb/frontend.h>
 #include <lib/dvb/fastscan.h>
 #include <lib/base/cfile.h>
@@ -483,6 +484,14 @@ void eFastScan::parseResult()
 			eDVBChannelID chid;
 			int orbitalposbcd = (*it)->getOrbitalPosition();
 			int orbitalpos = (orbitalposbcd & 0x0f) + ((orbitalposbcd >> 4) & 0x0f) * 10 + ((orbitalposbcd >> 8) & 0x0f) * 100;
+
+			if (transponderParameters.orbital_position != orbitalpos &&
+				!eDVBSatelliteEquipmentControl::getInstance()->isOrbitalPositionConfigured(orbitalpos))
+			{
+				eDebug("[eFastScan] dropping this transponder, it's on another satellite %d not configured.", orbitalpos);
+				continue;
+			}
+
 			chid.dvbnamespace = eDVBNamespace(orbitalpos<<16);
 			chid.transport_stream_id = eTransportStreamID((*it)->getTransportStreamId());
 			chid.original_network_id = eOriginalNetworkID((*it)->getOriginalNetworkId());

--- a/lib/dvb/sec.cpp
+++ b/lib/dvb/sec.cpp
@@ -1749,3 +1749,17 @@ void eDVBSatelliteEquipmentControl::setRotorMoving(int slot_no, bool b)
 	else
 		m_rotorMoving &= ~(1 << slot_no);
 }
+
+bool eDVBSatelliteEquipmentControl::isOrbitalPositionConfigured(int orbital_position)
+{
+	for (int idx=0; idx <= m_lnbidx; ++idx)
+	{
+		eDVBSatelliteLNBParameters &lnb_param = m_lnbs[idx];
+		std::map<int, eDVBSatelliteSwitchParameters>::iterator sit = lnb_param.m_satellites.find(orbital_position);
+		if (sit != lnb_param.m_satellites.end())
+		{
+			return true;
+		}
+	}
+	return false;
+}

--- a/lib/dvb/sec.h
+++ b/lib/dvb/sec.h
@@ -396,6 +396,7 @@ public:
 	bool isRotorMoving();
 	bool canMeasureInputPower() { return m_canMeasureInputPower; }
 	int getTargetOrbitalPosition() { return m_target_orbital_position; }
+	bool isOrbitalPositionConfigured(int orbital_position);
 
 	friend class eFBCTunerManager;
 };


### PR DESCRIPTION
The fastscan it is possible to return orbital positions currently not configured.
Instead of getting unknown entries keep the positions we have LNB configured.