### PR TITLE
[ActionMap] HelpableActionMaps multiple contexts

### DIFF
--- a/lib/python/Components/ActionMap.py
+++ b/lib/python/Components/ActionMap.py
@@ -1,7 +1,12 @@
 from enigma import eActionMap
+from Tools.KeyBindings import queryKeyBinding
 
 class ActionMap:
-	def __init__(self, contexts = [ ], actions = { }, prio=0):
+	def __init__(self, contexts=None, actions=None, prio=0):
+		if not actions:
+			actions = {}
+		if not contexts:
+			contexts = []
 		self.actions = actions
 		self.contexts = contexts
 		self.prio = prio
@@ -41,14 +46,14 @@ class ActionMap:
 		self.checkBind()
 
 	def action(self, context, action):
-		print " ".join(("action -> ", context, action))
 		if action in self.actions:
+			print "[ActionMap] Keymap '%s' -> Action = '%s'" % (context, action)
 			res = self.actions[action]()
 			if res is not None:
 				return res
 			return 1
 		else:
-			print "unknown action %s/%s! typo in keymap?" % (context, action)
+			print "[ActionMap] Keymap '%s' -> Unknown action '%s'! (Typo in keymap?)" % (context, action)
 			return 0
 
 	def destroy(self):
@@ -67,7 +72,8 @@ class NumberActionMap(ActionMap):
 class HelpableActionMap(ActionMap):
 	"""An Actionmap which automatically puts the actions into the helpList.
 
-	Note that you can only use ONE context here!"""
+	A context list is allowed, and for backward compatibility,
+	a single string context name also is allowed"""
 
 	# sorry for this complicated code.
 	# it's not more than converting a "documented" actionmap
@@ -77,17 +83,50 @@ class HelpableActionMap(ActionMap):
 	# the collected helpstrings (with correct context, action) is
 	# added to the screen's "helpList", which will be picked up by
 	# the "HelpableScreen".
-	def __init__(self, parent, context, actions = { }, prio=0):
-		alist = [ ]
-		adict = { }
-		for (action, funchelp) in actions.iteritems():
-			# check if this is a tuple
-			if isinstance(funchelp, tuple):
-				alist.append((action, funchelp[1]))
-				adict[action] = funchelp[0]
-			else:
-				adict[action] = funchelp
 
-		ActionMap.__init__(self, [context], adict, prio)
+	def __init__(self, parent, contexts, actions=None, prio=0, description=None):
+		self.description = description
+		if not actions:
+			actions = {}
+		if not hasattr(contexts, '__iter__'):
+			contexts = [contexts]
+		adict = {}
+		for context in contexts:
+			alist = []
+			for (action, funchelp) in actions.iteritems():
+				# check if this is a tuple
+				if isinstance(funchelp, tuple):
+					if queryKeyBinding(context, action):
+						alist.append((action, funchelp[1]))
+					adict[action] = funchelp[0]
+				else:
+					if queryKeyBinding(context, action):
+						alist.append((action, None))
+					adict[action] = funchelp
+			parent.helpList.append((self, context, alist))
 
-		parent.helpList.append((self, context, alist))
+		ActionMap.__init__(self, contexts, adict, prio)
+
+
+class HelpableNumberActionMap(NumberActionMap, HelpableActionMap):
+	"""An Actionmap which automatically puts the actions into the helpList.
+
+	A context list is allowed, and for backward compatibility,
+	a single string context name also is allowed"""
+
+	# sorry for this complicated code.
+	# it's not more than converting a "documented" actionmap
+	# (where the values are possibly (function, help)-tuples)
+	# into a "classic" actionmap, where values are just functions.
+	# the classic actionmap is then passed to the ActionMap constructor,
+	# the collected helpstrings (with correct context, action) is
+	# added to the screen's "helpList", which will be picked up by
+	# the "HelpableScreen".
+
+	def __init__(self, parent, contexts, actions=None, prio=0, description=None):
+		# Initialise NumberActionMap with empty context and actions
+		# so that the underlying ActionMap is only initialised with
+		# these once, via the HelpableActionMap.
+
+		NumberActionMap.__init__(self, [], {})
+		HelpableActionMap.__init__(self, parent, contexts, actions, prio, description)


### PR DESCRIPTION
Add HelpableNumberActionMap to OpenPLi to match OpenViX and Beyonwiz images.

Allow HelpableActionMap and HelpableNumberActionMap to accept a list of contexts as well as a single context.  This makes it possible to convert ActionMap and NumberActionMap objects to helpable without changing their basic structure.  Single-context helpable ActionMaps are retained for backwards compatibility.

Simplify the ActionMap logging, print only one line instead of two for keymap errors.

PEP8 clean-up and fixes.

(This change will be required if the improved Beyonwiz HELP system is ever adopted.)

Most of the code written by Prl for the Beyonwiz image (Nov-2014 - Jan-2015)
