### PR TITLE
Plugin SoftwareManager: fix packet parsing in PacketManager

### DIFF
--- a/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
@@ -1737,16 +1737,23 @@ class PacketManager(Screen, NumericalTextInput):
 			self.packetlist = []
 			last_name = ""
 			for x in result.splitlines():
-				tokens = x.split(' - ')
-				name = tokens[0].strip()
-				if not any(name.endswith(x) for x in self.unwanted_extensions):
-					l = len(tokens)
-					version = l > 1 and tokens[1].strip() or ""
-					descr = l > 2 and tokens[2].strip() or ""
-					if name == last_name:
-						continue
-					last_name = name
-					self.packetlist.append([name, version, descr])
+				if ' - ' in x:
+					tokens = x.split(' - ')
+					name = tokens[0].strip()
+					if name and not any(name.endswith(x) for x in self.unwanted_extensions):
+						l = len(tokens)
+						version = l > 1 and tokens[1].strip() or ""
+						descr = l > 2 and tokens[2].strip() or ""
+						if name == last_name:
+							continue
+						last_name = name
+						self.packetlist.append([name, version, descr])
+				elif len(self.packetlist) > 0:
+					# no ' - ' in the text, assume that this is the description
+					# therefore add this text to the last packet description
+					last_packet = self.packetlist[-1]
+					last_packet[2] = last_packet[2] + x
+					self.packetlist[:-1] + last_packet
 
 		if not self.Console:
 			self.Console = Console()


### PR DESCRIPTION
opkg list now print description in several rows,
therefore, no longer working division by ' - '.
If no ' - ' in the text, assume that this is the description
and therefore add this text to the last packet description.

Before fix:
![screenshot](https://user-images.githubusercontent.com/1623947/28085068-35ee89fc-6683-11e7-8908-4198db93873e.jpg)

After fix:
![screenshot_1](https://user-images.githubusercontent.com/1623947/28085086-3fb2d5ba-6683-11e7-8360-fc8e85c5f2b7.jpg)

