### PR TITLE
resolveFilename: do not change base path

### DIFF
--- a/lib/python/Tools/Directories.py
+++ b/lib/python/Tools/Directories.py
@@ -66,8 +66,8 @@ def resolveFilename(scope, base = "", path_prefix = None):
 				skinname = config.skin.primary_skin.value[:pos+1]
 				#  remove skin name from base if exist
 				if base.startswith(skinname):
-					base = base[pos+1:]
-				for dir in ("%s%s" % (path, skinname), "%s%s" % (path, "skin_default/")):
+					skinname = ""
+				for dir in ("%s%s" % (path, skinname), path, "%s%s" % (path, "skin_default/")):
 					for file in (base, os.path.basename(base)):
 						if pathExists("%s%s"% (dir, file)):
 							return "%s%s" % (dir, file)


### PR DESCRIPTION
Do not use a skin directory if it already exists in the base path.
This allows to keep the base path unchanged, as before, if nothing not found.

Also, add an additional path in the alternative directories search before the skin_default.
This allow check the path to a files in different skins, where they are specified.
For example if in skin PLi-FullNightHD is link to file in PLi-FullHD.
Before this path was not checked and returned default link if such image is not found in skin_default.