### PR TITLE
resolveFilename: do not check the alternatives if the original path exists

### DIFF
--- a/lib/python/Tools/Directories.py
+++ b/lib/python/Tools/Directories.py
@@ -61,6 +61,8 @@ def resolveFilename(scope, base = "", path_prefix = None):
 			path = tmp
 		else:
 			path = defaultPaths[SCOPE_SKIN][0]
+			if pathExists("%s%s" % (path, base)):
+				return "%s%s" % (path, base)
 			pos = config.skin.primary_skin.value.rfind('/')
 			if pos != -1:
 				for dir in ("%s%s" % (path, config.skin.primary_skin.value[:pos+1]), "%s%s" % (path, "skin_default/")):


### PR DESCRIPTION
Broken in: https://github.com/OpenPLi/enigma2/commit/fbe82a1064859bda26ed800994d1ead75b2f2497

For example:
In the skin I specified the path pixmap="SimpleGrayHD/window/volume.png".
defaultPaths[SCOPE_SKIN][0] is "/usr/share/enigma2/"
base "SimpleGrayHD/window/volume.png"

Instead of using this path, they are looking for alternatives.
An alternative is found in skin_default and the image is used from skin_default, instead from skin.
Only if the alternatives are not found, path from skin is used.

This should fix this.