### PR TITLE
[servicedvb] fix automatic subtitles logic for cache sub

### DIFF
--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -3251,7 +3251,7 @@ RESULT eDVBServicePlay::getCachedSubtitle(struct SubtitleTrack &track)
 					return 0;
 				}
 			}
-			if (stream != -1 && (tmp != 0 || !usecache))
+			if (stream != -1 && (tmp != 0 && usecache))
 			{
 				if (program.subtitleStreams[stream].subtitling_type == 1)
 				{


### PR DESCRIPTION
When "Prefer subtitles stored by service" disabled not show stored cache
subtitles for current service