### PR TITLE
Setup.py refactor and enhancements

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -9,6 +9,7 @@
 		<item level="1" text="Sort order for menu entries" description="This option allows you to hide and sort menu entries. When selecting user you can change order and hide menu items via the blue button">config.usage.menu_sort_mode</item>
 		<item level="1" text="Show menu paths" description="This option allows you to show menu paths.">config.usage.menu_path</item>
 		<item level="0" text="Show menu numbers" description="This option allows you to show menu number quick links.">config.usage.menu_show_numbers</item>
+ 		<item level="1" text="Sort setting screens alphabetically" description="This option allows you to disable sorting of the option in setting screens">config.usage.sort_settings</item>
 		<item level="2" text="Show softcam setup in extensions menu" description="This option allows you to add the softcam setup in the extensions menu." requires="HasSoftcamInstalled">config.misc.softcam_setup.extension_menu</item>
 		<item level="1" text="Zap mode" requires="ZapMode" description="Configure the way in which the receiver changes channels.">config.misc.zapmode</item>
 		<item level="2" text="Enable teletext caching" description="When enabled, teletext pages will be cached, allowing faster access.">config.usage.enable_tt_caching</item>

--- a/doc/SETUPGUIDE
+++ b/doc/SETUPGUIDE
@@ -1,0 +1,366 @@
+Proposal for Standardised and Uniform Setup Menus in Enigma2
+------------------------------------------------------------
+
+Written by IanSav - 2-Apr-2018
+Updated by IanSav - 6-Apr-2018
+
+INTRODUCTION:
+=============
+
+Enigma2 is a massive open source project that has many contributors and 
+add-ons.  Over time a number of alternative approaches to performing common 
+tasks have evolved.  This document proposes some conventions that can be 
+adopted by all developers, contributors and skin authors to ensure that 
+everyone can work independently but still achieve results that work together 
+interchangeably.
+
+Standard variable names are proposed, together with code and skin coding 
+conventions to assist in creating code that works more universally, with 
+additional benefits from improved Setup menu load performance and reduction 
+in merge issues between images.
+
+Lastly, the document explains the proposed operation and features of the 
+refactored Setup menu interface ("Screen/Setup.py").
+
+REFACTOR OF "Screens/Setup.py":
+===============================
+
+The refactor of the "Screens/Setup.py" code has been based on the OpenPLi, 
+OpenViX and Beyonwiz builds.  Features have been drawn from all the builds 
+and the code has been rewritten to be compatible with all three builds 
+without needing any modifications.  That is, the proposed code has been 
+written to make the "Screens/Setup.py" a superset of all builds and to 
+operate, without modification, on OpenPLi, OpenViX and Beyonwiz builds 
+of Enigma2.  This should allow the same code to be used in all builds to 
+eliminate or at least reduce merge issues.
+
+The changes, even with the enhancements, result in up to a four-fold 
+reduction in time to generate any "Screens/Setup.py" based Setup menu on 
+OpenViX and Beyonwiz builds.  The time taken to build any Setup menu lists 
+is slightly longer for the first menu item but then about 50 time faster 
+for all subsequent searches.  (The menu feature is not used on Beyonwiz 
+builds.)
+
+Significant changes, in no particular order, are:
+
+1)	All setup XML file data is cached into memory on the first access.  
+	Every subsequent access will check if the source file has been 
+	changed.  If so, the file will be reloaded and reprocessed.  If not, 
+	the cached results are returned.  This change significantly improves 
+	"Screens/Setup.py" menu load times.
+
+	This change also means that the GUI no longer has to be restarted to 
+	allow changes to "setup.xml" to be processed by OpenPLi.
+
+2)	All setup menu titles are also extracted and cached to improve menu 
+	building time.  This code uses a derivative of the OpenViX 
+	"titleshort" attribute here known as "menuTitle" to allow 
+	"Screens/Menu.py" based menus to have alternate title text.  This 
+	change improves "Screens/Menu.py" menu load times for "Setup" based 
+	menus.
+
+3)	Optimise, improve and enhance generation of Setup menu item lists.  
+	For OpenViX and Beyonwiz this change allows the list to be processed 
+	once for display rather than the two or three cycles in the previous 
+	versions.
+
+4)	Create a log entry if the Setup menu has no valid entries.
+
+5)	Remove remnants of the setup.xml "separation" attribute directive.  
+	This feature is now offered via the skin parameter 
+	"ConfigListSeperator".
+
+6)	Where implemented, obey Setup menu sort setting.
+
+7)	If "%s %s" is found in an item's "text" or "description" attribute 
+	then replace it with the current box machine brand and model name.
+
+8)	Move the description code from the "SetupSummary" class into the main 
+	"Setup" class where it is used.
+
+9) 	Add Beyonwiz and OpenViX footnote support code.  If the last 
+	character of a menu item is an "*" then when this item 	is currently 
+	selected by the user a footnote message will appear to 	advise the 
+	user that a restart will be required if this item is changed.
+
+10)	Add OpenViX menu path code to display the menu path to the current 
+	menu.
+
+11)	Add an option to provide "Setup" menu images based on matching the 
+	setup menu "key" attribute with an image defined in a new "<setups>" 
+	block in the skin.  This code is conditional on having compatible 
+	changes in "skin.py".
+
+12)	Enable the HELP button to allow users to obtain help while using any 
+	"Screens/Setup.py" based screen.  To be fully operational these 
+	changes also need to be accompanied by changes to 
+	"Components/ConfigList.py".
+
+	To properly implement HELP and clean up the ActionMaps, the ActionMap 
+	and associated code should be removed from "Screens/Setup.py" and 
+	integrated into the ActionMap in "Components/ConfigList.py".
+
+13)	The "setup_key" skin facility appears to be unused.  The name has 
+	been changed to "Setup_key" to better match existing skin names.  
+	This option allows skin designers to create custom "Setup" based 
+	screens for any "Setup" menu item.
+
+	The "setup.xml" file's "setup" tag also offers a "skin" attribute to 
+	also allow for the screen for that menu to be specified.
+
+	The order of screen selection is first look for a "skin" attribute 
+	screen, then try for a "Setup_key" screen and finally use the 
+	standard "Setup" screen.
+
+14)	Rename the GREEN button text from "OK" to a more appropriate "Save".
+
+15)	Perform a PEP8 clean-up of the code.
+
+16)	Reorganise the imports and code blocks to improve readability of the 
+	refactored code.
+
+STRUCTURE OF "setup.xml" FILES:
+===============================
+
+Syntax:
+	
+	<setupxml>
+		<setup key="Sample1" title="Sample1 settings">
+			<item level="0" text="Configuration item 1" description="This is the description text that explains the purpose and settings of config item 1.">config_item1</item>
+			<item level="0" text="Configuration item 2" description="This is the description text that explains the purpose and settings of config item 2.">config_item2</item>
+		</setup>
+		<setup key="Sample2" title="Sample2 settings">
+			<item level="0" text="Configuration item 3" description="This is the description text that explains the purpose and settings of config item 3.">config_item3</item>
+			<item level="1" text="Configuration item 4" description="This is the description text that explains the purpose and settings of config item 4.">config_item4</item>
+		</setup>
+	</setupxml>
+
+The "setupxml" tag defines that the file is a setup configuration file. The 
+"setupxml" tag has no attributes and should contain a list of one or more 
+"setup" tag blocks. Each of the "setup" tag blocks should contain a list of 
+one or more "item" blocks.  Each of the "item" tag blocks must contain a 
+configuration element that has been defined in "Components/UsageConfig.py" 
+or elsewhere.
+
+Each of the "setup" tags can have the following attributes:
+
+	Attribute	Required	Description
+	---------	--------	-----------
+	"key"		Mandatory	This attribute is the reference name, 
+					or key, used to identify this Setup 
+					menu.
+
+	"title"		Mandatory	This attribute is the long form title 
+					text used for the heading or title of 
+					this setup menu screen.
+
+	"menuTitle"	Optional	This attribute is the title that can 
+					be used as an alternative for the 
+					"title" in menus of Setup menu items.
+
+	"skin"		Optional	This attribute is used to specify an 
+					override screen name defined in the 
+					skin to be used to display this Setup 
+					screen.
+
+Each of the "item" tags can have the following attributes:
+
+	Attribute	Required	Description
+	---------	--------	-----------
+	"text"		Mandatory	This attribute is the prompt text 
+					that is displayed to the user when 
+					activating this Setup menu.
+
+	"level"		Recommended	The list of items that may be 
+					displayed in any Setup menu is 
+					dynamic. This attribute determines 
+					the user interface setup mode or 
+					level where this option may be 
+					displayed.  The default level, if 
+					not specified, is 0.
+
+				Level=0 -> Basic / Normal / Simple or higher
+				Level=1 -> Advanced / Intermediate or higher
+				Level=2 -> Expert
+
+	"description"	Recommended	This attribute is the help prompt or 
+					information that can, and should, be 
+					used to offer guidance to users in 
+					when and how to set the associated 
+					configuration option.  If this is 
+					omitted no assistance or information 
+					will be offered to users.
+
+	"conditional"	Optional	This attribute allows for programmed 
+					logic to decide is this item is 
+					eligible for display in the Setup 
+					menu.
+
+	"requires"	Optional	This attribute allows for "SystemInfo" 
+					or "config" variables to be used to 
+					enable display of the item.  If the 
+					first character of the attribute 
+					argument is "!" then the argument 
+					logic is inverted.
+
+	NOTE 1:	The text in the "text" and "description" attributes will 
+		be processed by the language translation system.
+
+	NOTE 2:	After the text in the "text" and "description" attributes 
+		has been translated any occurrence of the string "%s %s" will 
+		be replaced by the current make and model of the device upon 
+		which the code is running.
+
+	NOTE 3: If the last character of the "text" attribute is "*" then 
+		when this item is currently selected by the user a footnote 
+		message will appear to advise the user that a restart will be 
+		required if this item is changed.
+
+The payload or data element of the "item" tag should be the config element 
+defined in "Components/UsageConfig.py", or elsewhere, to be managed / changed 
+by the encompassing item tag.
+
+
+"Screens/Setup.py" / "Setup" SCREEN VARIABLES:
+==============================================
+
+	Variable		Description
+	--------		-----------
+	menu_path_compressed	This variable uses a 
+				source="menu_path_compressed" render=Label" 
+				widget that provides the menu path to the 
+				currently used "Setup" menu.  (This 
+				information and is only defined for the 
+				OpenViX and Beyonwiz builds.  It is 
+				handled differently in OpenPLi.)
+
+	title			This variable uses a name="title" widget 
+				that provides the title of the "Setup" menu.
+
+	config			This variable uses a name="config" widget 
+				that provides the list of available "Setup" 
+				configuration items.
+
+	description		This variable uses a name="description" 
+				widget that provides any available help or 
+				description text for the currently selected 
+				"Setup" item.
+
+	footnote		This variable uses a name="footnote" widget 
+				that provides a footnote message that 
+				typically advises when changing the item's 
+				value may trigger a restart.
+
+	key_red			This variable uses a source="key_red" 
+				render="Label" widget that provides the text 
+				for the RED button.  This variable can also 
+				be used to trigger an associated button 
+				graphic.
+
+	key_green		This variable uses a source="key_green" 
+				render="Label" widget that provides the text 
+				for the GREEN button.  This variable can also 
+				be used to trigger an associated button 
+				graphic.
+
+	key_yellow		This variable uses a source="key_yellow" 
+				render="Label" widget that provides the text 
+				for the YELLOW button.  This variable can 
+				also be used to trigger an associated button 
+				graphic.  The YELLOW button is not used by 
+				the core "Setup" class but may be used by 
+				other code based on the "Setup" class.
+
+	key_blue		This variable uses a source="key_blue" 
+				render="Label" widget that provides the text 
+				for the BLUE button.  This variable can also 
+				be used to trigger an associated button 
+				graphic.  The BLUE button is not used by 
+				the core "Setup" class but may be used by 
+				other code based on the "Setup" class.
+
+	key_help		This variable uses a source="key_help" 
+				render="Label" widget that provides a signal 
+				to the skin to display the HELP button.
+
+	VKeyIcon		This variable uses a source="VKeyIcon" 
+				render="Pixmap" widget that provides a signal 
+				to the skin to display the TEXT button when 
+				appropriate.
+
+	HelpWindow		This variable uses a name="HelpWindow" widget 
+				that displays the SMS helper window overlay 
+				when appropriate.
+
+SAMPLE "Setup" SCREEN:
+======================
+
+	<screen name="Setup" title="Setup" position="center,center" size="1000,565">
+		<widget source="menu_path_compressed" render="Label" position="560,0" size="440,15" conditional="menu_path_compressed" font="Regular;12" halign="right" transparent="1" />
+		<widget source="Title" render="Label" position="560,15" size="440,25" font="Regular;20" halign="right" noWrap="1" transparent="1" />
+		<widget source="key_red" render="Pixmap" pixmap="buttons/red.png" position="0,0" size="140,40" alphatest="blend" conditional="key_red">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget source="key_red" render="Label" position="0,0" size="140,40" backgroundColor="#9f1313" font="Regular;20" halign="center" transparent="1" valign="center" zPosition="+1" />
+		<widget source="key_green" render="Pixmap" pixmap="buttons/green.png" position="140,0" size="140,40" alphatest="blend" conditional="key_green">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget source="key_green" render="Label" position="140,0" size="140,40" backgroundColor="#1f771f" font="Regular;20" halign="center" transparent="1" valign="center" zPosition="+1" />
+		<widget source="key_yellow" render="Pixmap" pixmap="buttons/yellow.png" position="280,0" size="140,40" alphatest="blend" conditional="key_yellow">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget source="key_yellow" render="Label" position="280,0" size="140,40" backgroundColor="#a08500" font="Regular;20" halign="center" transparent="1" valign="center" zPosition="+1" />
+		<widget source="key_blue" render="Pixmap" pixmap="buttons/blue.png" position="420,0" size="140,40" alphatest="blend" conditional="key_blue">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget source="key_blue" render="Label" position="420,0" size="140,40" backgroundColor="#141484" font="Regular;20" halign="center" transparent="1" valign="center" zPosition="+1" />
+		<widget source="key_help" render="Pixmap" pixmap="buttons/key_help.png" position="0,540" size="35,25" alphatest="blend" transparent="1" />
+		<widget source="VKeyIcon" render="Pixmap" pixmap="buttons/key_text.png" position="40,540" size="35,25" alphatest="blend" transparent="1">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget name="HelpWindow" pixmap="buttons/vkey_icon.png" position="0,250" size="1,1" zPosition="+1" />
+		<widget name="menuimage" position="0,50" size="200,400" alphatest="blend" conditional="menuimage" transparent="1" />
+		<widget name="config" position="200,50" size="800,400" enableWrapAround="1" scrollbarMode="showOnDemand" transparent="1" />
+		<widget name="footnote" position="200,460" size="800,20" font="Regular;18" transparent="1" valign="center" />
+		<widget name="description" position="200,490" size="800,75" font="Regular;20" transparent="1" valign="center" />
+	</screen>
+
+SKIN "Setups" SUPPORT BLOCK:
+============================
+
+Syntax:
+
+	<setups>
+		<setup key="default" image="setup_default.png" />
+		<setup key="Sample1" image="setup_key.png" />
+	</setups>
+
+This block is optional but if defined allows a skin designer to associate 
+an image with any "Screens/Setup.py" based menu.  The "setups" tag has no 
+attributes and contains a list of "setup" tags.
+
+Each "setup" tag must contain two attributes:
+
+	key	This attribute is the value of the key attribute from a 
+		setup.xml file.  If the keys match then this entry defines 
+		an image that is to be used when the nominated Setup menu 
+		is displayed.
+
+	image	This attribute is the pathname of the image that is to be 
+		associated with the Setup menu identified by the "key" 
+		attribute.
+
+There is a special "key" attribute with the name "default".  This entry, 
+if defined, assigns a default image to be used in ALL "Screens/Setup.py" 
+screens that do not have a specifically assigned image.
+
+CONCLUSION:
+===========
+
+For all the Enigma2 builds there is a significant difference in facilities 
+offered by the "Screens/Setup.py code.  This proposal outlines what I 
+believe to be a conservative approach to making a significant and beneficial 
+change in unifying and standardising the operation of "Setup" menus and 
+screens across the Enigma2 UI.
+
+---END---

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -86,6 +86,7 @@ def InitUsageConfig():
 		("small", _("Small")),
 		("large", _("Large")),])
 	config.usage.enable_tt_caching = ConfigYesNo(default = True)
