### PR TITLE
[Satfinder] Fix PLP ID.

### DIFF
--- a/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
@@ -29,6 +29,7 @@ class Satfinder(ScanSetup, ServiceScan):
 		self.satEntry = None
 		self.typeOfInputEntry = None
 		self.DVB_TypeEntry = None
+		self.systemEntryTerr = None
 
 		ScanSetup.__init__(self, session)
 		self.setTitle(_("Satfinder"))
@@ -75,7 +76,7 @@ class Satfinder(ScanSetup, ServiceScan):
 
 	def newConfig(self):
 		cur = self["config"].getCurrent()
-		if cur in (self.typeOfTuningEntry, self.systemEntry, self.typeOfInputEntry, self.systemEntryATSC, self.DVB_TypeEntry):
+		if cur in (self.typeOfTuningEntry, self.systemEntry, self.typeOfInputEntry, self.systemEntryATSC, self.DVB_TypeEntry, self.systemEntryTerr):
 			self.createSetup()
 		elif cur == self.satfinderTunerEntry:
 			self.feid = int(self.satfinder_scan_nims.value)


### PR DESCRIPTION
When switching between between DVB-T and DVB-T2 reload createSetup so "PLP ID" becomes available.

More info: https://forums.openpli.org/topic/52001-vu-solo-4k-dvb-t2-broken/#entry737965