### PR TITLE
Fix &quot; problem when used in xml

### DIFF
--- a/po/xml2po.py
+++ b/po/xml2po.py
@@ -61,6 +61,7 @@ for arg in sys.argv[1:]:
 		if c:
 			for l in c.split('\n'):
 				print "#. ", l
+		k=k.replace('\"', '\\"')
 		print 'msgid "' + str(k) + '"'
 		print 'msgstr ""'
 


### PR DESCRIPTION
When &quot; is used in the source xml file, the generated msgid string has a double quote in the text, this double quote must be escaped in order to generate a proper .pot file.