+	config.usage.sort_settings = ConfigYesNo(default = False)
 	choicelist = []
 	for i in (10, 30):
 		choicelist.append((str(i), ngettext("%d second", "%d seconds", i) % i))

--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -1,5 +1,5 @@
 from Screen import Screen
-from Components.ActionMap import NumberActionMap
+from Components.ActionMap import HelpableActionMap
 from Components.config import config, ConfigNothing, ConfigBoolean, ConfigSelection, ConfigYesNo
 from Components.Label import Label
 from Components.SystemInfo import SystemInfo
@@ -7,6 +7,7 @@ from Components.ConfigList import ConfigListScreen
 from Components.Pixmap import Pixmap
 from Components.Sources.StaticText import StaticText
 from Components.Sources.Boolean import Boolean
+from Screens.HelpMenu import HelpableScreen
 from Tools.Directories import resolveFilename, SCOPE_CURRENT_PLUGIN, SCOPE_SKIN, SCOPE_CURRENT_SKIN
 from Tools.LoadPixmap import LoadPixmap
 
@@ -119,7 +120,7 @@ class SetupSummary(Screen):
 		self["SetupEntry"].text = self.parent.getCurrentEntry()
 		self["SetupValue"].text = self.parent.getCurrentValue()
 
-class Setup(ConfigListScreen, Screen):
+class Setup(ConfigListScreen, Screen, HelpableScreen):
 
 	ALLOW_SUSPEND = True
 
