### PR TITLE
[Satconfig] alter text for Unicable

### DIFF
--- a/lib/python/Screens/Satconfig.py
+++ b/lib/python/Screens/Satconfig.py
@@ -329,7 +329,7 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 				self.list.append(getConfigListEntry(_("Threshold"), currLnb.threshold))
 
 			if currLnb.lof.value == "unicable":
-				self.advancedUnicable = getConfigListEntry("SCR (Unicable/JESS) "+_("Configuration mode"), currLnb.unicable)
+				self.advancedUnicable = getConfigListEntry("SCR (Unicable/JESS) "+_("mode"), currLnb.unicable)
 				self.list.append(self.advancedUnicable)
 				if currLnb.unicable.value == "unicable_user":
 					self.advancedFormat = getConfigListEntry(_("Format"), currLnb.format)
@@ -344,7 +344,7 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 					self.list.append(getConfigListEntry(_("Threshold"), currLnb.threshold))
 				else:
 					self.advancedManufacturer = getConfigListEntry(_("Manufacturer"), currLnb.unicableManufacturer)
-					self.advancedType = getConfigListEntry(_("Type"), currLnb.unicableProduct)
+					self.advancedType = getConfigListEntry(_("Model"), currLnb.unicableProduct)
 					self.advancedSCR = getConfigListEntry(_("Channel"), currLnb.scrList)
 					self.advancedPosition = getConfigListEntry(_("Position"), currLnb.positionNumber)
 					self.list.append(self.advancedManufacturer)

--- a/lib/python/Screens/Satconfig.py
+++ b/lib/python/Screens/Satconfig.py
@@ -329,7 +329,7 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 				self.list.append(getConfigListEntry(_("Threshold"), currLnb.threshold))
 
 			if currLnb.lof.value == "unicable":
-				self.advancedUnicable = getConfigListEntry("SCR (Unicable/JESS) "+_("mode"), currLnb.unicable)
+				self.advancedUnicable = getConfigListEntry("SCR (Unicable/JESS) "+_("type"), currLnb.unicable)
 				self.list.append(self.advancedUnicable)
 				if currLnb.unicable.value == "unicable_user":
 					self.advancedFormat = getConfigListEntry(_("Format"), currLnb.format)


### PR DESCRIPTION
Change Unicable text.
1. Shorthen the text. It is obvious we are in configuration mode but actually selecting type of SCR setup.
2. Change "Type" to "Model". We are selecting model of LNB/switch of the unicable product

Original
![pli unicable original](https://user-images.githubusercontent.com/6644489/27015610-028fe4ce-4f0a-11e7-992b-a7fad0e1f68b.jpg)

After changes
![pli unicable modified](https://user-images.githubusercontent.com/6644489/27015611-0ef01f40-4f0a-11e7-814d-30b94b24e407.jpg)
