### PR TITLE
ConfigList: fix GSOD on HideHelp if config not set

### DIFF
--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -212,11 +212,11 @@ class ConfigListScreen:
 		self.session.openWithCallback(self.VirtualKeyBoardCallback, VirtualKeyBoard, title = self["config"].getCurrent()[0], text = self["config"].getCurrent()[1].getValue())
 
 	def HideHelp(self):
-		if "config" in self and (self["config"].getCurrent()[1].__class__.__name__ == 'ConfigText' or self["config"].getCurrent()[1].__class__.__name__ == 'ConfigPassword') and self["config"].getCurrent()[1].help_window and self["config"].getCurrent()[1].help_window.instance is not None:
+		if "config" in self and self["config"].getCurrent() is not None and self["config"].getCurrent()[1].__class__.__name__ in ('ConfigText', 'ConfigPassword') and self["config"].getCurrent()[1].help_window and self["config"].getCurrent()[1].help_window.instance is not None:
 			self["config"].getCurrent()[1].help_window.hide()
 
 	def ShowHelp(self):
-		if "config" in self and (self["config"].getCurrent()[1].__class__.__name__ == 'ConfigText' or self["config"].getCurrent()[1].__class__.__name__ == 'ConfigPassword') and self["config"].getCurrent()[1].help_window and self["config"].getCurrent()[1].help_window.instance is not None:
+		if "config" in self and self["config"].getCurrent() is not None and self["config"].getCurrent()[1].__class__.__name__ in ('ConfigText', 'ConfigPassword') and self["config"].getCurrent()[1].help_window and self["config"].getCurrent()[1].help_window.instance is not None:
 			self["config"].getCurrent()[1].help_window.show()
 
 	def VirtualKeyBoardCallback(self, callback = None):


### PR DESCRIPTION
Add aditional check if config getCurrent() exist to slove GSOD on HideHelp.
For example when create settings backup with plugin SoftwareManager.
You get:
```
  File "/usr/lib/enigma2/python/mytest.py", line 200, in processDelay
    self.current_dialog.doClose()
  File "/usr/lib/enigma2/python/Screens/Screen.py", line 111, in doClose
    x()
  File "/usr/lib/enigma2/python/Components/ConfigList.py", line 217, in HideHelp
    if "config" in self and (self["config"].getCurrent()[1].__class__.__name__ == 'ConfigText' or self["config"].getCurrent()[1].__class__.__name__ == 'ConfigPassword') and self["config"].getCurrent()[1].help_window and self["config"].getCurrent()[1].help_window.instance is not None:
TypeError: 'NoneType' object has no attribute '__getitem__'
```
Also small code optimization, thx Huevos.