@@ -138,6 +139,7 @@ class Setup(ConfigListScreen, Screen):
 
 	def __init__(self, session, setup, plugin=None, menu_path=None, PluginLanguageDomain=None):
 		Screen.__init__(self, session)
+		HelpableScreen.__init__(self)
 		# for the skin: first try a setup_<setupID>, then Setup
 		self.skinName = ["setup_" + setup, "Setup" ]
 		self.setup = setup
@@ -162,18 +164,18 @@ class Setup(ConfigListScreen, Screen):
 		#check for list.entries > 0 else self.close
 		self["key_red"] = StaticText(_("Cancel"))
 		self["key_green"] = StaticText(_("OK"))
+		self["key_help"] = StaticText(_("HELP"))
 		self["description"] = Label("")
 		self["footnote"] = Label("")
 		self["HelpWindow"] = Pixmap()
 		self["HelpWindow"].hide()
 		self["VKeyIcon"] = Boolean(False)
 
-		self["actions"] = NumberActionMap(["SetupActions", "MenuActions"],
-			{
-				"cancel": self.keyCancel,
-				"save": self.keySave,
-				"menu": self.closeRecursive,
-			}, -2)
+		self["actions"] = HelpableActionMap(self, "SetupActions", {
+			"cancel": (self.keyCancel, _("Cancel any changed settings and exit")),
+			"save": (self.keySave, _("Save all changed settings and exit")),
+			"menu": (self.closeRecursive, _("Cancel any changed settings and exit all menus"))
+		}, prio=-2, description=_("Common Setup Functions"))
 
 		defaultmenuimage = setups.get("default", "")
 		menuimage = setups.get(self.setup, defaultmenuimage)

