### PR TITLE
[ActionMap] Improve initialisation and logging, add HelpableNumberActionMap

### DIFF
--- a/lib/python/Components/ActionMap.py
+++ b/lib/python/Components/ActionMap.py
@@ -1,9 +1,16 @@
+from Tools.KeyBindings import queryKeyBinding
+
 from enigma import eActionMap
 
+
 class ActionMap:
-	def __init__(self, contexts = [ ], actions = { }, prio=0):
-		self.actions = actions
+	def __init__(self, contexts=None, actions=None, prio=0):
+		if contexts is None:
+			contexts = []
+		if actions is None:
+			actions = {}
 		self.contexts = contexts
+		self.actions = actions
 		self.prio = prio
 		self.p = eActionMap.getInstance()
 		self.bound = False
@@ -41,18 +48,19 @@ class ActionMap:
 		self.checkBind()
 
 	def action(self, context, action):
-		print " ".join(("action -> ", context, action))
 		if action in self.actions:
+			print "[ActionMap] Keymap '%s' -> Action = '%s'" % (context, action)
 			res = self.actions[action]()
 			if res is not None:
 				return res
 			return 1
 		else:
-			print "unknown action %s/%s! typo in keymap?" % (context, action)
+			print "[ActionMap] Keymap '%s' -> Unknown action '%s'! (Typo in keymap?)" % (context, action)
 			return 0
 
 	def destroy(self):
 		pass
+
 
 class NumberActionMap(ActionMap):
 	def action(self, contexts, action):
@@ -64,10 +72,12 @@ class NumberActionMap(ActionMap):
 		else:
 			return ActionMap.action(self, contexts, action)
 
+
 class HelpableActionMap(ActionMap):
 	"""An Actionmap which automatically puts the actions into the helpList.
 
-	Note that you can only use ONE context here!"""
+	A context list is allowed, and for backward compatibility,
+	a single string context name also is allowed"""
 
 	# sorry for this complicated code.
 	# it's not more than converting a "documented" actionmap
@@ -77,17 +87,49 @@ class HelpableActionMap(ActionMap):
 	# the collected helpstrings (with correct context, action) is
 	# added to the screen's "helpList", which will be picked up by
 	# the "HelpableScreen".
-	def __init__(self, parent, context, actions = { }, prio=0):
-		alist = [ ]
-		adict = { }
-		for (action, funchelp) in actions.iteritems():
-			# check if this is a tuple
-			if isinstance(funchelp, tuple):
-				alist.append((action, funchelp[1]))
-				adict[action] = funchelp[0]
-			else:
-				adict[action] = funchelp
 
-		ActionMap.__init__(self, [context], adict, prio)
+	def __init__(self, parent, contexts, actions=None, prio=0, description=None):
+		if not hasattr(contexts, '__iter__'):
+			contexts = [contexts]
+		if actions is None:
+			actions = {}
+		self.description = description
+		adict = {}
+		for context in contexts:
+			alist = []
+			for (action, funchelp) in actions.iteritems():
+				# Check if this is a tuple
+				if isinstance(funchelp, tuple):
+					if queryKeyBinding(context, action):
+						alist.append((action, funchelp[1]))
+					adict[action] = funchelp[0]
+				else:
+					if queryKeyBinding(context, action):
+						alist.append((action, None))
+					adict[action] = funchelp
+			parent.helpList.append((self, context, alist))
+		ActionMap.__init__(self, contexts, adict, prio)
 
-		parent.helpList.append((self, context, alist))
+
+class HelpableNumberActionMap(NumberActionMap, HelpableActionMap):
+	"""An Actionmap which automatically puts the actions into the helpList.
+
+	A context list is allowed, and for backward compatibility,
+	a single string context name also is allowed"""
+
+	# sorry for this complicated code.
+	# it's not more than converting a "documented" actionmap
+	# (where the values are possibly (function, help)-tuples)
+	# into a "classic" actionmap, where values are just functions.
+	# the classic actionmap is then passed to the ActionMap constructor,
+	# the collected helpstrings (with correct context, action) is
+	# added to the screen's "helpList", which will be picked up by
+	# the "HelpableScreen".
+
+	def __init__(self, parent, contexts, actions=None, prio=0, description=None):
+		# Initialise NumberActionMap with empty context and actions
+		# so that the underlying ActionMap is only initialised with
+		# these once, via the HelpableActionMap.
+		#
+		NumberActionMap.__init__(self, [], {})
+		HelpableActionMap.__init__(self, parent, contexts, actions, prio, description)

--- a/lib/python/Components/ActionMap.py
+++ b/lib/python/Components/ActionMap.py
@@ -1,5 +1,3 @@
-from Tools.KeyBindings import queryKeyBinding
-
 from enigma import eActionMap
 
 
@@ -76,8 +74,7 @@ class NumberActionMap(ActionMap):
 class HelpableActionMap(ActionMap):
 	"""An Actionmap which automatically puts the actions into the helpList.
 
