### PR TITLE
For actual bookmarks and accepting changes without restart e2

### DIFF
--- a/lib/python/Screens/LocationBox.py
+++ b/lib/python/Screens/LocationBox.py
@@ -529,6 +529,7 @@ class LocationBox(Screen, NumericalTextInput, HelpableScreen):
 		return str(type(self)) + "(" + self.text + ")"
 
 def MovieLocationBox(session, text, dir, filename = "", minFree = None):
+	config.movielist.videodirs.load()
 	return LocationBox(session, text = text,  filename = filename, currDir = dir, bookmarks = config.movielist.videodirs, autoAdd = True, editDir = True, inhibitDirs = defaultInhibitDirs, minFree = minFree)
 
 class TimeshiftLocationBox(LocationBox):

--- a/lib/python/Screens/RecordPaths.py
+++ b/lib/python/Screens/RecordPaths.py
@@ -25,6 +25,7 @@ class RecordPathsSettings(Screen,ConfigListScreen):
 		self["key_green"] = StaticText(_("Save"))
 		self.setTitle(_("Recording paths"))
 		ConfigListScreen.__init__(self, [])
+		config.movielist.videodirs.load()
 		self.initConfigList()
 
 		self["setupActions"] = ActionMap(["SetupActions", "ColorActions", "MenuActions"],

--- a/lib/python/Screens/TimerEntry.py
+++ b/lib/python/Screens/TimerEntry.py
@@ -62,6 +62,7 @@ class TimerEntry(Screen, ConfigListScreen):
 		pipzap = self.timer.pipzap
 		rename_repeat = self.timer.rename_repeat
 		conflict_detection = self.timer.conflict_detection
+		config.movielist.videodirs.load()
 
 		afterevent = {
 			AFTEREVENT.NONE: "nothing",


### PR DESCRIPTION
- actual list of valid videodir directories (stored in config.movielist.videodirs) is created on start enigma2 only, Then any changes in mounted/umounted devices are ignored. Due it must be actualised always before using 