--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -7,7 +7,8 @@ from Components.ConfigList import ConfigListScreen
 from Components.Pixmap import Pixmap
 from Components.Sources.StaticText import StaticText
 from Components.Sources.Boolean import Boolean
-from Tools.Directories import resolveFilename, SCOPE_CURRENT_PLUGIN, SCOPE_SKIN
+from Tools.Directories import resolveFilename, SCOPE_CURRENT_PLUGIN, SCOPE_SKIN, SCOPE_CURRENT_SKIN
+from Tools.LoadPixmap import LoadPixmap
 
 try:
 	from boxbranding import getMachineBrand, getMachineName
@@ -16,6 +17,10 @@ except ImportError:
 	# from models.owibranding import getBoxType, getMachineName
 	branding_available = False
 from gettext import dgettext
+try:
+	from skin import setups
+except ImportError:
+	setups = {}
 
 import os
 import xml.etree.cElementTree
@@ -170,6 +175,23 @@ class Setup(ConfigListScreen, Screen):
 				"menu": self.closeRecursive,
 			}, -2)
 
+		defaultmenuimage = setups.get("default", "")
+		menuimage = setups.get(self.setup, defaultmenuimage)
+		if menuimage:
+			if menuimage == defaultmenuimage:
+				msg = "Default"
+			else:
+				msg = "Menu"
+			menuimage = resolveFilename(SCOPE_CURRENT_SKIN, menuimage)
+			print "[Setup] %s image: '%s'" % (msg, menuimage)
+			self.menuimage = LoadPixmap(menuimage)
+			if self.menuimage:
+				self["menuimage"] = Pixmap()
+			else:
+				print "[Setup] ERROR: Unable to load menu image '%s'!" % menuimage
+		else:
+			self.menuimage = None
+
 		self.list = []
 		self.refill()
 		ConfigListScreen.__init__(self, self.list, session = session, on_change = self.changedEntry)
