### PR TITLE
Fix and Improve ActionMap

### DIFF
--- a/lib/python/Components/ActionMap.py
+++ b/lib/python/Components/ActionMap.py
@@ -1,9 +1,13 @@
 from enigma import eActionMap
 
 class ActionMap:
-	def __init__(self, contexts = [ ], actions = { }, prio=0):
-		self.actions = actions
+	def __init__(self, contexts=None, actions=None, prio=0):
+		if contexts is None:
+			contexts = []
+		if actions is None:
+			actions = {}
 		self.contexts = contexts
+		self.actions = actions
 		self.prio = prio
 		self.p = eActionMap.getInstance()
 		self.bound = False

--- a/lib/python/Components/ActionMap.py
+++ b/lib/python/Components/ActionMap.py
@@ -1,5 +1,6 @@
 from enigma import eActionMap
 
+
 class ActionMap:
 	def __init__(self, contexts=None, actions=None, prio=0):
 		if contexts is None:
@@ -58,6 +59,7 @@ class ActionMap:
 	def destroy(self):
 		pass
 
+
 class NumberActionMap(ActionMap):
 	def action(self, contexts, action):
 		if action in ("0", "1", "2", "3", "4", "5", "6", "7", "8", "9") and action in self.actions:
@@ -67,6 +69,7 @@ class NumberActionMap(ActionMap):
 			return 1
 		else:
 			return ActionMap.action(self, contexts, action)
+
 
 class HelpableActionMap(ActionMap):
 	"""An Actionmap which automatically puts the actions into the helpList.
@@ -81,22 +84,21 @@ class HelpableActionMap(ActionMap):
 	# the collected helpstrings (with correct context, action) is
 	# added to the screen's "helpList", which will be picked up by
 	# the "HelpableScreen".
+	#
 	def __init__(self, parent, context, actions=None, prio=0, description=None):
 		if actions is None:
 			actions = {}
 		self.description = description
-		alist = [ ]
-		adict = { }
+		alist = []
+		adict = {}
 		for (action, funchelp) in actions.iteritems():
-			# check if this is a tuple
+			# Check if this is a tuple.
 			if isinstance(funchelp, tuple):
 				alist.append((action, funchelp[1]))
 				adict[action] = funchelp[0]
 			else:
 				adict[action] = funchelp
-
 		ActionMap.__init__(self, [context], adict, prio)
-
 		parent.helpList.append((self, context, alist))
 
 

--- a/lib/python/Components/ActionMap.py
+++ b/lib/python/Components/ActionMap.py
@@ -81,7 +81,10 @@ class HelpableActionMap(ActionMap):
 	# the collected helpstrings (with correct context, action) is
 	# added to the screen's "helpList", which will be picked up by
 	# the "HelpableScreen".
-	def __init__(self, parent, context, actions = { }, prio=0):
+	def __init__(self, parent, context, actions=None, prio=0, description=None):
+		if actions is None:
+			actions = {}
+		self.description = description
 		alist = [ ]
 		adict = { }
 		for (action, funchelp) in actions.iteritems():

--- a/lib/python/Components/ActionMap.py
+++ b/lib/python/Components/ActionMap.py
@@ -45,14 +45,14 @@ class ActionMap:
 		self.checkBind()
 
 	def action(self, context, action):
-		print " ".join(("action -> ", context, action))
 		if action in self.actions:
+			print "[ActionMap] Keymap '%s' -> Action = '%s'" % (context, action)
 			res = self.actions[action]()
 			if res is not None:
 				return res
 			return 1
 		else:
-			print "unknown action %s/%s! typo in keymap?" % (context, action)
+			print "[ActionMap] Keymap '%s' -> Unknown action '%s'! (Typo in keymap?)" % (context, action)
 			return 0
 
 	def destroy(self):

--- a/lib/python/Components/ActionMap.py
+++ b/lib/python/Components/ActionMap.py
@@ -95,3 +95,26 @@ class HelpableActionMap(ActionMap):
 		ActionMap.__init__(self, [context], adict, prio)
 
 		parent.helpList.append((self, context, alist))
+
+
+class HelpableNumberActionMap(NumberActionMap, HelpableActionMap):
+	"""An Actionmap which automatically puts the actions into the helpList.
+
+	Note that you can only use ONE context here!"""
+
+	# sorry for this complicated code.
+	# it's not more than converting a "documented" actionmap
+	# (where the values are possibly (function, help)-tuples)
+	# into a "classic" actionmap, where values are just functions.
+	# the classic actionmap is then passed to the ActionMap constructor,
+	# the collected helpstrings (with correct context, action) is
+	# added to the screen's "helpList", which will be picked up by
+	# the "HelpableScreen".
+	#
+	def __init__(self, parent, context, actions=None, prio=0, description=None):
+		# Initialise NumberActionMap with empty context and actions
+		# so that the underlying ActionMap is only initialised with
+		# these once, via the HelpableActionMap.
+		#
+		NumberActionMap.__init__(self, [], {})
+		HelpableActionMap.__init__(self, parent, context, actions, prio, description)


### PR DESCRIPTION
- Use a slightly longer form of initialisation for the ActionMap `__init__`.  This format avoids an issue where the initialisation parameters become persistent across all invocations of this code.  This is inappropriate and undesirable.

  In essence the problem with the original code is that it appears to be an efficient way to create a default empty list and dictionary.  What actually happens is that these items get created as a *persistent* objects.  Every invocation of the `__init__` method that doesn't specify the parameters will use that *SAME* (persistent) objects.  Any changes to either object will *persist* (be remembered) and be carried forward into every other invocation of this method!  THIS IS NOT WHAT SHOULD HAPPEN!

  Please refer to http://pylint-messages.wikidot.com/messages:w0102 and https://nedbatchelder.com/blog/200806/pylint.html for more details.

- ActionMap / keymap errors are now reported in a single log line rather than taking two lines.

- Add a HelpableNumberActionMap for action map symmetry.

- Use a slightly longer form of initialisation for the HelpableActionMap `__init__`.  This format avoids an issue where the initialisation parameters become persistent across all invocations of this code.  This is inappropriate and undesirable.

  See explanation in ActionMap comment avove.

- Perform a PEP8 clean up of the code and comments.


