### PR TITLE
Setup.py: Tidy up imports

### DIFF
--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -1,11 +1,10 @@
 from Screen import Screen
 from Components.ActionMap import NumberActionMap
-from Components.config import config, ConfigNothing
+from Components.config import config, ConfigNothing, ConfigText, ConfigPassword
 from Components.Label import Label
 from Components.SystemInfo import SystemInfo
 from Components.ConfigList import ConfigListScreen
 from Components.Sources.StaticText import StaticText
-from Components.config import ConfigText, ConfigPassword
 from enigma import eEnv
 
 import xml.etree.cElementTree


### PR DESCRIPTION
BTW, in practice the ConfigPassword check will never happen as ConfigPassword is a subclass of ConfigText. i.e. all subclasses of ConfigText are instances of ConfigText. For example ConfigNumber will also pass that test as it also is an instance of ConfigText.