### PR TITLE
Add screen title to "ChannelContextMenu" class

### DIFF
--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -118,6 +118,7 @@ class ChannelContextMenu(Screen):
 	def __init__(self, session, csel):
 
 		Screen.__init__(self, session)
+		self.setTitle(_("Channel context menu"))
 		self.csel = csel
 		self.bsel = None
 		if self.isProtected():


### PR DESCRIPTION
This screen doesn't have any title. It would be nice to have one like almost all other screens have.