### PR TITLE
Fix buutons in OSD3DSetup skin

### DIFF
--- a/data/skin_default.xml
+++ b/data/skin_default.xml
@@ -1008,6 +1008,14 @@ self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth)/2, orgpos.y() + (or
 		<widget name="config" position="10,50" size="400,300" scrollbarMode="showOnDemand"/>
 		<widget name="footer" position="0,0" size="0,0"/>
 	</screen>
+	<!-- OSD 3D setup -->
+	<screen name="OSD3DSetupScreen" position="center,center" size="400,200" title="OSD 3D setup">
+		<widget name="config" position="c-175,c-75" size="350,150"/>
+		<ePixmap pixmap="skin_default/buttons/green.png" position="c-145,e-45" size="140,40" alphatest="on"/>
+		<ePixmap pixmap="skin_default/buttons/red.png" position="c+5,e-45" size="140,40" alphatest="on"/>
+		<widget name="key_green" position="c-145,e-45" size="140,40" valign="center" halign="center" zPosition="1" font="Regular;20" transparent="1"/>
+		<widget name="key_red" position="c+5,e-45" size="140,40" valign="center" halign="center" zPosition="1" font="Regular;20" transparent="1"/>
+	</screen>
 	<!-- Positioner setup -->
 	<screen name="PositionerSetup" position="center,center" size="660,485" title="Positioner setup">
 		<widget name="list" position="120,10" size="420,180" transparent="1" font="Regular;20"/>

--- a/lib/python/Plugins/SystemPlugins/OSD3DSetup/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/OSD3DSetup/plugin.py
@@ -14,17 +14,7 @@ config.plugins.OSD3DSetup.mode = ConfigSelection(choices = modelist, default = "
 config.plugins.OSD3DSetup.znorm = ConfigInteger(default = 0)
 
 class OSD3DSetupScreen(Screen, ConfigListScreen):
-	skin = """
-	<screen position="c-200,c-100" size="400,200" title="OSD 3D setup">
-		<widget name="config" position="c-175,c-75" size="350,150" />
-		<ePixmap pixmap="skin_default/buttons/green.png" position="c-145,e-45" zPosition="0" size="140,40" alphatest="on" />
-		<ePixmap pixmap="skin_default/buttons/red.png" position="c+5,e-45" zPosition="0" size="140,40" alphatest="on" />
-		<widget name="ok" position="c-145,e-45" size="140,40" valign="center" halign="center" zPosition="1" font="Regular;20" transparent="1" backgroundColor="green" />
-		<widget name="cancel" position="c+5,e-45" size="140,40" valign="center" halign="center" zPosition="1" font="Regular;20" transparent="1" backgroundColor="red" />
-	</screen>"""
-
 	def __init__(self, session):
-		self.skin = OSD3DSetupScreen.skin
 		Screen.__init__(self, session)
 
 		self.setTitle(_("OSD 3D setup"))


### PR DESCRIPTION
The button widget name has been changed here https://github.com/OpenPLi/enigma2/commit/2a7abe5d9df27b3b23815771dbc4977e06f0001d, but it has not been changed in plugin skin.
Therefore, in skins where the screen comes from a plugin sources, these buttons are not displayed.
Also move the plugin skin from the plugin pyton file to the skin_default.xml