### PR TITLE
httpstream: Call getConfigBoolValue from mainloop

### DIFF
--- a/lib/base/httpsstream.cpp
+++ b/lib/base/httpsstream.cpp
@@ -19,6 +19,10 @@ eHttpsStream::eHttpsStream()
 	partialPktSz = 0;
 	tmpBufSize = 32;
 	tmpBuf = (char*)malloc(tmpBufSize);
+	if (eConfigManager::getConfigBoolValue("config.usage.remote_fallback_enabled", false))
+		startDelay = 500000;
+	else
+		startDelay = 0;
 
 	ctx = NULL;
 	ssl = NULL;
@@ -311,8 +315,7 @@ int eHttpsStream::open(const char *url)
 void eHttpsStream::thread()
 {
 	hasStarted();
-	if (eConfigManager::getConfigBoolValue("config.usage.remote_fallback_enabled", false))
-		usleep(500000); // wait half a second
+	usleep(startDelay); // wait up to half a second
 	std::string currenturl, newurl;
 	currenturl = streamUrl;
 	for (unsigned int i = 0; i < 5; i++)

--- a/lib/base/httpsstream.h
+++ b/lib/base/httpsstream.h
@@ -24,6 +24,7 @@ class eHttpsStream: public iTsSource, public sigc::trackable, public eThread
 	size_t partialPktSz;
 	char* tmpBuf;
 	size_t tmpBufSize;
+	int startDelay;
 
 	int openUrl(const std::string &url, std::string &newurl);
 	void thread();

--- a/lib/base/httpstream.cpp
+++ b/lib/base/httpstream.cpp
@@ -16,6 +16,10 @@ eHttpStream::eHttpStream()
 	partialPktSz = 0;
 	tmpBufSize = 32;
 	tmpBuf = (char*)malloc(tmpBufSize);
+	if (eConfigManager::getConfigBoolValue("config.usage.remote_fallback_enabled", false))
+		startDelay = 500000;
+	else
+		startDelay = 0;
 }
 
 eHttpStream::~eHttpStream()
@@ -236,8 +240,7 @@ int eHttpStream::open(const char *url)
 void eHttpStream::thread()
 {
 	hasStarted();
-	if (eConfigManager::getConfigBoolValue("config.usage.remote_fallback_enabled", false))
-		usleep(500000); // wait half a second
+	usleep(startDelay); // wait up to half a second
 	std::string currenturl, newurl;
 	currenturl = streamUrl;
 	for (unsigned int i = 0; i < 5; i++)

--- a/lib/base/httpstream.h
+++ b/lib/base/httpstream.h
@@ -20,6 +20,7 @@ class eHttpStream: public iTsSource, public sigc::trackable, public eThread
 	size_t partialPktSz;
 	char* tmpBuf;
 	size_t tmpBufSize;
+	int startDelay;
 
 	int openUrl(const std::string &url, std::string &newurl);
 	void thread();


### PR DESCRIPTION
Python code can only be called from the mainloop. This fixes
various crashes when httpstreams were used.