### PR TITLE
InputDevice: use correct IOC_SIZEBITS for non mips arch

### DIFF
--- a/lib/python/Components/InputDevice.py
+++ b/lib/python/Components/InputDevice.py
@@ -3,12 +3,13 @@ from SystemInfo import SystemInfo
 from fcntl import ioctl
 import os
 import struct
+import platform
 
-# asm-generic/ioctl.h
+# include/uapi/asm-generic/ioctl.h
 IOC_NRBITS = 8L
 IOC_TYPEBITS = 8L
-IOC_SIZEBITS = 13L
-IOC_DIRBITS = 3L
+IOC_SIZEBITS = 13L if "mips" in platform.machine() else 14L
+IOC_DIRBITS = 3L if "mips" in platform.machine() else 2L
 
 IOC_NRSHIFT = 0L
 IOC_TYPESHIFT = IOC_NRSHIFT+IOC_NRBITS


### PR DESCRIPTION
Hardcoding the IOC_SIZEBITS is very bad because arch can override that value.
Use 13 for mips or the default 14.

Most probably it is be better to export that function from enigma2 to python.
So python will not have to "guess" the right values.

Above fixes the following error on arm:
[iInputDevices] getInputDevices event0 <ERROR: ioctl(EVIOCGNAME): [Errno 22] Invalid argument >