### PR TITLE
[dvbtime] More stable time-keeping

### DIFF
--- a/lib/dvb/dvbtime.cpp
+++ b/lib/dvb/dvbtime.cpp
@@ -393,13 +393,32 @@ void eDVBLocalTimeHandler::updateTime( time_t tp_time, eDVBChannel *chan, int up
 					now.tm_sec);
 				time_difference = rtc_time - linuxTime;
 				eDebug("[eDVBLocalTimerHandler] RTC to Receiver time difference is %ld seconds", linuxTime - rtc_time );
-				if ( time_difference )
-				{
-					eDebug("[eDVBLocalTimerHandler] set Linux Time to RTC Time");
-					timeval tnow;
-					gettimeofday(&tnow,0);
-					tnow.tv_sec=rtc_time;
-					settimeofday(&tnow,0);
+				if ( time_difference ) {
+					if ( (time_difference >= -15) && (time_difference <= 15) ) {
+						// Slew small diffs ...
+						// Even good transponders can differ by 0-5 sec, if we would step these
+						// the system clock would permanentely jump around when zapping.
+						timeval tdelta, tolddelta;
+						tdelta.tv_sec=time_difference;
+						int rc=adjtime(&tdelta,&tolddelta);
+						if(rc==0) {
+							eDebug("[eDVBLocalTimerHandler] slewing Linux Time by %03d seconds", time_difference);
+						} else {
+							eDebug("[eDVBLocalTimerHandler] slewing Linux Time by %03d seconds FAILED", time_difference);
+						}
+					} else {
+						// ... only step larger diffs
+						timeval tnow;
+						gettimeofday(&tnow,0);
+						tnow.tv_sec=t;
+						settimeofday(&tnow,0);
+						linuxTime=time(0);
+						localtime_r(&linuxTime, &now);
+						eDebug("[eDVBLocalTimerHandler] stepped Linux Time to %02d:%02d:%02d",
+						now.tm_hour,
+						now.tm_min,
+						now.tm_sec);
+					}
 				}
 				else if ( !time_difference )
 					eDebug("[eDVBLocalTimerHandler] no change needed");


### PR DESCRIPTION
Slew small time diffs (Up to 15sec) rather than stepping them.

Tiny diffs (1-5sec) are normal even between good transponders, so permanent stepping would only make the system time jump around.
The clock jumping around by few seconds adds absolutely no value when it comes to accuracy but can ruin conditional access.

Slewing the system clock takes ages though (About 5sec correction in 3h), so it can not be used for large diffs.

Slewing small diffs and stepping only large ones reproduces the behaviour of ntpd/ntpdate.
This commit should remove the reason why oscam added the so-called CLOCKFIX (Which simply reverts all time changes in E2 by setting the last known time again), so preferably build oscam WITHOUT clockfix now.