@@ -258,6 +280,8 @@ class Setup(ConfigListScreen, Screen):
 		else:
 			title = _(self.setup_title)
 		self.setTitle(title)
+		if self.menuimage:
+			self["menuimage"].instance.setPixmap(self.menuimage)
 		if len(self["config"].getList()) == 0:
 			print "[Setup] No menu items available!"
 

--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -96,9 +96,8 @@ class SetupError(Exception):
 		return self.msg
 
 class SetupSummary(Screen):
-
 	def __init__(self, session, parent):
-		Screen.__init__(self, session, parent = parent)
+		Screen.__init__(self, session, parent=parent)
 		self["SetupTitle"] = StaticText(_(parent.setup_title))
 		self["SetupEntry"] = StaticText("")
 		self["SetupValue"] = StaticText("")
@@ -106,19 +105,20 @@ class SetupSummary(Screen):
 		self.onHide.append(self.removeWatcher)
 
 	def addWatcher(self):
-		if hasattr(self.parent,"onChangedEntry"):
+		if hasattr(self.parent, "onChangedEntry"):
 			self.parent.onChangedEntry.append(self.selectionChanged)
 			self.parent["config"].onSelectionChanged.append(self.selectionChanged)
 			self.selectionChanged()
 
 	def removeWatcher(self):
