### PR TITLE
About.py: use nine characters for driver date

### DIFF
--- a/lib/python/Components/About.py
+++ b/lib/python/Components/About.py
@@ -83,7 +83,7 @@ def getCPUInfoString():
 			except:
 				pass
 		if temperature:
-			return "%s %s MHz (%s) %s°C" % (processor, cpu_speed, ngettext("%d core", "%d cores", cpu_count) % cpu_count, temperature)
+			return "%s %s MHz (%s) %sÂ°C" % (processor, cpu_speed, ngettext("%d core", "%d cores", cpu_count) % cpu_count, temperature)
 		return "%s %s MHz (%s)" % (processor, cpu_speed, ngettext("%d core", "%d cores", cpu_count) % cpu_count)
 	except:
 		return _("undefined")
@@ -92,7 +92,7 @@ def getDriverInstalledDate():
 	try:
 		from glob import glob
 		try:
-			driver = [x.split("-")[-2:-1][0][-8:] for x in open(glob("/var/lib/opkg/info/*-dvb-modules-*.control")[0], "r") if x.startswith("Version:")][0]
+			driver = [x.split("-")[-2:-1][0][-9:] for x in open(glob("/var/lib/opkg/info/*-dvb-modules-*.control")[0], "r") if x.startswith("Version:")][0]
 			return  "%s-%s-%s" % (driver[:4], driver[4:6], driver[6:])
 		except:
 			driver = [x.split("Version:") for x in open(glob("/var/lib/opkg/info/*-dvb-proxy-*.control")[0], "r") if x.startswith("Version:")][0]


### PR DESCRIPTION
Since dreambox has added an 'a' to the driver date and it's possible others would follow, the driver date is shown as '0140-60-4a' instead of '2014-06-04a' in about screen of enigma2.
Tell "About.py" to use nine characters instead of eight to get rid of that bizarre driver date.
Fix by Hains