### PR TITLE
Add DTS-HD,WMA pro downmix and AC3 plus, AAC transcoding control

### DIFF
--- a/lib/python/Components/AVSwitch.py
+++ b/lib/python/Components/AVSwitch.py
@@ -203,6 +203,30 @@ def InitAVSwitch():
 		config.av.downmix_aac = ConfigYesNo(default = True)
 		config.av.downmix_aac.addNotifier(setAACDownmix)
 
+	if SystemInfo["CanDownmixDTSHD"]:
+		def setDTSHDDownmix(configElement):
+			open("/proc/stb/audio/dtshd", "w").write(configElement.value)
+		config.av.downmix_dtshd = ConfigSelection(default = "downmix", choices = [("downmix",  _("Downmix")), ("force_dts", _("convert to DTS")), ("use_hdmi_caps",  _("controlled by HDMI")), ("multichannel",  _("convert to multi-channel PCM")), ("hdmi_best",  _("use best, controlled by HDMI"))]
+		config.av.downmix_dtshd.addNotifier(setDTSHDDownmix)
+
+	if SystemInfo["CanDownmixWMApro"]:
+		def setWMAproDownmix(configElement):
+			open("/proc/stb/audio/wmapro", "w").write(configElement.value)
+		config.av.downmix_wmapro = ConfigSelection(default = "downmix", choices = [("downmix",  _("Downmix")), ("passthrough", _("Passthrough")), ("multichannel",  _("convert to multi-channel PCM")), ("hdmi_best",  _("use best, controlled by HDMI"))]
+		config.av.downmix_wmapro.addNotifier(setWMAproDownmix)
+
+	if SystemInfo["CanAC3plusTranscode"]:
+		def setAC3plusTranscode(configElement):
+			open("/proc/stb/audio/ac3plus", "w").write(configElement.value)
+		config.av.transcode_ac3plus = ConfigSelection(default = "force_ac3", choices = [("use_hdmi_caps", _("controlled by HDMI")), ("force_ac3", _("convert to AC3")), ("multichannel",  _("convert to multi-channel PCM")), ("hdmi_best",  _("use best, controlled by HDMI")), ("force_ddp",  _("force AC3 plus"))]
+		config.av.transcode_ac3plus.addNotifier(setAC3plusTranscode)
+
+	if SystemInfo["CanAACTranscode"]:
+		def setAACTranscode(configElement):
+			open("/proc/stb/audio/aac_transcode", "w").write(configElement.value)
+		config.av.transcode_aac = ConfigSelection(default = "off", choices = [("off", _("Off")), ("ac3", _("AC3")), ("dts", _("DTS"))]
+		config.av.transcode_aac.addNotifier(setAACTranscode)
+
 	try:
 		SystemInfo["CanChangeOsdAlpha"] = open("/proc/stb/video/alpha", "r") and True or False
 	except:

--- a/lib/python/Components/SystemInfo.py
+++ b/lib/python/Components/SystemInfo.py
@@ -95,3 +95,7 @@ SystemInfo["HasOfflineDecoding"] = HardwareInfo().get_device_model() not in ('os
 SystemInfo["canFlashWithOfgwrite"] = not HardwareInfo().get_device_model().startswith("dm")
 SystemInfo["canMultiBoot"] = HardwareInfo().get_device_model() in ('hd51', 'h7', 'vs1500', 'e4hd') and (1, 4) or HardwareInfo().get_device_model() in ('gbue4k', 'gbquad4k') and (3, 3)
 SystemInfo["canMode12"] = HardwareInfo().get_device_model() in ("hd51", "vs1500") and '192M' or HardwareInfo().get_device_model() in ("h7") and '200M'
+SystemInfo["CanDownmixDTSHD"] = fileExists("/proc/stb/audio/dtshd_choices") or fileExists("/proc/stb/audio/dtshd")
+SystemInfo["CanDownmixWMApro"] = fileExists("/proc/stb/audio/wmapro_choices") or fileExists("/proc/stb/audio/wmapro")
+SystemInfo["CanAC3plusTranscode"] = fileExists("/proc/stb/audio/ac3plus_choices") or fileExists("/proc/stb/audio/ac3plus")
+SystemInfo["CanAACTranscode"] = fileExists("/proc/stb/audio/aac_transcode_choices") or fileExists("/proc/stb/audio/aac_transcode")

--- a/lib/python/Plugins/SystemPlugins/Videomode/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Videomode/plugin.py
@@ -124,6 +124,14 @@ class VideoSetup(Screen, ConfigListScreen):
 				getConfigListEntry(_("General AC3 delay"), config.av.generalAC3delay, _("Configure the general audio delay of Dolby Digital sound tracks.")),
 				getConfigListEntry(_("General PCM delay"), config.av.generalPCMdelay, _("Configure the general audio delay of stereo sound tracks."))
 			))
+			if SystemInfo["CanDownmixDTSHD"]:
+				self.list.append(getConfigListEntry(_("DTS-HD downmix"), config.av.downmix_dtshd, _("Configure whether DTS-HD channel sound tracks should be downmixed or transcoded.")))
+			if SystemInfo["CanDownmixWMApro"]:
+				self.list.append(getConfigListEntry(_("WMA pro downmix"), config.av.downmix_wmapro, _("Configure whether WMA pro channel sound tracks should be downmixed or transcoded.")))
+			if SystemInfo["CanAC3plusTranscode"]:
+				self.list.append(getConfigListEntry(_("AC3 plus transcoding"), config.av.transcode_ac3plus, _("Configure whether AC3 plus sound tracks should be transcoded to AC3.")))
+			if SystemInfo["CanAACTranscode"]:
+				self.list.append(getConfigListEntry(_("AAC transcoding"), config.av.transcode_aac, _("Configure whether AAC sound tracks should be transcoded.")))
 			if SystemInfo["HasMultichannelPCM"]:
 				self.list.append(getConfigListEntry(_("Multichannel PCM"), config.av.multichannel_pcm, _("Configure whether multi channel PCM sound should be enabled.")))
 			if SystemInfo["HasAutoVolume"] or SystemInfo["HasAutoVolumeLevel"]:

--- a/lib/python/Screens/AudioSelection.py
+++ b/lib/python/Screens/AudioSelection.py
@@ -95,7 +95,16 @@ class AudioSelection(Screen, ConfigListScreen):
 				self.settings.downmix.addNotifier(self.changeAC3Downmix, initial_call = False)
 				conflist.append(getConfigListEntry(_("Multi channel downmix"), self.settings.downmix))
 				self["key_red"].setBoolean(True)
-
+			if SystemInfo["CanAC3plusTranscode"]:
+				choice_list = [("use_hdmi_caps", _("controlled by HDMI")), ("force_ac3", _("convert to AC3")), ("multichannel",  _("convert to multi-channel PCM")), ("hdmi_best",  _("use best, controlled by HDMI")), ("force_ddp",  _("force AC3 plus"))]
+				self.settings.transcode_ac3plus = ConfigSelection(choices = choice_list, default = "force_ac3")
+				self.settings.transcode_ac3plus.addNotifier(self.setAC3plusTranscode, initial_call = False)
+				conflist.append(getConfigListEntry(_("AC3 plus transcoding"), self.settings.transcode_ac3plus, None))
+			if SystemInfo["CanAACTranscode"]:
+				choice_list = [("off", _("off")), ("ac3", _("AC3")), ("dts", _("DTS"))]
+				self.settings.transcode_aac = ConfigSelection(choices = choice_list, default = "off")
+				self.settings.transcode_aac.addNotifier(self.setAACTranscode, initial_call = False)
+				conflist.append(getConfigListEntry(_("AAC transcoding"), self.settings.transcode_aac, None))
 			if n > 0:
 				self.audioChannel = service.audioChannel()
 				if self.audioChannel:
@@ -264,6 +273,14 @@ class AudioSelection(Screen, ConfigListScreen):
 		if SystemInfo["CanDownmixAAC"]:
 			config.av.downmix_aac.value = config.av.downmix_ac3.value
 			config.av.downmix_aac.save()
+			
+	def setAC3plusTranscode(self, transcode):
+		config.av.transcode_ac3plus.setValue(transcode)
+		config.av.transcode_ac3plus.save()
+		
+	def setAACTranscode(self, transcode):
+		config.av.transcode_aac.setValue(transcode)
+		config.av.transcode_aac.save()
 
 	def changeMode(self, mode):
 		if mode is not None and self.audioChannel:


### PR DESCRIPTION
Let enigma2 control:

DTS-HD downmix
WMA pro downmix
AC3 plus transcoding
AAC transcoding

for supported STBs, also make choices translatable not like https://github.com/OpenPLi/enigma2/blob/develop/lib/python/Components/AVSwitch.py#L180 for example.