### PR TITLE
Remove obsolete properties from "ScanSetup", "ScanSimple" and "Satfinder" screens

### DIFF
--- a/data/skin_default.xml
+++ b/data/skin_default.xml
@@ -961,11 +961,11 @@ self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth)/2, orgpos.y() + (or
 		<widget name="RassLogo" pixmap="skin_default/icons/rass_logo.png" position="50,445" size="50,21"/>
 	</screen>
 	<!-- Satfinder -->
-	<screen name="Satfinder" position="center,center" size="520,450" title="Satfinder">
+	<screen name="Satfinder" position="center,center" size="520,450" title="Signal finder">
 		<ePixmap pixmap="skin_default/buttons/red.png" position="0,0" size="140,40" alphatest="on"/>
 		<ePixmap pixmap="skin_default/buttons/green.png" position="140,0" size="140,40" alphatest="on"/>
-		<eLabel text="Cancel" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1"/>
-		<eLabel text="Scan" position="140,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" transparent="1"/>
+		<widget source="key_red" render="Label" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1"/>
+		<widget source="key_green" render="Label" position="140,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" transparent="1"/>
 		<widget name="introduction" position="0,0" size="0,0" font="Regular;23"/>
 
 		<ePixmap pixmap="skin_default/icons/dish_scan.png" position="5,75" zPosition="0" size="119,110" transparent="1" alphatest="on"/>
@@ -1002,8 +1002,8 @@ self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth)/2, orgpos.y() + (or
 	<screen name="ScanSetup" position="center,center" size="520,450" title="Manual scan">
 		<ePixmap pixmap="skin_default/buttons/red.png" position="0,0" size="140,40" alphatest="on"/>
 		<ePixmap pixmap="skin_default/buttons/green.png" position="140,0" size="140,40" alphatest="on"/>
-		<eLabel text="Cancel" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1"/>
-		<eLabel text="Scan" position="140,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" transparent="1"/>
+		<widget source="key_red" render="Label" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1"/>
+		<widget source="key_green" render="Label" position="140,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" transparent="1"/>
 
 		<widget name="config" position="10,50" size="500,400" scrollbarMode="showOnDemand"/>
 		<widget name="introduction" position="0,0" size="0,0"/>
@@ -1012,10 +1012,9 @@ self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth)/2, orgpos.y() + (or
 	<screen name="ScanSimple" position="center,center" size="420,350" title="Automatic scan">
 		<ePixmap pixmap="skin_default/buttons/red.png" position="0,0" size="140,40" alphatest="on"/>
 		<ePixmap pixmap="skin_default/buttons/green.png" position="140,0" size="140,40" alphatest="on"/>
-		<eLabel text="Cancel" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1"/>
-		<eLabel text="Scan" position="140,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" transparent="1"/>
+		<widget source="key_red" render="Label" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1"/>
+		<widget source="key_green" render="Label" position="140,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" transparent="1"/>
 
-		<widget name="header" position="0,0" size="0,0" font="Regular;23"/>
 		<widget name="config" position="10,50" size="400,300" scrollbarMode="showOnDemand"/>
 		<widget name="footer" position="0,0" size="0,0"/>
 	</screen>

--- a/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
@@ -7,7 +7,6 @@ from Plugins.Plugin import PluginDescriptor
 
 from Components.Sources.FrontendStatus import FrontendStatus
 from Components.ActionMap import ActionMap
-from Components.Label import Label
 from Components.NimManager import nimmanager, getConfigSatlist
 from Components.config import config, ConfigSelection, getConfigListEntry
 from Components.TuneTest import Tuner
@@ -15,6 +14,8 @@ from Tools.Transponder import getChannelNumber, channel2frequency
 from Tools.BoundFunction import boundFunction
 
 class Satfinder(ScanSetup, ServiceScan):
+	"""Inherits StaticText [key_red] and [key_green] properties from ScanSetup"""
+
 	def __init__(self, session):
 		self.initcomplete = False
 		service = session and session.nav.getCurrentService()
@@ -41,7 +42,6 @@ class Satfinder(ScanSetup, ServiceScan):
 		ScanSetup.__init__(self, session)
 		self.setTitle(_("Signal finder"))
 		self["Frontend"] = FrontendStatus(frontend_source = lambda : self.frontend, update_interval = 100)
-		self["key_red"] = Label(_("Exit"))
 
 		self["actions"] = ActionMap(["SetupActions", "ColorActions"],
 		{

--- a/lib/python/Screens/ScanSetup.py
+++ b/lib/python/Screens/ScanSetup.py
@@ -624,9 +624,9 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 		ConfigListScreen.__init__(self, self.list)
 		if not self.scan_nims.value == "":
 			self.createSetup()
-			self["introduction"] = Label(_("Press OK to start the scan"))
+			self["introduction"] = Label(_("Press OK to scan"))
 		else:
-			self["introduction"] = Label(_("Nothing to scan!\nPlease setup your tuner settings before you start a service scan."))
+			self["introduction"] = Label(_("Nothing to scan! Setup your tuner and try again."))
 
 	def runAsync(self, finished_cb):
 		self.finished_cb = finished_cb

--- a/lib/python/Screens/ScanSetup.py
+++ b/lib/python/Screens/ScanSetup.py
@@ -622,7 +622,6 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 
 		self.list = []
 		ConfigListScreen.__init__(self, self.list)
-		self["header"] = Label(_("Manual Scan"))
 		if not self.scan_nims.value == "":
 			self.createSetup()
 			self["introduction"] = Label(_("Press OK to start the scan"))
@@ -1731,7 +1730,6 @@ class ScanSimple(ConfigListScreen, Screen, CableTransponderSearchSupport, Terres
 				self.list.append(getConfigListEntry(_("Scan ") + nim.slot_name + " (" + nim.friendly_type + ")", nimconfig))
 
 		ConfigListScreen.__init__(self, self.list)
-		self["header"] = Label(_("Automatic scan"))
 		self["footer"] = Label(_("Press OK to scan"))
 
 	def runAsync(self, finished_cb):


### PR DESCRIPTION
This pull request follows commit https://github.com/OpenPLi/enigma2/commit/780e140bf55ade23f0440dad4fed6228b45bb2e4 and https://github.com/OpenPLi/enigma2/commit/2cff31dd25629bf89134e71afc70d395a421fcfb and the **comments** made on both of these.

Class "**ScanSetup**" has `self["header"] = Label(_("Manual Scan"))` which is the same as its screen title.
Class "**ScanSimple**" has `self["header"] = Label(_("Automatic scan"))` which is the same as its screen title.

These "header" elements are now removed, as they have no purpose being present. They don't offer anything. It's just the same text as in the screen title for both screens.

Also, by design, the "**Satfinder**" plugin, inherits all properties of the "ScanSetup" class, which among others are:

`self["key_red"] = StaticText(_("Close"))`
`self["key_green"] = StaticText(_("Scan"))`

and the above mentioned `self["header"] = Label(_("Manual Scan"))` which is now gone.

In addition, the plugin defines `self["key_red"]` and `self["key_green"]` buttons again!

Previous commits, removed the `self["key_green"]`, but left `self["key_red"]` untouched. So I removed it this pull request.

I also took it one step further to improve a few text messages and update the default skin.

**To summarize, I removed only double and obsolete labels from these 3 screens. I didn't add anything new and I didn't change existing elements. No skin is broken with this pull request.**
