### PR TITLE
Removes unnecessary functions in TextBox

### DIFF
--- a/lib/python/Screens/TextBox.py
+++ b/lib/python/Screens/TextBox.py
@@ -12,17 +12,11 @@ class TextBox(Screen):
 
 		self["actions"] = ActionMap(["OkCancelActions", "DirectionActions"],
 				{
-					"cancel": self.cancel,
-					"ok": self.ok,
+					"cancel": self.close,
+					"ok": self.close,
 					"up": self["text"].pageUp,
 					"down": self["text"].pageDown,
 				}, -1)
 
 		if title:
 			self.setTitle(title)
-
-	def ok(self):
-		self.close()
-
-	def cancel(self):
-		self.close()


### PR DESCRIPTION
Why for the close use separate functions ok and cancel if we can use close directly in ActionMap.