### PR TITLE
Generate .sc .ap files for h265 encoded channels

### DIFF
--- a/lib/dvb/pvrparse.cpp
+++ b/lib/dvb/pvrparse.cpp
@@ -1020,10 +1020,10 @@ int eMPEGStreamParserTS::processPacket(const unsigned char *pkt, off_t offset)
 					int nal_unit_type = (sc >> 1);
 					if (nal_unit_type == 35) /* H265 NAL unit access delimiter */
 					{
-						unsigned long long data = sc | (pkt[4] << 8);
+						unsigned long long data = sc | (pkt[5] << 8);
 						writeStructureEntry(offset + pkt_offset, data);
 
-						if ((pkt[4] >> 5) == 0) /* check pic_type for I-frame */
+						if ((pkt[5] >> 5) == 0) /* check pic_type for I-frame */
 						{
 							if (ptsvalid)
 							{
@@ -1200,12 +1200,12 @@ void eMPEGStreamParserTS::setPid(int _pid, iDVBTSRecorder::timing_pid_type pidty
 {
 	m_pktptr = 0;
 	/*
-	 * Currently, eMPEGStreamParserTS can only parse video, mpeg2 (streamtype 0) and h264 (streamtype 1).
+	 * Currently, eMPEGStreamParserTS can only parse video, mpeg2 (streamtype 0), h264 (streamtype 1) and h265 (streamtype 6).
 	 * Also, streamtype -1 should be accepted, which will cause the streamtype to be autodetected.
 	 * Do not try to parse audio pids, which might lead to false hits,
 	 * and waste cpu time.
 	 */
-	if (pidtype == iDVBTSRecorder::video_pid && streamtype < 2)
+	if (pidtype == iDVBTSRecorder::video_pid && (streamtype < 2 || streamtype == 6))
 	{
 		m_pid = _pid;
 		m_streamtype = streamtype;


### PR DESCRIPTION
plus fix bug: h265 uses 2 byte NAL unit header.