### PR TITLE
CableScan: fix install/uninstall plugin without restart GUI

### DIFF
--- a/lib/python/Plugins/SystemPlugins/CableScan/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/CableScan/plugin.py
@@ -248,7 +248,7 @@ def getNimList():
 	return [x for x in nimmanager.getNimListOfType("DVB-C") if config.Nims[x].configMode.value != "nothing"]
 
 def CableScanMain(session, **kwargs):
-		Session.open(CableScanScreen, getNimList())
+	session.open(CableScanScreen, getNimList())
 
 def restartScanAutoStartTimer(reply=False):
 	if reply:
@@ -259,7 +259,7 @@ def restartScanAutoStartTimer(reply=False):
 
 def CableScanAuto():
 	nimlist = getNimList()
-	if nimlist:
+	if nimlist and Session:
 		if Session.nav.RecordTimer.isRecording():
 			restartScanAutoStartTimer()
 		else:
@@ -276,10 +276,14 @@ def standbyCountChanged(value):
 		inStandby.onClose.append(leaveStandby)
 		CableScanAutoStartTimer.startLongTimer(150)
 
-def startSession(session, **kwargs):
+def autostart(reason, **kwargs):
 	global Session
-	Session = session
-	config.misc.standbyCounter.addNotifier(standbyCountChanged, initial_call=False)
+	if reason == 0 and "session" in kwargs and Session is None:
+		Session = kwargs["session"]
+		config.misc.standbyCounter.addNotifier(standbyCountChanged, initial_call=False)
+	elif reason == 1:
+		Session = None
+		config.misc.standbyCounter.removeNotifier(standbyCountChanged)
 
 def CableScanStart(menuid, **kwargs):
 	if menuid == "scan" and getNimList():
@@ -290,6 +294,6 @@ def CableScanStart(menuid, **kwargs):
 def Plugins(**kwargs):
 	if nimmanager.hasNimType("DVB-C"):
 		return [PluginDescriptor(name=_("Cable Scan"), description="Scan cable provider channels", where = PluginDescriptor.WHERE_MENU, fnc=CableScanStart),
-			PluginDescriptor(where=[PluginDescriptor.WHERE_SESSIONSTART], fnc=startSession)]
+			PluginDescriptor(where=[PluginDescriptor.WHERE_SESSIONSTART, PluginDescriptor.WHERE_AUTOSTART], fnc=autostart)]
 	else:
 		return []


### PR DESCRIPTION
File
"/usr/lib/enigma2/python/Plugins/SystemPlugins/CableScan/plugin.py",
line 255, in CableScanMain
Session.open(MessageBox, _("No cable
tuner found!"), type=MessageBox.TYPE_ERROR)
AttributeError: 'NoneType'
object has no attribute 'open

tnanks littlesat