### PR TITLE
[config.py] Fix __getattr_ method error code

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -1660,7 +1660,9 @@ class ConfigSubsection(object):
 			value.load()
 
 	def __getattr__(self, name):
-		return self.content.items[name]
+		if name in self.content.items:
+			return self.content.items[name]
+		raise AttributeError(name)
 
 	def getSavedValue(self):
 		res = self.content.stored_values


### PR DESCRIPTION
NOTE: This pull request should not be merged until a build of OpenWebif built on or after 31-Mar-2018 has been incorporated.  (OpenWebif was incorrectly checking for a KeyError rather than the correct AttributeError.)

The `__getattr__` method in ConfigSubsection did not check if the attribute being retrieved existed.  This caused a KeyError to be raised instead of the expected AttributeError.  This issue means that the getattr() function could not correctly test for the existence of a config item without causing a crash.  This fix will allow the method to return the attribute if it exists or raise an AttributeError.  The AttributeError allows the getattr() function to be supplied with a default that can be returned to the calling code.

For example: getattr(config.usage, "fred", None) would crash rather than return the expected None if config.usage.fred does not exist.  This change fixes the crash and allows getattr() to function as expected.  That is, the definition of "fred" will be returned if it exists or else None will be returned.

Also fixed the last line of the file to have a newline.
