### PR TITLE
[setup.xml] Suppress menu title warning

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -2,7 +2,7 @@
 	<setup key="timezone" title="Timezone">
 		<item level="0" text="Timezone">config.timezone.val</item>
 	</setup>
-	<setup key="avsetup">
+	<setup key="avsetup" title="A/V settings">
 		<!-- this is just a placeholder, the Videomode plugin implements this submenu -->
 	</setup>
 	<setup key="usage" title="Customize">


### PR DESCRIPTION
Add a title to the dummy "avsetup" menu entry to suppress the missing title error (`[Setup] Error: Setup ID 'avsetup' title is missing or blank!`) in the new Setup.py code.
