### PR TITLE
Patch reactor

### DIFF
--- a/lib/base/ebase.cpp
+++ b/lib/base/ebase.cpp
@@ -170,7 +170,7 @@ void eMainloop::removeSocketNotifier(eSocketNotifier *sn)
 	eFatal("[eMainloop::removeSocketNotifier] removed socket notifier which is not present, fd=%d", fd);
 }
 
-int eMainloop::processOneEvent(unsigned int twisted_timeout, PyObject **res, ePyObject additional)
+int eMainloop::processOneEvent(long user_timeout, PyObject **res, ePyObject additional)
 {
 	int return_reason = 0;
 
@@ -210,9 +210,9 @@ int eMainloop::processOneEvent(unsigned int twisted_timeout, PyObject **res, ePy
 		}
 	}
 
-	if ((twisted_timeout > 0) && (poll_timeout > 0) && ((unsigned int)poll_timeout > twisted_timeout))
+	if (poll_timeout < 0 || (user_timeout >= 0 && poll_timeout > user_timeout))
 	{
-		poll_timeout = twisted_timeout;
+		poll_timeout = user_timeout;
 		return_reason = 1;
 	}
 
@@ -249,6 +249,7 @@ int eMainloop::processOneEvent(unsigned int twisted_timeout, PyObject **res, ePy
 			pfd[i++].events = PyInt_AsLong(val);
 		}
 	}
+
 
 	ret = _poll(pfd, fdcount, poll_timeout);
 
@@ -338,7 +339,7 @@ int eMainloop::iterate(unsigned int twisted_timeout, PyObject **res, ePyObject d
 		if (app_quit_now)
 			return -1;
 
-		int to = 0;
+		int to = -1;
 		if (twisted_timeout)
 		{
 			timespec now, timeout;

--- a/lib/base/ebase.cpp
+++ b/lib/base/ebase.cpp
@@ -173,7 +173,6 @@ void eMainloop::removeSocketNotifier(eSocketNotifier *sn)
 int eMainloop::processOneEvent(unsigned int twisted_timeout, PyObject **res, ePyObject additional)
 {
 	int return_reason = 0;
-		/* get current time */
 
 	if (additional && !PyDict_Check(additional))
 		eFatal("[eMainloop::processOneEvent] additional, but it's not dict");
@@ -188,6 +187,7 @@ int eMainloop::processOneEvent(unsigned int twisted_timeout, PyObject **res, ePy
 		if (it != m_timer_list.end())
 		{
 			eTimer *tmr = *it;
+			/* get current time */
 			timespec now;
 			clock_gettime(CLOCK_MONOTONIC, &now);
 			/* process all timers which are ready. first remove them out of the list. */

--- a/lib/base/ebase.h
+++ b/lib/base/ebase.h
@@ -196,7 +196,11 @@ class eMainloop
 	int m_interrupt_requested;
 	timespec m_twisted_timer;
 
-	int processOneEvent(unsigned int user_timeout, PyObject **res=0, ePyObject additional=ePyObject());
+	/* user_timeout < 0 - forever
+	 * user_timeout = 0 - immediately
+	 * user_timeout > 0 - wait
+	 */
+	int processOneEvent(long user_timeout, PyObject **res=0, ePyObject additional=ePyObject());
 	void addSocketNotifier(eSocketNotifier *sn);
 	void removeSocketNotifier(eSocketNotifier *sn);
 	void addTimer(eTimer* e);


### PR DESCRIPTION
This needs more discussion. Just a copy of explanation from the commit message:

## Fixed bugs:

In processOneEvent(), when `user_timeout > 0` but `poll_timeout == -1`
(because there were no timers for example)
poll was going to infinite wait, but it should abort after `user_timeout`.

In iterate `to` variable could become 0 due to rounding.
In this case processOneEvent was getting argument `user_timeout=0`,
that was treated as infinite poll waiting time.
Now we pass singed integer to processOneEvent
and zero argument means exiting immediately

## TODO:

eMainLoop::poll() interprets zero timeout as infinite wait.
I think twisted reactor use None for that purpose and 0 means no waiting
