### PR TITLE
encoding.conf: Enable UTF-8 for Persian

### DIFF
--- a/data/encoding.conf
+++ b/data/encoding.conf
@@ -17,6 +17,10 @@ slk ISO6937
 chi GB18030
 zho GB18030
 chn GB18030
+fas UTF-8
+per UTF-8
+fa UTF-8
+pes UTF-8
 
 #Fallback encoding when in dvb-text no encoding table is given
 #and no Countrycode  and no transponders configs in this config file


### PR DESCRIPTION
I know Codepage 1256 - Microsoft Windows Arabic supports Persian but it's not defined in enigma2's encoding so enable UTF-8 for Persian.

I did close https://github.com/OpenPLi/enigma2/pull/1612 as github changes the file encoding by default:

"We’ve detected the file encoding as ISO-8859-1. When you commit changes we will transcode it to UTF-8."