### PR TITLE
[HDMI-CEC] plugin - set default enabled as off

### DIFF
--- a/lib/python/Components/HdmiCec.py
+++ b/lib/python/Components/HdmiCec.py
@@ -46,7 +46,7 @@ cmdList = {
 	}
 
 config.hdmicec = ConfigSubsection()
-config.hdmicec.enabled = ConfigYesNo(default = True)
+config.hdmicec.enabled = ConfigYesNo(default = False)
 config.hdmicec.control_tv_standby = ConfigYesNo(default = True)
 config.hdmicec.control_tv_wakeup = ConfigYesNo(default = True)
 config.hdmicec.report_active_source = ConfigYesNo(default = True)


### PR DESCRIPTION
-this plugin is not for normal users