### PR TITLE
Add PyLong_FromUnsignedLongLong ePyObject wrapper

### DIFF
--- a/lib/python/python.h
+++ b/lib/python/python.h
@@ -266,6 +266,10 @@ inline ePyObject Impl_PyLong_FromLongLong(const char* file, int line, long long 
 {
 	return ePyObject(PyLong_FromLongLong(val), file, line);
 }
+inline ePyObject Impl_PyLong_FromUnsignedLongLong(const char* file, int line, unsigned long long val)
+{
+	return ePyObject(PyLong_FromUnsignedLongLong(val), file, line);
+}
 
 inline ePyObject Impl_PyList_GET_ITEM(const char *file, int line, ePyObject list, unsigned int pos)
 {
@@ -347,6 +351,10 @@ inline ePyObject Impl_PyLong_FromLongLong(long long val)
 {
 	return PyLong_FromLongLong(val);
 }
+inline ePyObject Impl_PyLong_FromUnsignedLongLong(unsigned long long val)
+{
+	return PyLong_FromUnsignedLongLong(val);
+}
 
 inline ePyObject Impl_PyList_GET_ITEM(ePyObject list, unsigned int pos)
 {
@@ -390,6 +398,7 @@ inline void Impl_DECREF(PyObject *ob)
 #define PyLong_FromLong(val) Impl_PyLong_FromLong(__FILE__, __LINE__, val)
 #define PyLong_FromUnsignedLong(val) Impl_PyLong_FromUnsignedLong(__FILE__, __LINE__, val)
 #define PyLong_FromLongLong(val) Impl_PyLong_FromLongLong(__FILE__, __LINE__, val)
+#define PyLong_FromUnsignedLongLong(val) Impl_PyLongFromUnsignedLongLong(__FILE__, __LINE__, val)
 #define PyList_GET_ITEM(list, pos) Impl_PyList_GET_ITEM(__FILE__, __LINE__, list, pos)
 #define PyTuple_GET_ITEM(list, pos) Impl_PyTuple_GET_ITEM(__FILE__, __LINE__, list, pos)
 #else
@@ -406,6 +415,7 @@ inline void Impl_DECREF(PyObject *ob)
 #define PyLong_FromLong(val) Impl_PyLong_FromLong(val)
 #define PyLong_FromUnsignedLong(val) Impl_PyLong_FromUnsignedLong(val)
 #define PyLong_FromLongLong(val) Impl_PyLong_FromLongLong(val)
+#define PyLong_FromUnsignedLongLong(val) Impl_PyLong_FromUnsignedLongLong(val)
 #define PyList_GET_ITEM(list, pos) Impl_PyList_GET_ITEM(list, pos)
 #define PyTuple_GET_ITEM(list, pos) Impl_PyTuple_GET_ITEM(list, pos)
 #endif


### PR DESCRIPTION
When I was compiling enigma2 on ubuntu, this function was missing. I don't remember the reason, although it's good to have it for completeness. 

Generated by copy & paste, so please look carefully for typos.