### PR TITLE
EventView - avoid crash using KEY_INFO

### DIFF
--- a/lib/python/Screens/EventView.py
+++ b/lib/python/Screens/EventView.py
@@ -329,7 +329,7 @@ class EventViewSimple(Screen, EventViewBase):
 	def __init__(self, session, Event, Ref, callback=None, similarEPGCB=None, parent=None):
 		Screen.__init__(self, session)
 		self.skinName = "EventView"
-		EventViewBase.__init__(self, Event, Ref, callback, similarEPGCB, parent)
+		EventViewBase.__init__(self, Event, Ref, callback, similarEPGCB)
 
 class EventViewEPGSelect(Screen, EventViewBase):
 	def __init__(self, session, Event, Ref, callback=None, singleEPGCB=None, multiEPGCB=None, similarEPGCB=None, parent=None):
@@ -337,7 +337,7 @@ class EventViewEPGSelect(Screen, EventViewBase):
 		self.skinName = "EventView"
 		self.singleEPGCB = singleEPGCB
 		self.multiEPGCB = multiEPGCB
-		EventViewBase.__init__(self, Event, Ref, callback, similarEPGCB, parent)
+		EventViewBase.__init__(self, Event, Ref, callback, similarEPGCB)
 		self["key_yellow"].setText(_("Single EPG"))
 		self["key_blue"].setText(_("Multi EPG"))
 		self["epgactions"] = ActionMap(["EventViewEPGActions"],


### PR DESCRIPTION
EventViewBase.__init__(self, Event, Ref, callback, similarEPGCB, parent)
TypeError: EventViewBase__init__() takes at most 5 arguments (6 given)

re-commit previous commit to correct commit info - working tree must have been dirty...

Thank's teamblue
https://github.com/teamblue-e2/enigma2/commit/b8c71d7fcbe1fb7c6d57ca6bde75c0f72bad33b2#diff-0b2df61f72a741cfb67a38e78da24ec5