### PR TITLE
Fix "HotkeySetupSelect" yellow button not showing

### DIFF
--- a/lib/python/Screens/Hotkey.py
+++ b/lib/python/Screens/Hotkey.py
@@ -343,7 +343,7 @@ class HotkeySetupSelect(Screen):
 					self.selected.append(ChoiceEntryComponent('',((function[0][0]), function[0][1])))
 		self.prevselected = self.selected[:]
 		if self.prevselected:
-			self.yellow = StaticText(_("Edit selection"))
+			self.yellowButton(_("Edit selection"))
 		self["choosen"] = ChoiceList(list=self.selected, selection=0)
 		self["list"] = ChoiceList(list=self.getFunctionList(), selection=0)
 		self["actions"] = ActionMap(["OkCancelActions", "ColorActions", "DirectionActions", "KeyboardInputActions", "MenuActions"],


### PR DESCRIPTION
On commit https://github.com/OpenPLi/enigma2/commit/5e89e8a5cd7ead533b8b6f9bab800ae14e9d0dcc line 346 was changed by mistake. It should have been left as it was before. This restores it to the previous correct state.