### PR TITLE
Fix Zgemma h9 CPU info (undefined problem)

### DIFF
--- a/lib/python/Components/About.py
+++ b/lib/python/Components/About.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import sys, os, time
 from Tools.HardwareInfo import HardwareInfo
+from Tools.Directories import fileCheck
 
 def getVersionString():
 	return getImageVersionString()
@@ -76,6 +77,10 @@ def getCPUInfoString():
 	try:
 		cpu_count = 0
 		cpu_speed = 0
+		if HardwareInfo().get_device_model() in ("h9") and fileCheck("/proc/stb/info/chipset"):
+			f = open("/proc/stb/info/chipset", 'r')
+			processor = f.readline().strip()
+			f.close()
 		for line in open("/proc/cpuinfo").readlines():
 			line = [x.strip() for x in line.strip().split(":")]
 			if line[0] in ("system type", "model name"):


### PR DESCRIPTION
/proc/cpuinfo won't give us what we need for h9 instead /proc/stb/info/chipset give us hi3798mv200
After this you will see 1600 MHz (4 cores) too.
It seems HiSilicon has this problem so you could use this for future models too.
Screenshot: https://forums.openpli.org/topic/28532-merge-requests-for-plis-git/?view=findpost&p=912860