### PR TITLE
[skin.py] Disallow string parameters

### DIFF
--- a/skin.py
+++ b/skin.py
@@ -235,10 +235,8 @@ def parseParameter(s):
 		return float(s)
 	elif s in colorNames:
 		return colorNames[s].argb()
-	elif s.lstrip('-+ ').isdigit():
-		return int(s)
 	else:
-		return s
+		return int(s)
 
 def collectAttributes(skinAttributes, node, context, skin_path_prefix=None, ignore=(), filenames=frozenset(("pixmap", "pointer", "seek_pointer", "backgroundPixmap", "selectionPixmap", "sliderPixmap", "scrollbarbackgroundPixmap"))):
 	# walk all attributes


### PR DESCRIPTION
This change reduces the functionality of the previous commit but protects legacy code that only ever expects to see numeric parameters.  This change restores the skin processing "bad parameter" error when non numeric parameters are encountered.  (Note that valid integers, floats, hex values, colour codes and colour names will all resolve to numbers and not trigger the error log.

String parameters can be revisited when a need arises.
