### PR TITLE
[HdmiCec] wake up TV when "Enable wakeup timer"  is yes

### DIFF
--- a/lib/python/Components/HdmiCec.py
+++ b/lib/python/Components/HdmiCec.py
@@ -121,7 +121,7 @@ class HdmiCec:
 				if config.hdmicec.report_active_source.value and NavigationInstance.instance and not NavigationInstance.instance.isRestartUI():
 					self.sendMessage(0, "sourceinactive")
 				self.sendMessage(0, "menuactive")
-			if config.hdmicec.handle_deepstandby_events.value and not getFPWasTimerWakeup():
+			if config.hdmicec.handle_deepstandby_events.value and (not getFPWasTimerWakeup() or (config.usage.startup_to_standby.value == "no" and config.misc.prev_wakeup_time_type.value == 3)):
 				self.onLeaveStandby()
 
 	def getPhysicalAddress(self):


### PR DESCRIPTION
"Enable wakeup timer"  is yes and "Startup to Standby" is no and
HdmiCec/"Regard deep standby as standby" is yes run HdmiCec wakeup
messages.