### PR TITLE
InfoBarCueSheetSupport: on playback startup show the question only if it is set in the settings

### DIFF
--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -3068,10 +3068,10 @@ class InfoBarCueSheetSupport:
 			if length[0]:
 				length = (-1, 0) #  Set length 0 if error in getLength()
 			print "seekable.getLength() returns:", length
-			if (last > 900000) and (not length[1]  or (last < length[1] - 900000)):
+			if (last > 900000) and (not length[1] or last < length[1] - 900000):
 				self.resume_point = last
 				l = last / 90000
-				if "ask" in config.usage.on_movie_start.value or not length[1]:
+				if "ask" in config.usage.on_movie_start.value:
 					Notifications.AddNotificationWithCallback(self.playLastCB, MessageBox, _("Do you want to resume this playback?") + "\n" + (_("Resume position at %s") % ("%d:%02d:%02d" % (l/3600, l%3600/60, l%60))), timeout=10, default="yes" in config.usage.on_movie_start.value)
 				elif config.usage.on_movie_start.value == "resume":
 # TRANSLATORS: The string "Resuming playback" flashes for a moment


### PR DESCRIPTION
Fix error intruduced in https://github.com/OpenPLi/enigma2/commit/88ae2af46810e58eb2866e5f350aaeb87b6561c3
If the length is returned correctly (higer that 0) is checked before, the question in message box need displayed only if it is set in the settings,

Also removes unnecessary brackets in check.