### PR TITLE
fix Harddisk module crash when devfs type is unknown

### DIFF
--- a/lib/python/Components/Harddisk.py
+++ b/lib/python/Components/Harddisk.py
@@ -55,6 +55,7 @@ class Harddisk:
 			self.type = DEVTYPE_DEVFS
 		else:
 			print "[Harddisk] Unable to determine structure of /dev"
+			self.type = -1
 			self.card = False
 
 		self.max_idle_time = 0


### PR DESCRIPTION
This is very minor, shouldn't harm anybody, but useful when running enigma2 on desktop linux distribution (without root).