### PR TITLE
[Harddisk] fixed  crash  when show hdd free state

### DIFF
--- a/lib/python/Components/Harddisk.py
+++ b/lib/python/Components/Harddisk.py
@@ -186,8 +186,11 @@ class Harddisk:
 	def free(self):
 		dev = self.findMount()
 		if dev:
-			stat = os.statvfs(dev)
-			return (stat.f_bfree/1000) * (stat.f_bsize/1024)
+			try:
+				stat = os.statvfs(dev)
+				return (stat.f_bfree/1000) * (stat.f_bsize/1024)
+			except:
+				pass
 		return -1
 
 	def numPartitions(self):


### PR DESCRIPTION
When umount device manualy and open menu About:
File "/usr/lib/enigma2/python/Screens/About.py", line 94, in __init__
File "/usr/lib/enigma2/python/Components/Harddisk.py", line 189, in free
OSError: [Errno 2] No such file or directory: '/media/usb'