### PR TITLE
NimManager: Allow getFriendlyFullDescriptionCompressed() to...

### DIFF
--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -542,11 +542,11 @@ class NIM(object):
 	def getSlotID(self, slot=None):
 		return chr(ord('A') + (slot if slot is not None else self.slot))
 
-	def getSlotName(self):
+	def getSlotName(self, slot_id=None):
 		# get a friendly description for a slot name.
 		# we name them "Tuner A/B/C/...", because that's what's usually written on the back
 		# of the device.
-		return "%s %s" % (_("Tuner"), self.slot_id)
+		return "%s %s" % (_("Tuner"), slot_id or self.slot_id)
 
 	def getI2C(self):
 		return self.i2c
@@ -613,7 +613,8 @@ class NIM(object):
 
 	def getFriendlyFullDescriptionCompressed(self):
 		if self.isFBCTuner():
-			return "%s-%s: %s" % (self.slot_name, self.getSlotID(self.slot + 7), self.getFullDescription())
+			firstFBCslot = self.slot - self.slot % 8
+			return "%s-%s: %s" % (self.getSlotName(self.getSlotID(firstFBCslot)), self.getSlotID(firstFBCslot + 7), self.getFullDescription())
 		#compress by combining dual tuners by checking if the next tuner has a rf switch
 		elif os.access("/proc/stb/frontend/%d/rf_switch" % (self.frontend_id + 1), os.F_OK):
 			return "%s-%s: %s" % (self.slot_name, self.getSlotID(self.slot + 1), self.getFullDescription())


### PR DESCRIPTION
Allow getFriendlyFullDescriptionCompressed() to be called on any slot within the FBC complex and return the correct name for the whole complex.

i.e. calling this function when nim.slot = 4 will return: "Tuner A-H: Vu-Tuner blablabla (DVB_S2)".

Also, this commit along with the previous two from Littlesat allow these functions to be called individually with arguments or as part of a chain, giving the coder maximum flexibility for their future use in other applications, plugins,etc, not just the "About" screen.