### PR TITLE
Fix resolveFilename for pointer and seek_pointer pixmap

### DIFF
--- a/skin.py
+++ b/skin.py
@@ -248,7 +248,10 @@ def collectAttributes(skinAttributes, node, context, skin_path_prefix=None, igno
 	for attrib, value in node.items():
 		if attrib not in ignore:
 			if attrib in filenames:
-				value = resolveFilename(SCOPE_CURRENT_SKIN, value, path_prefix=skin_path_prefix)
+				if "pointer" in attrib:
+					value = "%s%s%s" % (resolveFilename(SCOPE_CURRENT_SKIN, value.split(":")[0], path_prefix=skin_path_prefix), ":", value.split(":")[1])
+				else:
+					value = resolveFilename(SCOPE_CURRENT_SKIN, value, path_prefix=skin_path_prefix)
 			# Bit of a hack this, really. When a window has a flag (e.g. wfNoBorder)
 			# it needs to be set at least before the size is set, in order for the
 			# window dimensions to be calculated correctly in all situations.


### PR DESCRIPTION
pointer and seek_pointer value contains path on pixmap and also position.
Therefore, in resolveFilename is not used the correct path for pixmap.
Split this value to use correct path and be able to use alternative path to pixmaps if necessary.