### PR TITLE
servicemp3: Move event evStart to the READY to PAUSED

### DIFF
--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -1796,13 +1796,10 @@ void eServiceMP3::gstBusCall(GstMessage *msg)
 
 			switch(transition)
 			{
-				case GST_STATE_CHANGE_NULL_TO_READY:
-				{
-					m_event(this, evStart);
-				}	break;
 				case GST_STATE_CHANGE_READY_TO_PAUSED:
 				{
 					m_state = stRunning;
+					m_event(this, evStart);
 #if GST_VERSION_MAJOR >= 1
 					GValue result = { 0, };
 #endif
@@ -1947,9 +1944,6 @@ void eServiceMP3::gstBusCall(GstMessage *msg)
 						gst_object_unref(GST_OBJECT(videoSink));
 						videoSink = NULL;
 					}
-				}	break;
-				case GST_STATE_CHANGE_READY_TO_NULL:
-				{
 				}	break;
 			}
 			break;


### PR DESCRIPTION
Playback starts and seek functions start working only after READY to PAUSED.
Thefore move evStart from NULL to READY to this state.
This for example fix getLength problem on playback start.

Also remove unused state transition checks.

This dublicate commit in seperate servicemp3 witch is used on branch develop https://github.com/OpenPLi/servicemp3/commit/885e0591fa4f31f9061c22d7aae34fa1c76beda2