-		if hasattr(self.parent,"onChangedEntry"):
+		if hasattr(self.parent, "onChangedEntry"):
 			self.parent.onChangedEntry.remove(self.selectionChanged)
 			self.parent["config"].onSelectionChanged.remove(self.selectionChanged)
 
 	def selectionChanged(self):
 		self["SetupEntry"].text = self.parent.getCurrentEntry()
 		self["SetupValue"].text = self.parent.getCurrentValue()
+
 
 class Setup(ConfigListScreen, Screen, HelpableScreen):
 
@@ -141,7 +141,7 @@ class Setup(ConfigListScreen, Screen, HelpableScreen):
 		Screen.__init__(self, session)
 		HelpableScreen.__init__(self)
 		# for the skin: first try a setup_<setupID>, then Setup
-		self.skinName = ["setup_" + setup, "Setup" ]
+		self.skinName = ["setup_" + setup, "Setup"]
 		self.setup = setup
 		self.plugin = plugin
 		self.menu_path = menu_path
@@ -196,7 +196,7 @@ class Setup(ConfigListScreen, Screen, HelpableScreen):
 
 		self.list = []
 		self.refill()
-		ConfigListScreen.__init__(self, self.list, session = session, on_change = self.changedEntry)
+		ConfigListScreen.__init__(self, self.list, session=session, on_change=self.changedEntry)
 		if config.usage.sort_settings.value:
 			self["config"].list.sort()
 		if self.levelChanged not in config.usage.setup_level.notifiers:

--- a/skin.py
+++ b/skin.py
@@ -24,6 +24,7 @@ fonts = {
 }
 
 parameters = {}
+setups = {}
 
 def dump(x, i=0):
 	print " " * i + str(x)
@@ -589,6 +590,16 @@ def loadSingleSkinData(desktop, skin, path_prefix):
 				parameters[name] = "," in value and map(int, value.split(",")) or int(value)
 			except Exception, ex:
 				print "[Skin] Bad parameter", ex
