### PR TITLE
pmt: fix HbbTV url when AIT descriptor order is not the expected one

### DIFF
--- a/lib/dvb/pmt.cpp
+++ b/lib/dvb/pmt.cpp
@@ -282,9 +282,9 @@ void eDVBServicePMTHandler::AITready(int error)
 							{
 								if ((*i)->getApplicationControlCode() == 0x01) /* AUTOSTART */
 								{
-									m_HBBTVUrl = (*interactionit)->getUrlBase()->getUrl();
+									m_HBBTVUrl.insert(0, (*interactionit)->getUrlBase()->getUrl());
 								}
-								aitinfo.url = (*interactionit)->getUrlBase()->getUrl();
+								aitinfo.url.insert(0, (*interactionit)->getUrlBase()->getUrl());
 								break;
 							}
 							break;
@@ -301,7 +301,6 @@ void eDVBServicePMTHandler::AITready(int error)
 							m_HBBTVUrl += applicationlocation->getInitialPath();
 						}
 						aitinfo.url += applicationlocation->getInitialPath();
-						m_aitInfoList.push_back(aitinfo);
 						break;
 					}
 					case APPLICATION_USAGE_DESCRIPTOR:
@@ -310,6 +309,7 @@ void eDVBServicePMTHandler::AITready(int error)
 						break;
 					}
 				}
+				m_aitInfoList.push_back(aitinfo);
 			}
 		}
 		if (!m_HBBTVUrl.empty())


### PR DESCRIPTION
When SIMPLE_APPLICATION_LOCATION_DESCRIPTOR is found before the TRANSPORT_PROTOCOL_DESCRIPTOR
then HbbTV url was set only to TRANSPORT_PROTOCOL_DESCRIPTOR loosing changes from SIMPLE_APPLICATION_LOCATION_DESCRIPTOR.

Now when TRANSPORT_PROTOCOL_DESCRIPTOR is found we are inserting url in front. So at the end of the loop we have
the right HbbTV url including the SIMPLE_APPLICATION_LOCATION_DESCRIPTOR.

Also push to m_aitInfoList when going out of loop, for the same reason. We cannot expect that order will be always
TRANSPORT_PROTOCOL_DESCRIPTOR followed by SIMPLE_APPLICATION_LOCATION_DESCRIPTOR.

This commit fixes the HbbTV url creation on ERT DIGEA HbbTV.

Credits: VU+ http://code.vuplus.com/gitweb/?p=vuplus_dvbapp;a=blobdiff;f=lib/dvb/pmt.cpp;h=ded43a03a64861d3b384f1160f0c53a439501cfd;hp=fbd9b8f815285b0f8f8ebc6e3dd16812007433a9;hb=097eb7b26bdc1fc761a745b71bfab29e076856c0;hpb=c1bbfb59b91856990845e3092380dc2a0b1da257