### PR TITLE
Volume.py: Allow VolumeText on the VolumeBar

### DIFF
--- a/lib/python/Screens/Volume.py
+++ b/lib/python/Screens/Volume.py
@@ -1,5 +1,6 @@
 from Screen import Screen
 from Components.VolumeBar import VolumeBar
+from Components.Label import Label
 
 class Volume(Screen):
 	def __init__(self, session):
@@ -8,7 +9,9 @@ class Volume(Screen):
 		self.volumeBar = VolumeBar()
 
 		self["Volume"] = self.volumeBar
+		self["VolumeText"] = Label("")
 
 	def setValue(self, vol):
 		print "setValue", vol
 		self.volumeBar.setValue(vol)
+		self["VolumeText"].setText(str(vol))


### PR DESCRIPTION
Some people like VolumeText on the VolumeBar: https://forums.openpli.org/topic/61388-volumetext/
Thanks to vali
Sample for full hd skin is:
<screen name="Volume" position="center,60" size="773,39" title="Volume" backgroundColor="#ff000000" zPosition="10" flags="wfNoBorder">
    <widget name="Volume" position="0,14" size="681,12" foregroundColor="#2397db" backgroundColor="#ff9c00" />
    <widget name="VolumeText" font="Regular;33" transparent="1" foregroundColor="#ff9c00" borderWidth="3" halign="center" position="698,2" size="75,36" />
</screen