### PR TITLE
[HdmiCec] always init "Use TV remote control" wnen load box

### DIFF
--- a/lib/python/Components/HdmiCec.py
+++ b/lib/python/Components/HdmiCec.py
@@ -115,8 +115,13 @@ class HdmiCec:
 		eActionMap.getInstance().bindAction('', -maxint - 1, self.keyEvent)
 		config.hdmicec.volume_forwarding.addNotifier(self.configVolumeForwarding)
 		config.hdmicec.enabled.addNotifier(self.configVolumeForwarding)
-		if config.hdmicec.enabled.value and config.hdmicec.handle_deepstandby_events.value and not getFPWasTimerWakeup():
-			self.onLeaveStandby()
+		if config.hdmicec.enabled.value:
+			if config.hdmicec.report_active_menu.value:
+				if config.hdmicec.report_active_source.value:
+					self.sendMessage(0, "sourceinactive")
+				self.sendMessage(0, "menuactive")
+			if config.hdmicec.handle_deepstandby_events.value and not getFPWasTimerWakeup():
+				self.onLeaveStandby()
 
 	def getPhysicalAddress(self):
 		physicaladdress = eHdmiCEC.getInstance().getPhysicalAddress()

--- a/lib/python/Components/HdmiCec.py
+++ b/lib/python/Components/HdmiCec.py
@@ -2,6 +2,7 @@ import struct, os, time
 from config import config, ConfigSelection, ConfigYesNo, ConfigSubsection, ConfigText, ConfigCECAddress, ConfigLocations, ConfigDirectory
 from enigma import eHdmiCEC, eActionMap
 from Tools.StbHardware import getFPWasTimerWakeup
+import NavigationInstance
 from enigma import eTimer
 from sys import maxint
 
@@ -117,7 +118,7 @@ class HdmiCec:
 		config.hdmicec.enabled.addNotifier(self.configVolumeForwarding)
 		if config.hdmicec.enabled.value:
 			if config.hdmicec.report_active_menu.value:
-				if config.hdmicec.report_active_source.value:
+				if config.hdmicec.report_active_source.value and NavigationInstance.instance and not NavigationInstance.instance.isRestartUI():
 					self.sendMessage(0, "sourceinactive")
 				self.sendMessage(0, "menuactive")
 			if config.hdmicec.handle_deepstandby_events.value and not getFPWasTimerWakeup():


### PR DESCRIPTION
TV remote control always active if load box and this solve problem some
tv and receivers, e.g. Samsung+HD51