### PR TITLE
Update HardwareInfo.py

### DIFF
--- a/lib/python/Tools/HardwareInfo.py
+++ b/lib/python/Tools/HardwareInfo.py
@@ -75,7 +75,7 @@ class HardwareInfo:
 			return "%s (%s)" % (hw_info.device_model, hw_info.device_version)
 		return hw_info.device_model
 
-	def get_machine_name(self)
+	def get_machine_name(self):
 		# get the reported device model
 		machine = get_device_model()
 		# map Xtrend device models to machine names


### PR DESCRIPTION
Fix:
File "/usr/lib/enigma2/python/Components/SystemInfo.py", line 3, in <module>
ImportError: No module named HardwareInfo