### PR TITLE
Network.py: More accuracy in detecting Broadcom

### DIFF
--- a/lib/python/Components/Network.py
+++ b/lib/python/Components/Network.py
@@ -315,7 +315,7 @@ class Network:
 				name = 'Atmel'
 			elif name.startswith('iwm'):
 				name = 'Intel'
-			elif name.startswith('brcm'):
+			elif name.startswith('brcm') or name.startswith('bcm'):
 				name = 'Broadcom'
 		else:
 			name = _('Unknown')


### PR DESCRIPTION
We have "brcm" but some start with "bcm"