### PR TITLE
[Renderer/Listbox] solve negative value  attrib if update list

### DIFF
--- a/lib/python/Components/Renderer/Listbox.py
+++ b/lib/python/Components/Renderer/Listbox.py
@@ -96,6 +96,8 @@ class Listbox(Renderer, object):
 			self.scrollbarMode = self.source.scrollbarMode
 		if len(what) > 1 and isinstance(what[1], str) and what[1] == "style":
 			return
+		if self.content:
+			return
 		self.content = self.source.content
 
 	def entry_changed(self, index):


### PR DESCRIPTION
When use widget ...render="Listbox"  itemHeight=...
and setList twice, itemHeight reset to default.
When changed not update self.content,if it already exists.
Instead, use it def contentChanged, if you need to update self.content