### PR TITLE
po files creation delete obsolete strings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -131,8 +131,9 @@ if test "$with_po" = "yes"; then
 	AC_PATH_PROG(MSGINIT, msginit)
 	AC_PATH_PROG(MSGMERGE, msgmerge)
 	AC_PATH_PROG(MSGUNIQ, msguniq)
+	AC_PATH_PROG(MSGATTRIB, msgattrib)
 	AC_PATH_PROG(XGETTEXT, xgettext)
-	if test -z "$MSGINIT" -o -z "$MSGMERGE" -o -z "$MSGUNIQ" -o -z "$XGETTEXT"; then
+	if test -z "$MSGINIT" -o -z "$MSGMERGE" -o -z "$MSGUNIQ" -o -z "$MSGATTRIB" -o -z "$XGETTEXT"; then
 		AC_MSG_ERROR([Could not find required gettext tools])
 	fi
 fi

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -21,6 +21,7 @@ enigma2.pot: enigma2-py.pot enigma2-xml.pot
 %.po: enigma2.pot
 	if [ -f $@ ]; then \
 		$(MSGMERGE) --backup=none --no-wrap --no-location -s -U $@ $< && touch $@; \
+		$(MSGATTRIB) --no-wrap --no-obsolete $@ -o $@; \
 	else \
 		$(MSGINIT) -l $@ -o $@ -i $< --no-translator; \
 	fi


### PR DESCRIPTION
During po.files creation the obsolete translation remains in the generated .po files. This is useless and can create confusion for translators that compare there own file with the en.po one.
So this change will always create a clean .po file with only the useful translated and untranslated strings.
By using command:  msgattrib --no-wrap --no-obsolete