### PR TITLE
About.py: Fix zgemma h9 cpu/temp info

### DIFF
--- a/lib/python/Components/About.py
+++ b/lib/python/Components/About.py
@@ -78,7 +78,7 @@ def getCPUInfoString():
 		cpu_speed = 0
 		for line in open("/proc/cpuinfo").readlines():
 			line = [x.strip() for x in line.strip().split(":")]
-			if line[0] in ("system type", "model name"):
+			if line[0] in ("system type", "model name", "Processor"):
 				processor = line[1].split()[0]
 			elif line[0] == "cpu MHz":
 				cpu_speed = "%1.0f" % float(line[1])
@@ -99,13 +99,15 @@ def getCPUInfoString():
 			temperature = open("/proc/stb/fp/temp_sensor_avs").readline().replace('\n','')
 		elif os.path.isfile('/proc/stb/power/avs'):
 			temperature = open("/proc/stb/power/avs").readline().replace('\n','')
+		elif os.path.isfile('/proc/stb/fp/temp_sensor'):
+			temperature = open("/proc/stb/fp/temp_sensor").readline().replace('\n','')
 		elif os.path.isfile("/sys/devices/virtual/thermal/thermal_zone0/temp"):
 			try:
 				temperature = int(open("/sys/devices/virtual/thermal/thermal_zone0/temp").read().strip())/1000
 			except:
 				pass
 		if temperature:
-			return "%s %s MHz (%s) %s°C" % (processor, cpu_speed, ngettext("%d core", "%d cores", cpu_count) % cpu_count, temperature)
+			return "%s %s MHz (%s) %sÂ°C" % (processor, cpu_speed, ngettext("%d core", "%d cores", cpu_count) % cpu_count, temperature)
 		return "%s %s MHz (%s)" % (processor, cpu_speed, ngettext("%d core", "%d cores", cpu_count) % cpu_count)
 	except:
 		return _("undefined")


### PR DESCRIPTION
After this you will see 1600 MHz (4 cores) + cpu temp instead of undefined.
For exact cpu model we need to read /proc/stb/info/chipset which gives us hi3798mv200 instead of /proc/cpuinfo but I didn't find a proper way to do it.
It seems HiSilicon has this problem so you could use this for future models too.
For temp we need a new proc file which is /proc/stb/fp/temp_sensor
Related to: https://github.com/OpenPLi/enigma2/pull/1660