-	A context list is allowed, and for backward compatibility,
-	a single string context name also is allowed"""
+	Note that you can only use ONE context here!"""
 
 	# sorry for this complicated code.
 	# it's not more than converting a "documented" actionmap
@@ -87,35 +84,27 @@ class HelpableActionMap(ActionMap):
 	# the collected helpstrings (with correct context, action) is
 	# added to the screen's "helpList", which will be picked up by
 	# the "HelpableScreen".
-
-	def __init__(self, parent, contexts, actions=None, prio=0, description=None):
-		if not hasattr(contexts, '__iter__'):
-			contexts = [contexts]
+	def __init__(self, parent, context, actions=None, prio=0, description=None):
 		if actions is None:
 			actions = {}
 		self.description = description
+		alist = []
 		adict = {}
-		for context in contexts:
-			alist = []
-			for (action, funchelp) in actions.iteritems():
-				# Check if this is a tuple
-				if isinstance(funchelp, tuple):
-					if queryKeyBinding(context, action):
-						alist.append((action, funchelp[1]))
-					adict[action] = funchelp[0]
-				else:
-					if queryKeyBinding(context, action):
-						alist.append((action, None))
-					adict[action] = funchelp
-			parent.helpList.append((self, context, alist))
-		ActionMap.__init__(self, contexts, adict, prio)
+		for (action, funchelp) in actions.iteritems():
+			# Check if this is a tuple
+			if isinstance(funchelp, tuple):
+				alist.append((action, funchelp[1]))
+				adict[action] = funchelp[0]
+			else:
+				adict[action] = funchelp
+		ActionMap.__init__(self, [context], adict, prio)
+		parent.helpList.append((self, context, alist))
 
 
 class HelpableNumberActionMap(NumberActionMap, HelpableActionMap):
 	"""An Actionmap which automatically puts the actions into the helpList.
 
-	A context list is allowed, and for backward compatibility,
-	a single string context name also is allowed"""
+	Note that you can only use ONE context here!"""
 
 	# sorry for this complicated code.
 	# it's not more than converting a "documented" actionmap
@@ -126,10 +115,10 @@ class HelpableNumberActionMap(NumberActionMap, HelpableActionMap):
 	# added to the screen's "helpList", which will be picked up by
 	# the "HelpableScreen".
 
-	def __init__(self, parent, contexts, actions=None, prio=0, description=None):
+	def __init__(self, parent, context, actions=None, prio=0, description=None):
 		# Initialise NumberActionMap with empty context and actions
 		# so that the underlying ActionMap is only initialised with
 		# these once, via the HelpableActionMap.
 		#
 		NumberActionMap.__init__(self, [], {})
-		HelpableActionMap.__init__(self, parent, contexts, actions, prio, description)
+		HelpableActionMap.__init__(self, parent, context, actions, prio, description)

--- a/lib/python/Components/ActionMap.py
+++ b/lib/python/Components/ActionMap.py
@@ -84,6 +84,7 @@ class HelpableActionMap(ActionMap):
 	# the collected helpstrings (with correct context, action) is
 	# added to the screen's "helpList", which will be picked up by
 	# the "HelpableScreen".
+	#
 	def __init__(self, parent, context, actions=None, prio=0, description=None):
 		if actions is None:
 			actions = {}
@@ -114,7 +115,7 @@ class HelpableNumberActionMap(NumberActionMap, HelpableActionMap):
 	# the collected helpstrings (with correct context, action) is
 	# added to the screen's "helpList", which will be picked up by
 	# the "HelpableScreen".
-
+	#
 	def __init__(self, parent, context, actions=None, prio=0, description=None):
 		# Initialise NumberActionMap with empty context and actions
 		# so that the underlying ActionMap is only initialised with


### PR DESCRIPTION
- Use a slightly longer form of initialisation for the ActionMap `__init__`.  This format avoids an issue where the initialisation parameters become persistent across all invocations of this code.  This is inappropriate and undesirable.

    In essence the problem with the original code is that it appears to be an efficient way to create a default empty list and dictionary.  What actually happens is that these items get created as a *persistent* objects.  Every invocation of the `__init__` method that doesn't specify the parameters will use that *SAME* (persistent) objects.  Any changes to either object will *persist* (be remembered) and be carried forward into every other invocation of this method!  THIS IS NOT WHAT SHOULD HAPPEN!

    Please refer to http://pylint-messages.wikidot.com/messages:w0102 and https://nedbatchelder.com/blog/200806/pylint.html for more details.

- ActionMap / keymap errors are now reported in a single log line rather than taking two lines.

- Add a HelpableNumberActionMap for action map symmetry.

- PEP8 clean-up and fixes.

These changes should be fully backward compatible with all exiting Enigma2 code.  No changes to any existing code should be required required.

This code is based on code written by Prl (Nov-2014 - Jan-2015).
