### PR TITLE
Rollup of VirtualKeyBoard changes

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -75,7 +75,7 @@
 		<key id="KEY_YELLOW" mapto="locale" flags="m" />
 		<key id="KEY_BLUE" mapto="shift" flags="m" />
 		<key id="KEY_EXIT" mapto="cancel" flags="m" />
-		<key id="KEY_OK" mapto="ok" flags="m" />
+		<key id="KEY_OK" mapto="select" flags="m" />
 		<key id="KEY_UP" mapto="up" flags="mr" />
 		<key id="KEY_PREVIOUS" mapto="first" flags="m" />
 		<key id="KEY_REWIND" mapto="prev" flags="mr" />
@@ -105,7 +105,7 @@
 		<key id="KEY_F3" mapto="locale" flags="m" />
 		<key id="KEY_F4" mapto="shift" flags="m" />
 		<key id="KEY_ESC" mapto="cancel" flags="m" />
-		<key id="KEY_ENTER" mapto="ok" flags="m" />
+		<key id="KEY_ENTER" mapto="select" flags="m" />
 		<key id="KEY_PREVIOUSSONG" mapto="first" flags="m" />
 		<key id="KEY_F9" mapto="first" flags="m" />
 		<key id="KEY_F11" mapto="prev" flags="m" />

--- a/doc/VIRTUALKEYBOARD
+++ b/doc/VIRTUALKEYBOARD
@@ -2,7 +2,7 @@ A Guide to the VirtualKeyBoard Screen
 -------------------------------------
 
 Written by IanSav - 18-Aug-2018
-Updated by IanSav - 31-Aug-2018
+Updated by IanSav -  4-Sep-2018
 
 This document explains the changes and updates to the VirtualKeyBoard of 
 Enigma2.  The code is located in:
@@ -99,8 +99,17 @@ For example in a 1280 x 720 skin:
 		<widget name="language" position="0,0" size="0,0" font="Regular;20" transparent="1" />
 	</screen>
 
-	WARNING: Due to limitations in the current parameter parsing the 
-	shift colours MUST be specified as decimal numbers.
+	WARNING: Due to limitations in the parameter parsing the shift 
+	colours MUST be specified as decimal numbers for all firmware 
+	versions earlier than 4-Sep-2018.  For firmware builds later than 
+	4-Sep-2018 the colours can be specified as decimal numbers, hex 
+	numbers, Enigma2 "#" colour codes or colour names.  For example, 
+	the following parameters are equaly valid and effectively the same:
+		<parameter name="VirtualKeyBoardShiftColors" value="16777215,16777215,65535,16711935" />
+		<parameter name="VirtualKeyBoardShiftColors" value="0x00ffffff,0x00ffffff,0x0000ffff,0x00ff00ff" />
+		<parameter name="VirtualKeyBoardShiftColors" value="#00ffffff,#00ffffff,#0000ffff,#00ff00ff" />
+		<parameter name="VirtualKeyBoardShiftColors" value="White,White,Cyan,Magenta" />
+		(Assuming the colours "White", "Cyan" and "Magenta" are defined!)
 
 	IMPORTANT: Make sure that all the 720 "vkey_*" images are copied to 
 	the "/usr/share/enigma2/<skin>/buttons/" directory where "<skin>" is 
@@ -127,8 +136,17 @@ For example in a 1920 x 1080 skin:
 		<widget name="language" position="0,0" size="0,0" font="Regular;20" transparent="1" />
 	</screen>
 
-	WARNING: Due to limitations in the current parameter parsing the 
-	shift colours MUST be specified as decimal numbers.
+	WARNING: Due to limitations in the parameter parsing the shift 
+	colours MUST be specified as decimal numbers for all firmware 
+	versions earlier than 4-Sep-2018.  For firmware builds later than 
+	4-Sep-2018 the colours can be specified as decimal numbers, hex 
+	numbers, Enigma2 "#" colour codes or colour names.  For example, 
+	the following parameters are equaly valid and effectively the same:
+		<parameter name="VirtualKeyBoardShiftColors" value="16777215,16777215,65535,16711935" />
+		<parameter name="VirtualKeyBoardShiftColors" value="0x00ffffff,0x00ffffff,0x0000ffff,0x00ff00ff" />
+		<parameter name="VirtualKeyBoardShiftColors" value="#00ffffff,#00ffffff,#0000ffff,#00ff00ff" />
+		<parameter name="VirtualKeyBoardShiftColors" value="White,White,Cyan,Magenta" />
+		(Assuming the colours "White", "Cyan" and "Magenta" are defined!)
 
 	IMPORTANT: Make sure that all the 1080 "vkey_*" images are copied to 
 	the "/usr/share/enigma2/<skin>/buttons/" directory where "<skin>" is 

--- a/lib/python/Screens/VirtualKeyBoard.py
+++ b/lib/python/Screens/VirtualKeyBoard.py
@@ -434,6 +434,7 @@ class VirtualKeyBoard(Screen, HelpableScreen):
 		keyList[0][2][11] = u"\u00B4"
 		keyList[0][2][12] = u"\\"
 		keyList[0][3] = [u"SHIFT", u"]", u"z", u"x", u"c", u"v", u"b", u"n", u"m", u",", u".", u"-", u"{", u"SHIFT"]