+
+	for c in skin.findall("setups"):
+		for setup in c.findall("setup"):
+			get = setup.attrib.get
+			key = get("key")
+			image = get("image")
+			if key and image:
+				setups[key] = image
+			else:
+				raise SkinError("[Skin] Setup needs key and image, got '%s' '%s'" % (key, image))
 
 	for c in skin.findall("subtitles"):
 		from enigma import eSubtitleWidget


### PR DESCRIPTION
- [Setup.py] Cache and optimise loading of setup.xml

    Cache the setup XML data in memory on the first access.  Every subsequent access will check if the source file has been changed.  If so, the file will be reloaded and reprocessed.  If not, the cached results are returned.

    All setup menu titles are also extracted and cached to improve menu building time.  This code uses a derivative of the OpenViX "titleshort" attribute here known as "menuTitle" to allow Menu.py based menus to have alternate title text.

    The "raise SetupError()" in "getSetupTitle()" has been retained as requested.  I still believe that this code should not crash just because a menu entry is missing.  It is enough to display an error message and log the error.  If the retention decision is reversed then remove the "SetupError()" class, the "raise SetupError()" line and associated comments.

    This code change improves Setup menu and index load times.

- [Setup.py] Clean up and optimise setup menu load

    Optimise, improve and enhance generation of Setup menu item lists.  For OpenViX and Beyonwiz this change allows the list to be processed once for display rather than the two or three cycles in the previous versions.

    Remove remnants of the setup.xml "separation" attribute directive.  This feature is now offered via the skin parameter "ConfigListSeperator".

    Create a log entry if the Setup menu has no valid entries.

    Obey Setup menu sort setting.

    Correctly detect a Setup Level change and update the list accordingly.

    If "%s %s" is found in an item's "text" or "description" attribute then replace it with the current box machine brand and model name.

- [Setup.py] Move description code, add footnote

    Move the description code from the SetupSummary class into the main Setup class where it is used.

    Add Beyonwiz and OpenViX footnote support code.  An "*" at the end of a menu item displays a message to the user that changing this setting will result in a GUI Restart.

    Add OpenViX menu path code to display the menu path to the current menu.

- [Setup.py] Add menuimage feature

    Add an option to provide setup menu images based on matching the setup menu "key" attribute with an image defined in a new <setups> block in the skin.  This code is conditional on having compatible changes in skin.py.  This will be subject to a separate pull request.

- [Setup.py] Add HELP button support

    Enable the HELP button to allow users to obtain help while using any Setup based screen.  This will be enhanced / accompanied by a separate pull request to also add this facility to the ConfigList.py part of the menu.

- [Setup.py] PEP8 clean up

    Perform a PEP8 clean up of the code.

- [Setup.py] Code clean for readability and tweaks

    Reorganise the imports and code blocks to improve readability of the newly refactored code.

    Check that the initialisation call back code is only added if not already added.

    The "setup_key" skin facility appears to have been unused.  The name has been changed to "Setup_key" to better match existing skin names.  This option allows skin designers to create custom Setup based screens for any Setup menu item.

    Rename the GREEN button text from "OK" to a more appropriate "Save".

    The overall effect of this series of changes is to make the Setup.py features a superset of all builds while also adding new features and options.  The setp.xml file is only loaded and processed once per boot or GUI restart.  The source file is checked for any changes and the file will be reloaded should the file be changed.  This means that the GUI no longer has to be restarted to allow changes to setup.xml to be processed (OpenPLi).  All the changes and enhancements come with an up to four-fold reduction in time to generate any Setup.py based setup menu (Beyonwiz and OpenViX).  The time taken to build any setup menu lists (non Beyonwiz builds) is slightly longer for the first menu item but then about 50 time faster for all subsequent searches.

- [SETUPGUIDE] Add documentation for Setup.py update

    This document explains the refactored and enhanced Setup.py.  Information is provided about:
    - the changes made during the refactor,
    - the setup.xml file syntax,
    - the "Setup" screen variables,
    - a sample "Setup" screen, and
    - the details of the new skin "setups" tag block


- [skin.py] Add support for Setup.py menuimages

    Add decoding for "`<setups>`" tag block.  See /doc/SETUPGUIDE for further information.

- [UsageConfig.py] Add Setup menu sort option

- [setup.xml] Add Setup sort entry

    Add a user configuration entry to support alphabetic sorting of any Setup based menu screens.
