### PR TITLE
TimerList: fix malformed string introduced in https://github.com/OpenPLi/enigma2/commit/0986d3684de44e1367dba4a17ab143233c4d9ce9

### DIFF
--- a/lib/python/Components/TimerList.py
+++ b/lib/python/Components/TimerList.py
@@ -45,10 +45,11 @@ class TimerList(HTMLComponent, GUIComponent, object):
 			if "autotimer" in timer.flags:
 				self.iconAutoTimer and res.append((eListboxPythonMultiContent.TYPE_PIXMAP_ALPHATEST, self.iconMargin / 2, self.rowSplit + (self.itemHeight - self.rowSplit - self.iconHeight) / 2, self.iconWidth, self.iconHeight, self.iconAutoTimer))
 		if timer.justplay:
-			extra_text = _("(ZAP)")
 			if timer.pipzap:
 				extra_text = _("(ZAP as PiP)")
-			text = repeatedtext + ((" %s "+ extra_text) % (begin[1]))
+			else:
+				extra_text = _("(ZAP)")
+			text = repeatedtext + ((" %s %s") % (begin[1], extra_text))
 		else:
 			text = repeatedtext + ((" %s ... %s (%d " + _("mins") + ")") % (begin[1], FuzzyTime(timer.end)[1], (timer.end - timer.begin) / 60))
 		icon = None


### PR DESCRIPTION
This structure of the string was correct before the change, when the second argumnet was not a variable.
Also assign extra_text only once if is used timer.pipzap.