### PR TITLE
Adapt Makefile.am to allow .po files creation on OSX

### DIFF
--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -10,7 +10,7 @@ if UPDATE_PO
 # the TRANSLATORS: allows putting translation comments before the to-be-translated line.
 enigma2-py.pot: $(top_srcdir)/*.py $(top_srcdir)/lib/python/*/*.py $(top_srcdir)/lib/python/*/*/*.py $(top_srcdir)/lib/python/Plugins/*/*/*.py
 	$(XGETTEXT) --no-wrap -L Python --from-code=UTF-8 -kpgettext:1c,2 --add-comments="TRANSLATORS:" -d @PACKAGE_NAME@ -s -o $@ $^
-	sed --in-place $@ --expression=s/CHARSET/UTF-8/
+	$(SED) --in-place $@ --expression=s/CHARSET/UTF-8/
 
 enigma2-xml.pot: $(srcdir)/xml2po.py $(top_srcdir)/data/*.xml $(top_srcdir)/lib/python/Plugins/SystemPlugins/*/*.xml
 	$(PYTHON) $^ > $@


### PR DESCRIPTION
On OSX (Mac) the sed command is a BSD one and option are different, for the GNU version gsed must be used. Makefile autoconf create the variable SED that point to the correct "sed" (so on Mac point to gsed) so this is working fine if we use $(SED) in Makefile.am
With this change it is now possible to generate the po files on an Mac without manually editing the enigma2-py.pot file to change the CHARSET.