### PR TITLE
Fix HelpWindow position

### DIFF
--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -65,7 +65,8 @@ class ConfigList(GUIComponent, object):
 	GUI_WIDGET = eListbox
 
 	def selectionChanged(self):
-		self.onDeselect()
+		if isinstance(self.current, tuple) and len(self.current) >= 2:
+			self.current[1].onDeselect(self.session)
 		self.current = self.getCurrent()
 		if isinstance(self.current,tuple) and len(self.current) >= 2:
 			self.current[1].onSelect(self.session)
@@ -74,13 +75,13 @@ class ConfigList(GUIComponent, object):
 		for x in self.onSelectionChanged:
 			x()
 
-	def onDeselect(self):
+	def hideHelp(self):
 		if isinstance(self.current, tuple) and len(self.current) >= 2:
-			self.current[1].onDeselect(self.session)
+			self.current[1].hideHelp(self.session)
 
-	def onSelect(self):
+	def showHelp(self):
 		if isinstance(self.current, tuple) and len(self.current) >= 2:
-			self.current[1].onSelect(self.session)
+			self.current[1].showHelp(self.session)
 
 	def postWidgetCreate(self, instance):
 		instance.selectionChanged.get().append(self.selectionChanged)
@@ -88,7 +89,8 @@ class ConfigList(GUIComponent, object):
 		self.instance.setWrapAround(True)
 
 	def preWidgetRemove(self, instance):
-		self.onDeselect()
+		if isinstance(self.current, tuple) and len(self.current) >= 2:
+			self.current[1].onDeselect(self.session)
 		instance.selectionChanged.get().remove(self.selectionChanged)
 		instance.setContent(None)
 
@@ -213,7 +215,7 @@ class ConfigListScreen:
 				self["VKeyIcon"].boolean = False
 
 	def KeyText(self):
-		self["config"].onDeselect()
+		self["config"].hideHelp()
 		from Screens.VirtualKeyBoard import VirtualKeyBoard
 		self.session.openWithCallback(self.VirtualKeyBoardCallback, VirtualKeyBoard, title = self["config"].getCurrent()[0], text = self["config"].getCurrent()[1].getValue())
 
@@ -221,7 +223,7 @@ class ConfigListScreen:
 		if callback is not None and len(callback):
 			self["config"].getCurrent()[1].setValue(callback)
 			self["config"].invalidate(self["config"].getCurrent())
-		self["config"].onSelect()
+		self["config"].showHelp()
 
 	def keyOK(self):
 		self["config"].handleKey(KEY_OK)
@@ -294,7 +296,7 @@ class ConfigListScreen:
 
 	def cancelConfirm(self, result):
 		if not result:
-			self["config"].onSelect()
+			self["config"].showHelp()
 			return
 
 		for x in self["config"].list:
@@ -303,7 +305,7 @@ class ConfigListScreen:
 
 	def closeMenuList(self, recursive = False):
 		if self["config"].isChanged():
-			self["config"].onDeselect()
+			self["config"].hideHelp()
 			self.session.openWithCallback(self.cancelConfirm, MessageBox, _("Really close without saving settings?"))
 		else:
 			self.close(recursive)

--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -148,6 +148,12 @@ class ConfigElement(object):
 			self.changedFinal()
 			self.last_value = self.value
 
+	def hideHelp(self, session):
+		pass
+
+	def showHelp(self, session):
+		pass
+
 KEY_LEFT = 0
 KEY_RIGHT = 1
 KEY_OK = 2
@@ -1015,6 +1021,14 @@ class ConfigText(ConfigElement, NumericalTextInput):
 		if not self.last_value == self.value:
 			self.changedFinal()
 			self.last_value = self.value
+
+	def hideHelp(self, session):
+		if session is not None and self.help_window is not None:
+			self.help_window.hide()
+
+	def showHelp(self, session):
+		if session is not None and self.help_window is not None:
+			self.help_window.show()
 
 	def getHTML(self, id):
 		return '<input type="text" name="' + id + '" value="' + self.value + '" /><br>\n'


### PR DESCRIPTION
Add functions hideHelp and showHelp in config and use for HelpWindow.
This allow hide and show help_window in ConfigList.
Before that, the onDeselect and onSelect functions were used for it, which delete or add help_window instance.
It breaks the help_window position because it is set only once after the first help_window instance is added.
https://forums.openpli.org/topic/59254-do-commit-comments-get-read/