### PR TITLE
[vurero4k] hack for strange driver wait for vu driver fixes

### DIFF
--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -782,6 +782,8 @@ class NimManager:
 				entries[current_slot] = {}
 			elif line.startswith("Type:"):
 				entries[current_slot]["type"] = str(line[6:])
+				if entries[current_slot]["type"] == "DVB-S2X":
+					entries[current_slot]["type"] = "DVB-S2"
 				entries[current_slot]["isempty"] = False
 			elif line.startswith("Name:"):
 				entries[current_slot]["name"] = str(line[6:])


### PR DESCRIPTION
root@vuzero4k:~# dvb-fe-tool
Device Vuplus FE (/dev/dvb/adapter0/frontend0) capabilities:
     CAN_FEC_1_2
     CAN_FEC_2_3
     CAN_FEC_3_4
     CAN_FEC_5_6
     CAN_FEC_7_8
     CAN_FEC_AUTO
     CAN_INVERSION_AUTO
     CAN_QPSK
     CAN_RECOVER
DVB API Version 5.10, Current v5 delivery system: DVBS
Supported delivery systems:
    [DVBS]
     DVBS2
     (null)
DiSEqC VOLTAGE: OFF
ERROR    FE_SET_VOLTAGE: Operation not permitted
root@vuzero4k:~# cat /proc/bus/nim_sockets
NIM Socket 0:
        Type: DVB-S2X
        Name: Vuplus DVB-S NIM(SI2166)
        Frontend_Device: 0
        I2C_Device: 2