### PR TITLE
About.py: Fix zgemma h9 cpu and temp

### DIFF
--- a/lib/python/Components/About.py
+++ b/lib/python/Components/About.py
@@ -80,7 +80,9 @@ def getCPUInfoString():
 			line = [x.strip() for x in line.strip().split(":")]
 			if line[0] in ("system type", "model name"):
 				processor = line[1].split()[0]
-			elif line[0] == "cpu MHz":
+			else:
+				processor = open("/proc/stb/info/chipset").readline().strip()
+			if line[0] == "cpu MHz":
 				cpu_speed = "%1.0f" % float(line[1])
 			elif line[0] == "processor":
 				cpu_count += 1
@@ -99,13 +101,15 @@ def getCPUInfoString():
 			temperature = open("/proc/stb/fp/temp_sensor_avs").readline().replace('\n','')
 		elif os.path.isfile('/proc/stb/power/avs'):
 			temperature = open("/proc/stb/power/avs").readline().replace('\n','')
+		elif os.path.isfile('/proc/stb/fp/temp_sensor'):
+			temperature = open("/proc/stb/fp/temp_sensor").readline().replace('\n','')
 		elif os.path.isfile("/sys/devices/virtual/thermal/thermal_zone0/temp"):
 			try:
 				temperature = int(open("/sys/devices/virtual/thermal/thermal_zone0/temp").read().strip())/1000
 			except:
 				pass
 		if temperature:
-			return "%s %s MHz (%s) %s°C" % (processor, cpu_speed, ngettext("%d core", "%d cores", cpu_count) % cpu_count, temperature)
+			return "%s %s MHz (%s) %sÂ°C" % (processor, cpu_speed, ngettext("%d core", "%d cores", cpu_count) % cpu_count, temperature)
 		return "%s %s MHz (%s)" % (processor, cpu_speed, ngettext("%d core", "%d cores", cpu_count) % cpu_count)
 	except:
 		return _("undefined")


### PR DESCRIPTION
/proc/cpuinfo won't give us what we need for h9 instead /proc/stb/info/chipset give us hi3798mv200
After this you will see 1600 MHz (4 cores) +cpu temp instead of undefined.
It seems HiSilicon has this problem so you could use this for future models too.
Also for temp we need a new proc file which is /proc/stb/fp/temp_sensor
Related to: https://github.com/OpenPLi/enigma2/pull/1659