### PR TITLE
remove the refresh rate wizard when videomodus is rca

### DIFF
--- a/lib/python/Plugins/SystemPlugins/Videomode/videowizard.xml
+++ b/lib/python/Plugins/SystemPlugins/Videomode/videowizard.xml
@@ -22,7 +22,7 @@ self["portpic"].hide()
 	</step>
 	<step id="rateselection" timeout="20" timeoutaction="selectnext">
 		<condition>
-self.condition = (self.port != "DVI" or self.mode == "PC")
+self.condition = (self.port != "DVI" and not self.port == "RCA" or self.mode == "PC")
 		</condition>
 		<text value="Refresh rate selection." />
 		<displaytext value="Select refresh rate" />


### PR DESCRIPTION
all rca modes have static refresh rate so no point to set it
it cannot switch to modus like pal60 (480i)
(new patch based on https://github.com/OpenPLi/enigma2/pull/1439 )