### PR TITLE
ioprio: include syscall.h for SYS_ioprio_get/set

### DIFF
--- a/lib/base/ioprio.cpp
+++ b/lib/base/ioprio.cpp
@@ -2,55 +2,20 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <getopt.h>
 #include <unistd.h>
-#include <sys/ptrace.h>
-#include <asm/unistd.h>
+#include <sys/syscall.h>
 
 #include <lib/base/eerror.h>
 
-extern "C" int sys_ioprio_set(int, int, int);
-extern "C" int sys_ioprio_get(int, int);
-
-#ifndef __NR_ioprio_set
-#if defined(__i386__)
-#define __NR_ioprio_set		289
-#define __NR_ioprio_get		290
-#elif defined(__ppc__) || defined(__powerpc__)
-#define __NR_ioprio_set		273
-#define __NR_ioprio_get		274
-#elif defined(__x86_64__)
-#define __NR_ioprio_set		251
-#define __NR_ioprio_get		252
-#elif defined(__ia64__)
-#define __NR_ioprio_set		1274
-#define __NR_ioprio_get		1275
-#elif defined(__mips__)
-#define __NR_ioprio_set		4284
-#define __NR_ioprio_get		4285
-#else
-#error "Unsupported arch"
-#endif
-#endif
-
-#if defined(_syscall3) && defined(_syscall2)
-
-_syscall3(int, ioprio_set, int, which, int, who, int, ioprio);
-_syscall2(int, ioprio_get, int, which, int, who);
-
-#else
-
 static inline int ioprio_set(int which, int who, int ioprio)
 {
-	return syscall(__NR_ioprio_set, which, who, ioprio);
+	return syscall(SYS_ioprio_set, which, who, ioprio);
 }
 
 static inline int ioprio_get(int which, int who)
 {
-	return syscall(__NR_ioprio_get, which, who);
+	return syscall(SYS_ioprio_get, which, who);
 }
-
-#endif
 
 #define IOPRIO_CLASS_SHIFT	13
 


### PR DESCRIPTION
The sys/syscall.h header contains the required SYS_ioprio_get and SYS_ioprio_set values.
So we don't need to define them manually.

The same approach is used also now in ionice: https://github.com/karelzak/util-linux/blob/master/schedutils/ionice.c

Also remove unused includes getopt.h, sys/ptrace.h and asm/unistd.h