### PR TITLE
NimManager - fix crash getFriendlyFullDescriptionCompressed introduce…

### DIFF
--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -629,7 +629,7 @@ class NIM(object):
 		#compress by combining dual tuners by checking if the next tuner has an rf switch
 		elif os.access("/proc/stb/frontend/%d/rf_switch" % (self.frontend_id + 1), os.F_OK):
 			return "%s-%s: %s" % (self.slot_name, chr(ord('A') + self.slot + 1), self.getFullDescription())
-		return getFriendlyFullDescription()
+		return self.getFriendlyFullDescription()
 
 	friendly_full_description = property(getFriendlyFullDescription)
 	friendly_full_description_compressed = property(getFriendlyFullDescriptionCompressed)


### PR DESCRIPTION
…d in https://github.com/OpenPLi/enigma2/commit/7de73064e866d59467794e6142eacf127a0481fa

NameError: global name 'getFriendlyFullDescription' is not defined