### PR TITLE
[ConfigList] Show/hide HelpWindow correctly

### DIFF
--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -166,6 +166,8 @@ class ConfigListScreen:
 		if not self.handleInputHelpers in self["config"].onSelectionChanged:
 			self["config"].onSelectionChanged.append(self.handleInputHelpers)
 
+		self.onClose.append(self.HideHelp)
+
 	def createSummary(self):
 		self.setup_title = self.getTitle()
 		from Screens.Setup import SetupSummary
@@ -205,13 +207,31 @@ class ConfigListScreen:
 				self["VKeyIcon"].boolean = False
 
 	def KeyText(self):
+		self.HideHelp()
 		from Screens.VirtualKeyBoard import VirtualKeyBoard
 		self.session.openWithCallback(self.VirtualKeyBoardCallback, VirtualKeyBoard, title = self["config"].getCurrent()[0], text = self["config"].getCurrent()[1].getValue())
+
+	def HideHelp(self):
+		try:
+			if isinstance(self["config"].getCurrent()[1], ConfigText) or isinstance(self["config"].getCurrent()[1], ConfigPassword):
+				if self["config"].getCurrent()[1].help_window.instance is not None:
+					self["config"].getCurrent()[1].help_window.hide()
+		except:
+			pass
+
+	def ShowHelp(self):
+		try:
+			if isinstance(self["config"].getCurrent()[1], ConfigText) or isinstance(self["config"].getCurrent()[1], ConfigPassword):
+				if self["config"].getCurrent()[1].help_window.instance is not None:
+					self["config"].getCurrent()[1].help_window.show()
+		except:
+			pass
 
 	def VirtualKeyBoardCallback(self, callback = None):
 		if callback is not None and len(callback):
 			self["config"].getCurrent()[1].setValue(callback)
 			self["config"].invalidate(self["config"].getCurrent())
+		self.ShowHelp()
 
 	def keyOK(self):
 		self["config"].handleKey(KEY_OK)
@@ -284,6 +304,7 @@ class ConfigListScreen:
 
 	def cancelConfirm(self, result):
 		if not result:
+			self.ShowHelp()
 			return
 
 		for x in self["config"].list:
@@ -292,6 +313,7 @@ class ConfigListScreen:
 
 	def closeMenuList(self, recursive = False):
 		if self["config"].isChanged():
+			self.HideHelp()
 			self.session.openWithCallback(self.cancelConfirm, MessageBox, _("Really close without saving settings?"))
 		else:
 			self.close(recursive)


### PR DESCRIPTION
For example, the HelpWindow showed at the same time as the MessageBox ("Really close without saving settings?"), as well as other similar cases.