### PR TITLE
ScanSetup.py: Support BCM3466 dual DVB-T2

### DIFF
--- a/lib/python/Screens/ScanSetup.py
+++ b/lib/python/Screens/ScanSetup.py
@@ -125,6 +125,7 @@ terrestrial_autoscan_nimtype = {
 'TT3L10' : 'tt3l10_t2_scan',
 'TURBO' : 'vuplus_turbo_t',
 'TT2L08' : 'tt2l08_t2_scan'
+'BCM3466' : 'bcm3466'
 }
 
 def GetDeviceId(filter, nim_idx):
@@ -244,9 +245,9 @@ class CableTransponderSearchSupport:
 				if nim_name is not None and nim_name != "":
 					device_id = ""
 					nim_name = nim_name.split(' ')[-1][4:-1]
-					if nim_name == 'TT3L10':
+					if nim_name in ("TT3L10", "BCM3466"):
 						try:
-							device_id = GetDeviceId('TT3L10', nim_idx)
+							device_id = GetDeviceId(nim_name, nim_idx)
 							device_id = "--device=%s" % (device_id)
 						except Exception, err:
 							print "GetCommand ->", err


### PR DESCRIPTION
This is for new vuplus drivers (uno4k, uno4kse, ultimo4k)
New changes will be in the BSP layer soon.