### PR TITLE
eStreamServer: add ?duration=xx...

### DIFF
--- a/lib/dvb/streamserver.h
+++ b/lib/dvb/streamserver.h
@@ -30,6 +30,8 @@ protected:
 
 	std::string request;
 
+	ePtr<eTimer> m_timeout;
+
 	void streamStopped() { stopStream(); }
 	void tuneFailed() { stopStream(); }
 


### PR DESCRIPTION
Add ?duration=xx to the URL so we can force a stream duration (this is required for Plex DVR API).

Thanks to Athoik for help.