### PR TITLE
Transponder.py: Rename a variable

### DIFF
--- a/lib/python/Tools/Transponder.py
+++ b/lib/python/Tools/Transponder.py
@@ -57,11 +57,11 @@ def channel2frequency(channel, nim):
 			return (474000 + 8000*(channel-21))*1000
 	return 474000000
 
-def ConvertToHumanReadable(tp, type = None):
+def ConvertToHumanReadable(tp, tunertype = None):
 	ret = { }
-	if type is None:
-		type = tp.get("tuner_type", "None")
-	if type == "DVB-S":
+	if tunertype is None:
+		tunertype = tp.get("tuner_type", "None")
+	if tunertype == "DVB-S":
 		ret["tuner_type"] = _("Satellite")
 		ret["inversion"] = {
 			eDVBFrontendParametersSatellite.Inversion_Unknown : _("Auto"),
@@ -121,7 +121,7 @@ def ConvertToHumanReadable(tp, type = None):
 			ret["pls_mode"] = None
 			ret["is_id"] = None
 			ret["pls_code"] = None
-	elif type == "DVB-C":
+	elif tunertype == "DVB-C":
 		ret["tuner_type"] = _("Cable")
 		ret["modulation"] = {
 			eDVBFrontendParametersCable.Modulation_Auto: _("Auto"),
@@ -149,7 +149,7 @@ def ConvertToHumanReadable(tp, type = None):
 		ret["system"] = {
 			eDVBFrontendParametersCable.System_DVB_C_ANNEX_A : "DVB-C",
 			eDVBFrontendParametersCable.System_DVB_C_ANNEX_C : "DVB-C ANNEX C"}.get(tp.get("system"))
-	elif type == "DVB-T":
+	elif tunertype == "DVB-T":
 		ret["tuner_type"] = _("Terrestrial")
 		ret["bandwidth"] = {
 			0 : _("Auto"),
@@ -215,7 +215,7 @@ def ConvertToHumanReadable(tp, type = None):
 			eDVBFrontendParametersTerrestrial.System_DVB_T : "DVB-T",
 			eDVBFrontendParametersTerrestrial.System_DVB_T2 : "DVB-T2"}.get(tp.get("system"))
 		ret["channel"] = _("CH%s") % getChannelNumber(tp.get("frequency"), "DVB-T")
-	elif type == "ATSC":
+	elif tunertype == "ATSC":
 		ret["tuner_type"] = "ATSC"
 		ret["modulation"] = {
 			eDVBFrontendParametersATSC.Modulation_Auto: _("Auto"),
@@ -233,8 +233,8 @@ def ConvertToHumanReadable(tp, type = None):
 		ret["system"] = {
 			eDVBFrontendParametersATSC.System_ATSC : "ATSC",
 			eDVBFrontendParametersATSC.System_DVB_C_ANNEX_B : "DVB-C ANNEX B"}.get(tp.get("system"))
-	elif type != "None":
-		print "ConvertToHumanReadable: no or unknown type in tpdata dict for type:", type
+	elif tunertype != "None":
+		print "ConvertToHumanReadable: no or unknown tunertype in tpdata dict for tunertype:", type
 	for k,v in tp.items():
 		if k not in ret:
 			ret[k] = v


### PR DESCRIPTION
"type" should be considered a reserved word as it is a built in Python function.