### PR TITLE
[Setup.py] Improve getSetupTitle

### DIFF
--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -150,6 +150,8 @@ def getSetupTitle(id):
 	for x in xmldata.findall("setup"):
 		if x.get("key") == id:
 			title = x.get("title", "Settings").encode("UTF-8")
+			if title == "":
+				title = "** Setup error: '%s' title is blank!" % id
 	if title == "":
 		print "[Setup] Error: Setup ID '%s' not found in setup file!" % id
 		title = "** Setup error: '%s' section not found! **" % id

--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -27,12 +27,6 @@ def getConfigMenuItem(configElement):
 			return _(item.attrib["text"]), eval(configElement)
 	return "", None
 
-class SetupError(Exception):
-	def __init__(self, message):
-		self.msg = message
-
-	def __str__(self):
-		return self.msg
 
 class SetupSummary(Screen):
 
@@ -151,7 +145,12 @@ class Setup(ConfigListScreen, Screen):
 
 def getSetupTitle(id):
 	xmldata = setupdom.getroot()
+	id = str(id)
+	title = ""
 	for x in xmldata.findall("setup"):
 		if x.get("key") == id:
-			return x.get("title", "").encode("UTF-8")
-	raise SetupError("unknown setup id '%s'!" % repr(id))
+			title = x.get("title", "Settings").encode("UTF-8")
+	if title == "":
+		print "[Setup] Error: Setup ID '%s' not found in setup file!" % id
+		title = "** Setup error: '%s' section not found! **" % id
+	return _(title)


### PR DESCRIPTION
This change eliminates the forced crash if a setup menu id is not found in the setup.xml file.  This sort of error should be identified during development and not reach production code.  Forcing a crash is unnecessary and anti-social.  The crash could have nasty side effects like stopping running recordings.  Instead of the crash an error condition is logged and the user is provided with a dummy menu item indicating that this menu item is unavailable.  The error contains the ID tag so that the issue can be reported to developers for correction.

The title returned is now translated to the local language.

To test the change edit setup.xml and change the "key=" attribute for an item in a Setup based menu.  Before the code change loading the menu containing this menu item will force a crash of the GUI.  After the code change an error will be logged and the menu will be displayed but the menu item that can't be found will be shown as an error message.  (It is not fatal to select this menu item.  If selected a blank Setup screen will be shown.)
