### PR TITLE
ConfigList - skineable slider

### DIFF
--- a/lib/gui/elistboxcontent.cpp
+++ b/lib/gui/elistboxcontent.cpp
@@ -454,22 +454,28 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 						int size = (pvalue && PyInt_Check(psize)) ? PyInt_AsLong(psize) : 100;
 
 							/* calc. slider length */
-						int width = (m_itemsize.width() - m_seperation - 7) * value / size;
+						int width = (m_itemsize.width() - m_seperation - 15) * value / size;
 						int height = m_itemsize.height();
 
 
 							/* draw slider */
 						//painter.fill(eRect(offset.x() + m_seperation, offset.y(), width, height));
-						//hack - make it customizable
-						ePoint tl(offset.x() + m_seperation, offset.y() + 1);
-						ePoint tr(offset.x() + m_itemsize.width() - 1, tl.y());
-						ePoint bl(tl.x(), offset.y() + m_itemsize.height() - 2);
-						ePoint br(tr.x(), bl.y());
-						painter.line(tl, tr);
-						painter.line(tr, br);
-						painter.line(br, bl);
-						painter.line(bl, tl);
-						painter.fill(eRect(offset.x() + m_seperation + 3, offset.y() + 5, width, height - 10));
+						if (m_slider_space)
+						{
+							ePoint tl(offset.x() + m_seperation, offset.y() + m_slider_yoffset);
+							ePoint tr(offset.x() + m_itemsize.width() - 15 - 1, tl.y());
+							ePoint bl(tl.x(), offset.y() + height - m_slider_yoffset - 1);
+							ePoint br(tr.x(), bl.y());
+							painter.line(tl, tr);
+							painter.line(tr, br);
+							painter.line(br, bl);
+							painter.line(bl, tl);
+							painter.fill(eRect(offset.x() + m_seperation + m_slider_space + 1, offset.y() + m_slider_yoffset + m_slider_space + 1, width - 2*(m_slider_space + 1), height - 2*(m_slider_yoffset + m_slider_space + 1)));
+						}
+						else
+						{
+							painter.fill(eRect(offset.x() + m_seperation, offset.y() + m_slider_yoffset, width, height - 2*m_slider_yoffset));
+						}
 
 							/* pvalue is borrowed */
 					} else if (!strcmp(atype, "mtext"))

--- a/lib/gui/elistboxcontent.h
+++ b/lib/gui/elistboxcontent.h
@@ -56,8 +56,9 @@ public:
 	void paint(gPainter &painter, eWindowStyle &style, const ePoint &offset, int selected);
 	void setSeperation(int sep) { m_seperation = sep; }
 	int currentCursorSelectable();
+	void setSlider(int y_offset, int space) { m_slider_yoffset = y_offset; m_slider_space = space; }
 private:
-	int m_seperation;
+	int m_seperation, m_slider_yoffset, m_slider_space;
 };
 
 class eListboxPythonMultiContent: public eListboxPythonStringContent

--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -12,6 +12,8 @@ class ConfigList(GUIComponent, object):
 		self.l = eListboxPythonConfigContent()
 		seperation = skin.parameters.get("ConfigListSeperator", 200)
 		self.l.setSeperation(seperation)
+		y_offset, space = skin.parameters.get("ConfigListSlider",(4, 0))
+		self.l.setSlider(y_offset, space)
 		self.timer = eTimer()
 		self.list = list
 		self.onSelectionChanged = [ ]


### PR DESCRIPTION
There in skin set under <parameters> 2 values: "y_offset, space" in pixels:
f.eg: <parameter name="ConfigListSlider" value="4,2"/>, where:
- 1st parameter is y-offset for slider or for frame around slider (affected by 2nd parameter)
- 2nd parameter is space between frame and slider.
Frame around slider and slider are verticaly centered.
If is 2nd parameter set to 0, then frame is not used and 1st parameter is y-offset of slider
- fixed right slider alignment too