### PR TITLE
[RecordTimer] Add new option 'Event Name First" for recording filenames.

### DIFF
--- a/RecordTimer.py
+++ b/RecordTimer.py
@@ -215,7 +215,9 @@ class RecordTimerEntry(timer.TimerEntry, object):
 		name = name or self.name
 		filename = begin_date + " - " + service_name
 		if name:
-			if config.recording.filename_composition.value == "short":
+			if config.recording.filename_composition.value == "event":
+				filename = name + ' - ' + begin_date + "_" + service_name
+			elif config.recording.filename_composition.value == "short":
 				filename = strftime("%Y%m%d", localtime(self.begin)) + " - " + name
 			elif config.recording.filename_composition.value == "long":
 				filename += " - " + name + " - " + self.description

--- a/lib/python/Components/RecordingConfig.py
+++ b/lib/python/Components/RecordingConfig.py
@@ -11,6 +11,7 @@ def InitRecordingConfig():
 	config.recording.keep_timers = ConfigNumber(default=7)
 	config.recording.filename_composition = ConfigSelection(default = "standard", choices = [
 		("standard", _("standard")),
+		("event", _("Event name first")),
 		("short", _("Short filenames")),
 		("long", _("Long filenames")) ] )
 	config.recording.always_ecm = ConfigYesNo(default = False)

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -1919,7 +1919,9 @@ class InfoBarTimeshift:
 		begin_date = strftime("%Y%m%d %H%M", localtime(time()))
 		filename = begin_date + " - " + service_name
 
-		if config.recording.filename_composition.value == "short":
+		if config.recording.filename_composition.value == "event":
+			filename = "%s - %s_%s" % (info["name"], strftime("%Y%m%d %H%M",localtime(time())), service_name)
+		elif config.recording.filename_composition.value == "short":
 			filename = strftime("%Y%m%d", localtime(time())) + " - " + info["name"]
 		elif config.recording.filename_composition.value == "long":
 			filename += " - " + info["name"] + " - " + info["description"]


### PR DESCRIPTION
Adds a fourth type of filename composition. standard, long, short, then "Event Name First"
so recorded filenames do not have the date as the filename prefix.

Credit: AndyBlac
https://github.com/OpenViX/enigma2/commit/5ec78dfb9dec22dbdca8734662f7623c1037aa80