### PR TITLE
[ChannelSelection] add sham getMutableList for SimpleChannelSelection

### DIFF
--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -2571,3 +2571,6 @@ class SimpleChannelSelection(ChannelSelectionBase, SelectionEventInfo):
 	def setModeRadio(self):
 		self.setRadioMode()
 		self.showFavourites()
+
+	def getMutableList(self, root=None):
+		return None


### PR DESCRIPTION
File "/usr/lib/enigma2/python/Screens/ChannelSelection.py", line 1686,
in keyRight
    self.changeBouquet(+1)
  File
"/usr/lib/enigma2/python/Screens/ChannelSelection.py", line 1644, in
changeBouquet
    if ref.flags & eServiceReference.flagDirectory and not
self.getMutableList() or
Components.ParentalControl.parentalControl.isServicePlayable(ref,
self.changeBouquetParentalControlCallback,
self.session):
AttributeError: 'SimpleChannelSelection' object has no
attribute 'getMutableList'