### PR TITLE
[Autodiseqc] Change 28.2 tuning parameters

### DIFF
--- a/lib/python/Screens/AutoDiseqc.py
+++ b/lib/python/Screens/AutoDiseqc.py
@@ -40,13 +40,13 @@ class AutoDiseqc(Screen, ConfigListScreen):
 		eDVBFrontendParametersSatellite.RollOff_auto, eDVBFrontendParametersSatellite.Pilot_Unknown, \
 		-1, 0, 1, 3224, 3, "Astra 3 23.5e"),
 
-		# astra 282 bbc
-		( 10773, 22000, \
+		# astra 282 EPG background audio
+		( 11778, 27500, \
 		eDVBFrontendParametersSatellite.Polarisation_Horizontal, eDVBFrontendParametersSatellite.FEC_5_6, \
 		eDVBFrontendParametersSatellite.Inversion_Off, 282, \
 		eDVBFrontendParametersSatellite.System_DVB_S, eDVBFrontendParametersSatellite.Modulation_Auto, \
 		eDVBFrontendParametersSatellite.RollOff_auto, eDVBFrontendParametersSatellite.Pilot_Unknown, \
-		-1, 0, 1, 2045, 2, "Astra 2 28.2e"),
+		-1, 0, 1, 2004, 2, "Astra 2 28.2e"),
 
 		# hotbird 130 rai
 		( 10992, 27500, \


### PR DESCRIPTION
All Sky receivers use this frequency for gathering EPG/channel lists
The Sky frequency is receivable in more areas of Europe than the BBC spot beam