### PR TITLE
frontend.cpp: BCM45208 FBC tuner SNR info fix

### DIFF
--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -1059,7 +1059,7 @@ void eDVBFrontend::calculateSignalQuality(int snr, int &signalquality, int &sign
 	{
 		ret = (snr * 240) >> 8;
 	}
-	else if (strstr(m_description, "BCM4506") || strstr(m_description, "BCM4505"))
+	else if (strstr(m_description, "BCM4506") || strstr(m_description, "BCM4505") || strstr(m_description, "BCM45208"))
 	{
 		ret = (snr * 100) >> 8;
 	}


### PR DESCRIPTION
It won't bite if we support more hardwares but not box related stuff.