### PR TITLE
[eSubtitleWidget] Fix memory leak

### DIFF
--- a/lib/gui/esubtitle.cpp
+++ b/lib/gui/esubtitle.cpp
@@ -308,7 +308,7 @@ int eSubtitleWidget::event(int event, void *data, void *data2)
 					eRect &area = element.m_area;
 					if (eConfigManager::getConfigBoolValue("config.subtitles.showbackground"))
 					{
-						eTextPara *para = new eTextPara(area);
+						ePtr<eTextPara> para = new eTextPara(area);
 						para->setFont(subtitleStyles[Subtitle_TTX].font);
 						para->renderString(element.m_text.c_str(), RS_WRAP);
 						eRect bbox = para->getBoundBox();
@@ -394,7 +394,7 @@ int eSubtitleWidget::event(int event, void *data, void *data2)
 				eRect &area = element.m_area;
 				if (eConfigManager::getConfigBoolValue("config.subtitles.showbackground"))
 				{
-					eTextPara *para = new eTextPara(area);
+					ePtr<eTextPara> para = new eTextPara(area);
 					para->setFont(subtitleStyles[face].font);
 					para->renderString(text.c_str(), RS_WRAP);
 					eRect bbox = para->getBoundBox();


### PR DESCRIPTION
Showing the background in subtitles would allocate an eTextPara, but not
release it.  Use an ePtr, not a raw pointer.

https://bitbucket.org/beyonwiz/easy-ui-4/commits/789c152a8837d3a560b11867bdfadba8d7f171a2#chg-lib/gui/esubtitle.cpp