### PR TITLE
Fix crash change language by pressing yellow button ...

### DIFF
--- a/lib/python/Screens/VirtualKeyBoard.py
+++ b/lib/python/Screens/VirtualKeyBoard.py
@@ -368,7 +368,8 @@ class VirtualKeyBoard(Screen):
 			self.lang = 'en_EN'
 			self.nextLang = 'ar_AE'
 		self["country"].setText(self.lang)
-		self["key_yellow"].setText(language.lang[self.lang][0])
+		self["key_yellow"].setText(self.lang)
+		self.max_key=47+len(self.keys_list[4])
 
 	def virtualKeyBoardEntryComponent(self, keys):
 		w, h = skin.parameters.get("VirtualKeyboard",(45, 45))


### PR DESCRIPTION
>   File "/usr/lib/enigma2/python/Components/ActionMap.py", line 69, in action
  File "/usr/lib/enigma2/python/Components/ActionMap.py", line 49, in action
  File "/usr/lib/enigma2/python/Screens/VirtualKeyBoard.py", line 134, in switchLang
    self.setLang()
  File "/usr/lib/enigma2/python/Screens/VirtualKeyBoard.py", line 371, in setLang
    self["key_yellow"].setText(language.lang[self.lang][0])
KeyError: 'cs_CZ'