+		keyList[0][-1].extend([u"www.", u".com", u".net", u".org", u".edu", u".nl", u".tv"])
 		keyList[1][0] = [u"\u00A7", u"!", u"\"", u"#", u"$", u"%", u"&", u"_", u"(", u")", u"'", u"?", u"~", u"BACKSPACE"]
 		keyList[1][1][11] = u"^"
 		keyList[1][1][12] = u"|"
@@ -442,10 +443,11 @@ class VirtualKeyBoard(Screen, HelpableScreen):
 		keyList[1][2][11] = u"`"
 		keyList[1][2][12] = u"\u00A6"
 		keyList[1][3] = [u"SHIFT", u"[", u"Z", u"X", u"C", u"V", u"B", u"N", u"M", u";", u":", u"=", u"}", u"SHIFT"]
+		keyList[1][-1].extend([u"www.", u".com", u".net", u".org", u".edu", u".nl", u".tv"])
 		keyList.append([
 			[u"\u00AC", u"\u00B9", u"\u00B2", u"\u00B3", u"\u00BC", u"\u00BD", u"\u00BE", u"\u00A3", u"{", u"}", u"$", u"\\", u"", u"BACKSPACE"],
 			[u"FIRST", u"", u"", u"\u20AC", u"\u00B6", u"", u"", u"", u"", u"", u"", u"", u"", u""],
-			[u"LAST", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"", u"ENTER"],
+			[u"LAST", u"", u"\u00E1", u"\u00E9", u"\u00ED", u"\u00F3", u"\u00FA", u"\u00C1", u"\u00C9", u"\u00CD", u"\u00D3", u"\u00DA", u"", u"ENTER"],
 			[u"SHIFT", u"\u00A6", u"\u00AB", u"\u00BB", u"\u00A2", u"", u"", u"", u"\u00B5", u"", u"\u00B7", u"", u"", u"SHIFT"],
 			[u"EXIT", u"LOC", u"LEFT", u"RIGHT", u"ALL", u"CLR", u"SPACE"]
 		])

--- a/lib/python/Screens/VirtualKeyBoard.py
+++ b/lib/python/Screens/VirtualKeyBoard.py
@@ -326,7 +326,7 @@ class VirtualKeyBoard(Screen, HelpableScreen):
 			"save": (self.save, _("Save any text changes and exit")),
 			"locale": (self.localeMenu, _("Select the virtual keyboard locale from a menu")),
 			"shift": (self.shiftClicked, _("Select the virtual keyboard shifted character set")),
-			"ok": (self.okClicked, _("Select the character or action under the virtual keyboard cursor")),
+			"select": (self.processSelect, _("Select the character or action under the virtual keyboard cursor")),
 			"up": (self.up, _("Move the virtual keyboard cursor up")),
 			"left": (self.left, _("Move the virtual keyboard cursor left")),
 			"right": (self.right, _("Move the virtual keyboard cursor right")),
@@ -575,7 +575,7 @@ class VirtualKeyBoard(Screen, HelpableScreen):
 
 	def smsGotChar(self):
 		if self.smsChar and self.selectAsciiKey(self.smsChar):
-			self.okClicked()
+			self.processSelect()
 
 	def setLocale(self):
 		self.language, self.location, self.keyList = self.locales.get(self.lang, [None, None, None])
@@ -640,7 +640,10 @@ class VirtualKeyBoard(Screen, HelpableScreen):
 		self.previousSelectedKey = self.selectedKey
 		self["list"].setList(self.list)
 
-	def okClicked(self):
+	def okClicked(self):  # Deprecated legacy interface to new processSelect used by YouTubeVirtualKeyBoard
+		self.processSelect()
+
+	def processSelect(self):
 		self.smsChar = None
 		text = self.keyList[self.shiftLevel][self.selectedKey / self.keyboardWidth][self.selectedKey % self.keyboardWidth].encode("UTF-8")
 		if text == u"":
@@ -781,7 +784,7 @@ class VirtualKeyBoard(Screen, HelpableScreen):
 	def keyGotAscii(self):
 		self.smsChar = None
 		if self.selectAsciiKey(str(unichr(getPrevAsciiCode()).encode("utf-8"))):
-			self.okClicked()
+			self.processSelect()
 
 	def selectAsciiKey(self, char):
 		if char == u" ":


### PR DESCRIPTION
- [VirtualKeyBoard.py] Restore processSelect method name

    Clarify the separation of the OK remote control button from the selection action code

    Provide interface for YouTubeVirtualKeyBoard plugin. Hopefully that plugin will adopt the more appropriate naming.  (This was discussed in the OpenPLi forum thread.)

    This change restores compatibility with the other copies of this code in other images.

- [keymap.xml] Separate OK name from select action  …

    Clarify the separation of the OK button from the selection action

- [VIRTUALKEYBOARD] Add new colour options info

- [VirtualKeyBoard.py] Update Dutch keyboard layout
