### PR TITLE
Add FEC 3/5 and 4/5 for dvb-t2

### DIFF
--- a/lib/dvb/frontendparms.cpp
+++ b/lib/dvb/frontendparms.cpp
@@ -506,6 +506,10 @@ int eDVBTerrestrialTransponderData::getCodeRateLp() const
 	case FEC_3_4: return eDVBFrontendParametersTerrestrial::FEC_3_4;
 	case FEC_5_6: return eDVBFrontendParametersTerrestrial::FEC_5_6;
 	case FEC_7_8: return eDVBFrontendParametersTerrestrial::FEC_7_8;
+	case FEC_6_7: return eDVBFrontendParametersTerrestrial::FEC_6_7;
+	case FEC_8_9: return eDVBFrontendParametersTerrestrial::FEC_8_9;
+	case FEC_3_5: return eDVBFrontendParametersTerrestrial::FEC_3_5;
+	case FEC_4_5: return eDVBFrontendParametersTerrestrial::FEC_4_5;
 	default:
 	case FEC_AUTO: return eDVBFrontendParametersTerrestrial::FEC_Auto;
 	}
@@ -522,6 +526,10 @@ int eDVBTerrestrialTransponderData::getCodeRateHp() const
 	case FEC_3_4: return eDVBFrontendParametersTerrestrial::FEC_3_4;
 	case FEC_5_6: return eDVBFrontendParametersTerrestrial::FEC_5_6;
 	case FEC_7_8: return eDVBFrontendParametersTerrestrial::FEC_7_8;
+	case FEC_6_7: return eDVBFrontendParametersTerrestrial::FEC_6_7;
+	case FEC_8_9: return eDVBFrontendParametersTerrestrial::FEC_8_9;
+	case FEC_3_5: return eDVBFrontendParametersTerrestrial::FEC_3_5;
+	case FEC_4_5: return eDVBFrontendParametersTerrestrial::FEC_4_5;
 	default:
 	case FEC_AUTO: return eDVBFrontendParametersTerrestrial::FEC_Auto;
 	}

--- a/lib/dvb/frontendparms.h
+++ b/lib/dvb/frontendparms.h
@@ -113,7 +113,7 @@ public:
 	 * (and it's too late to fix this now, we would break backward compatibility)
 	 */
 	enum {
-		FEC_1_2=0, FEC_2_3=1, FEC_3_4=2, FEC_5_6=3, FEC_7_8=4, FEC_Auto=5, FEC_6_7=6, FEC_8_9=7
+		FEC_1_2=0, FEC_2_3=1, FEC_3_4=2, FEC_5_6=3, FEC_7_8=4, FEC_Auto=5, FEC_6_7=6, FEC_8_9=7, FEC_3_5=8, FEC_4_5=9
 	};
 
 	enum {


### PR DESCRIPTION
See: https://en.wikipedia.org/wiki/DVB-T2

Also we had FEC 6/7 and 8/9 in "frontendparms.h" but not in "frontendparms.cpp" for "eDVBFrontendParametersTerrestrial"