### PR TITLE
Add DTS-HD,WMA pro downmix and AC3 plus, AAC transcoding control

### DIFF
--- a/lib/python/Components/AVSwitch.py
+++ b/lib/python/Components/AVSwitch.py
@@ -202,6 +202,50 @@ def InitAVSwitch():
 			open("/proc/stb/audio/aac", "w").write(configElement.value and "downmix" or "passthrough")
 		config.av.downmix_aac = ConfigYesNo(default = True)
 		config.av.downmix_aac.addNotifier(setAACDownmix)
+		
+	try:
+		SystemInfo["CanDownmixDTSHD"] = "downmix" in open("/proc/stb/audio/dtshd_choices", "r").read()
+	except:
+		SystemInfo["CanDownmixDTSHD"] = False
+
+	if SystemInfo["CanDownmixDTSHD"]:
+		def setDTSHDDownmix(configElement):
+			open("/proc/stb/audio/dtshd", "w").write(configElement.value)
+		config.av.downmix_dtshd = ConfigSelection(default = "downmix", choices = [("downmix",  _("Downmix")), ("force_dts", _("convert to DTS")), ("use_hdmi_caps",  _("controlled by HDMI")), ("multichannel",  _("convert to multi-channel PCM")), ("hdmi_best",  _("use best, controlled by HDMI"))]
+		config.av.downmix_dtshd.addNotifier(setDTSHDDownmix)
+		
+	try:
+		SystemInfo["CanDownmixWMApro"] = "downmix" in open("/proc/stb/audio/wmapro_choices", "r").read()
+	except:
+		SystemInfo["CanDownmixWMApro"] = False
+
+	if SystemInfo["CanDownmixWMApro"]:
+		def setWMAproDownmix(configElement):
+			open("/proc/stb/audio/wmapro", "w").write(configElement.value)
+		config.av.downmix_wmapro = ConfigSelection(default = "downmix", choices = [("downmix",  _("Downmix")), ("passthrough", _("Passthrough")), ("multichannel",  _("convert to multi-channel PCM")), ("hdmi_best",  _("use best, controlled by HDMI"))]
+		config.av.downmix_wmapro.addNotifier(setWMAproDownmix)
+		
+	try:
+		SystemInfo["CanAC3plusTranscode"] = "force_ac3" in open("/proc/stb/audio/ac3plus_choices", "r").read()
+	except:
+		SystemInfo["CanAC3plusTranscode"] = False
+
+	if SystemInfo["CanAC3plusTranscode"]:
+		def setAC3plusTranscode(configElement):
+			open("/proc/stb/audio/ac3plus", "w").write(configElement.value)
+		config.av.transcode_ac3plus = ConfigSelection(default = "force_ac3", choices = [("use_hdmi_caps", _("controlled by HDMI")), ("force_ac3", _("convert to AC3")), ("multichannel",  _("convert to multi-channel PCM")), ("hdmi_best",  _("use best, controlled by HDMI")), ("force_ddp",  _("force AC3 plus"))]
+		config.av.transcode_ac3plus.addNotifier(setAC3plusTranscode)
+		
+	try:
+		SystemInfo["CanAACTranscode"] = "off" in open("/proc/stb/audio/aac_transcode_choices", "r").read()
+	except:
+		SystemInfo["CanAACTranscode"] = False
+
+	if SystemInfo["CanAACTranscode"]:
+		def setAACTranscode(configElement):
+			open("/proc/stb/audio/aac_transcode", "w").write(configElement.value)
+		config.av.transcode_aac = ConfigSelection(default = "off", choices = [("off", _("Off")), ("ac3", _("AC3")), ("dts", _("DTS"))]
+		config.av.transcode_aac.addNotifier(setAACTranscode)
 
 	try:
 		SystemInfo["CanChangeOsdAlpha"] = open("/proc/stb/video/alpha", "r") and True or False

--- a/lib/python/Plugins/SystemPlugins/Videomode/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Videomode/plugin.py
@@ -124,6 +124,14 @@ class VideoSetup(Screen, ConfigListScreen):
 				getConfigListEntry(_("General AC3 delay"), config.av.generalAC3delay, _("Configure the general audio delay of Dolby Digital sound tracks.")),
 				getConfigListEntry(_("General PCM delay"), config.av.generalPCMdelay, _("Configure the general audio delay of stereo sound tracks."))
 			))
+			if SystemInfo["CanDownmixDTSHD"]:
+				self.list.append(getConfigListEntry(_("DTS-HD downmix"), config.av.downmix_dtshd, _("Configure whether DTS-HD channel sound tracks should be downmixed or transcoded.")))
+			if SystemInfo["CanDownmixWMApro"]:
+				self.list.append(getConfigListEntry(_("WMA pro downmix"), config.av.downmix_wmapro, _("Configure whether WMA pro channel sound tracks should be downmixed or transcoded.")))
+			if SystemInfo["CanAC3plusTranscode"]:
+				self.list.append(getConfigListEntry(_("AC3 plus transcoding"), config.av.transcode_ac3plus, _("Configure whether AC3 plus sound tracks should be transcoded to AC3.")))
+			if SystemInfo["CanAACTranscode"]:
+				self.list.append(getConfigListEntry(_("AAC transcoding"), config.av.transcode_aac, _("Configure whether AAC sound tracks should be transcoded.")))
 			if SystemInfo["HasMultichannelPCM"]:
 				self.list.append(getConfigListEntry(_("Multichannel PCM"), config.av.multichannel_pcm, _("Configure whether multi channel PCM sound should be enabled.")))
 			if SystemInfo["HasAutoVolume"] or SystemInfo["HasAutoVolumeLevel"]:

--- a/lib/python/Screens/AudioSelection.py
+++ b/lib/python/Screens/AudioSelection.py
@@ -264,6 +264,18 @@ class AudioSelection(Screen, ConfigListScreen):
 		if SystemInfo["CanDownmixAAC"]:
 			config.av.downmix_aac.value = config.av.downmix_ac3.value
 			config.av.downmix_aac.save()
+		if SystemInfo["CanDownmixDTSHD"]:
+			config.av.downmix_dtshd.value = config.av.downmix_dtshd.value
+			config.av.downmix_dtshd.save()
+		if SystemInfo["CanDownmixWMApro"]:
+			config.av.downmix_wmapro.value = config.av.downmix_wmapro.value
+			config.av.downmix_wmapro.save()
+		if SystemInfo["CanAC3plusTranscode"]:
+			config.av.transcode_ac3plus.value = config.av.transcode_ac3plus.value
+			config.av.transcode_ac3plus.save()
+		if SystemInfo["CanAACTranscode"]:
+			config.av.transcode_aac.value = config.av.transcode_aac.value
+			config.av.transcode_aac.save()
 
 	def changeMode(self, mode):
 		if mode is not None and self.audioChannel:


### PR DESCRIPTION
Let enigma2 control:

DTS-HD downmix
WMA pro downmix
AC3 plus transcoding
AAC transcoding

for supported STBs, also make choices translatable not like https://github.com/OpenPLi/enigma2/blob/develop/lib/python/Components/AVSwitch.py#L180 for example.

Also I don't get why did you use "downmix_ac3" instead of "downmix_aac" for https://github.com/OpenPLi/enigma2/blob/develop/lib/python/Screens/AudioSelection.py#L265