### PR TITLE
[db.cpp] Clear services before reloadServicelist

### DIFF
--- a/lib/dvb/db.cpp
+++ b/lib/dvb/db.cpp
@@ -351,6 +351,7 @@ DEFINE_REF(eDVBDB);
 
 void eDVBDB::reloadServicelist()
 {
+	m_services.clear();
 	loadServicelist(eEnv::resolve("${sysconfdir}/enigma2/lamedb").c_str());
 }
 


### PR DESCRIPTION
This commit is to replace a workaround in OpenWebIF ( https://github.com/oe-alliance/AutoBouquetsMaker/commit/89771c6a153f06bb2bd1b7c6b801e58ce6f65e60 ) and ABM ( https://github.com/oe-alliance/AutoBouquetsMaker/commit/89771c6a153f06bb2bd1b7c6b801e58ce6f65e60 )that should really be handled in enigma cpp code.

Recreate bug as follows:

1) Retrieve lamedb from STB over FTP.
2) Manually edit a channel name.
3) Send lamedb to STB over FTP.
4) Call http://<STB-IP>/web/servicelistreload?mode=0
5) Check channel name.

In the case of the current code the service name does not change.
This makes it impossible to correctly reload service lists.
Only way to get clean reload with current code is to put the STB to sleep (init 4).

The code in this commit cleans enigma2 before the reload so the new service list will not be contaminated by the current one loaded in the RAM.

Code author: Athoik. Thanks.

Tester: AbuBaniaz. Thanks.