### PR TITLE
Jobview skin fix

### DIFF
--- a/data/skin_default.xml
+++ b/data/skin_default.xml
@@ -1288,33 +1288,21 @@ self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth)/2, orgpos.y() + (or
 		<widget name="Volume" pixmap="skin_default/progress_small.png" position="31,7" zPosition="1" size="168,7" transparent="1"/>
 	</screen>
 	<!-- JobView -->
-	<screen name="JobView" position="center,center" size="520,350" title="Job overview">
-		<widget source="job_name" render="Label" position="20,12" size="480,60" font="Regular;28"/>
-		<widget source="job_task" render="Label" position="20,90" size="480,50" font="Regular;23"/>
-		<widget source="job_progress" render="Progress" position="20,162" size="480,36" borderWidth="2" backgroundColor="#254f7497"/>
-		<widget source="job_progress" render="Label" position="120,166" size="280,32" font="Regular;28" foregroundColor="#000000" zPosition="2" halign="center" transparent="1"  >
+	<screen name="JobView" position="center,center" size="560,350" title="Job overview">
+		<ePixmap pixmap="skin_default/buttons/red.png" position="0,300" size="140,40" alphatest="on"/>
+		<ePixmap pixmap="skin_default/buttons/green.png" position="140,300" size="140,40" alphatest="on"/>
+		<ePixmap pixmap="skin_default/buttons/blue.png" position="420,300" size="140,40" alphatest="on"/>
+		<widget source="key_red" render="Label" position="0,300" size="140,40" zPosition="1" halign="center" valign="center" font="Regular;20" foregroundColor="white" transparent="1"/>
+		<widget source="key_green" render="Label" position="140,300" size="140,40" zPosition="1" halign="center" valign="center" font="Regular;20" foregroundColor="white" transparent="1"/>
+		<widget source="key_blue" render="Label" position="420,300" size="140,40" zPosition="1" halign="center" valign="center" font="Regular;20" foregroundColor="white" transparent="1"/>
+		<widget source="job_name" render="Label" position="20,12" size="520,60" font="Regular;28"/>
+		<widget source="job_task" render="Label" position="20,90" size="520,50" font="Regular;23"/>
+		<widget source="job_progress" render="Progress" position="20,162" size="520,36" borderWidth="2" backgroundColor="#254f7497"/>
+		<widget source="job_progress" render="Label" position="140,166" size="280,32" font="Regular;28" foregroundColor="#000000" zPosition="2" halign="center" transparent="1"  >
 			<convert type="ProgressToText"/>
 		</widget>
-		<widget source="job_status" render="Label" position="20,212" size="480,26" font="Regular;23"/>
-		<widget name="config" position="20,254" size="480,20"/>
-		<widget source="cancelable" render="Pixmap" pixmap="skin_default/buttons/red.png" position="20,300" size="140,40" alphatest="on">
-			<convert type="ConditionalShowHide"/>
-		</widget>
-		<widget source="cancelable" render="FixedLabel" text="Cancel" position="20,300" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1">
-			<convert type="ConditionalShowHide"/>
-		</widget>
-		<widget source="finished" render="Pixmap" pixmap="skin_default/buttons/green.png" position="190,300" size="140,40" alphatest="on">
-			<convert type="ConditionalShowHide"/>
-		</widget>
-		<widget source="finished" render="FixedLabel" text="OK" font="Regular;20" halign="center" valign="center" position="190,300" size="140,40" transparent="1" backgroundColor="#1f771f">
-			<convert type="ConditionalShowHide"/>
-		</widget>
-		<widget source="backgroundable" render="Pixmap" pixmap="skin_default/buttons/blue.png" position="360,300" size="140,40" alphatest="on">
-			<convert type="ConditionalShowHide"/>
-		</widget>
-		<widget source="backgroundable" render="FixedLabel" text="Continue in background" font="Regular;20" halign="center" valign="center" position="360,300" size="140,40" transparent="1" backgroundColor="#18188b">
-			<convert type="ConditionalShowHide"/>
-		</widget>
+		<widget source="job_status" render="Label" position="20,212" size="520,26" font="Regular;23"/>
+		<widget name="config" position="20,254" size="520,20"/>
 	</screen>
 	<!-- VideoMode -->
 	<screen name="VideoMode" position="center,center" size="250,60" title="VideoMode">

--- a/lib/python/Screens/TaskView.py
+++ b/lib/python/Screens/TaskView.py
@@ -1,18 +1,19 @@
-from Screen import Screen
-from Components.ConfigList import ConfigListScreen
+from Components.ActionMap import ActionMap
 from Components.config import config, ConfigSubsection, ConfigSelection, getConfigListEntry
+from Components.ConfigList import ConfigListScreen
+from Components.Sources.Boolean import Boolean
+from Components.Sources.Progress import Progress
+from Components.Sources.StaticText import StaticText
 from Components.SystemInfo import SystemInfo
 from Components.Task import job_manager
 from InfoBarGenerics import InfoBarNotifications
-import Screens.Standby
 from Tools import Notifications
+from Screen import Screen
+from Screens.MessageBox import MessageBox
+import Screens.Standby
 
 class JobView(InfoBarNotifications, Screen, ConfigListScreen):
 	def __init__(self, session, job, parent=None, cancelable = True, backgroundable = True, afterEventChangeable = True):
-		from Components.Sources.StaticText import StaticText
-		from Components.Sources.Progress import Progress
-		from Components.Sources.Boolean import Boolean
-		from Components.ActionMap import ActionMap
 		Screen.__init__(self, session, parent)
 		InfoBarNotifications.__init__(self)
 		ConfigListScreen.__init__(self, [])
@@ -128,7 +129,6 @@ class JobView(InfoBarNotifications, Screen, ConfigListScreen):
 			return
 		elif self.settings.afterEvent.getValue() == "close" and self.job.status == self.job.FINISHED:
 			self.close(False)
-		from Screens.MessageBox import MessageBox
 		if self.settings.afterEvent.getValue() == "deepstandby":
 			if not Screens.Standby.inTryQuitMainloop:
 				Notifications.AddNotificationWithCallback(self.sendTryQuitMainloopNotification, MessageBox, _("A sleep timer wants to shut down\nyour receiver. Shutdown now?"), timeout = 20)

--- a/lib/python/Screens/TaskView.py
+++ b/lib/python/Screens/TaskView.py
@@ -28,11 +28,21 @@ class JobView(InfoBarNotifications, Screen, ConfigListScreen):
 		self["summary_job_progress"] = Progress()
 		self["summary_job_task"] = StaticText()
 		self["job_status"] = StaticText()
-		self["finished"] = Boolean()
-		self["cancelable"] = Boolean(cancelable)
-		self["backgroundable"] = Boolean(backgroundable)
 
-		self["key_blue"] = StaticText(_("Background"))
+		self.cancelable = Boolean(cancelable)
+		self.backgroundable = Boolean(backgroundable)
+
+		self["key_green"] = StaticText("")
+
+		if self.cancelable.getBoolean:
+			self["key_red"] = StaticText(_("Cancel"))
+		else:
+			self["key_red"] = StaticText("")
+
+		if self.backgroundable.getBoolean:
+			self["key_blue"] = StaticText(_("Hide"))
+		else:
+			self["key_blue"] = StaticText("")
 
 		self.onShow.append(self.windowShow)
 		self.onHide.append(self.windowHide)
@@ -97,15 +107,18 @@ class JobView(InfoBarNotifications, Screen, ConfigListScreen):
 			self["summary_job_task"].text = j.getStatustext()
 		if j.status in (j.FINISHED, j.FAILED):
 			self.performAfterEvent()
-			self["backgroundable"].boolean = False
+			self.backgroundable.setBoolean(False)
+			self["key_blue"].setText("")
 			if j.status == j.FINISHED:
-				self["finished"].boolean = True
-				self["cancelable"].boolean = False
+				self["key_green"].setText(_("OK"))
+				self.cancelable.setBoolean(False)
+				self["key_red"].setText("")
 			elif j.status == j.FAILED:
-				self["cancelable"].boolean = True
+				self.cancelable.setBoolean(True)
+				self["key_red"].setText(_("Cancel"))
 
 	def background(self):
-		if self["backgroundable"].boolean:
+		if self.backgroundable.getBoolean():
 			self.close(True)
 
 	def ok(self):
@@ -118,7 +131,7 @@ class JobView(InfoBarNotifications, Screen, ConfigListScreen):
 		if self.job.status == self.job.NOT_STARTED:
 			job_manager.active_jobs.remove(self.job)
 			self.close(False)
-		elif self.job.status == self.job.IN_PROGRESS and self["cancelable"].boolean == True:
+		elif self.job.status == self.job.IN_PROGRESS and self.cancelable.getBoolean():
 			self.job.cancel()
 		else:
 			self.close(False)


### PR DESCRIPTION
I made some changes to the JobView class (inside TaskView.py). There are some flaws/bugs with the current code:

1st. Double assignment to the blue button. There are 2 variables (skin elements) that are assigned to the blue button, `self["backgroundable"]` and `self["key_blue"]`, which result in double text appearing in the blue button. This bug is more than a decade old!

2nd. With the current design, there is hard-coded text into the skin, which is NOT translatable. See how it is done in the default skin, and all openpli skins as well:

	<widget source="cancelable" render="FixedLabel" text="Cancel" ...>
		<convert type="ConditionalShowHide"/>
	</widget>
	<widget source="finished" render="FixedLabel" text="OK" ...>
		<convert type="ConditionalShowHide"/>
	</widget>
	<widget source="backgroundable" render="FixedLabel" text="Continue in background" ...>
		<convert type="ConditionalShowHide"/>
	</widget>
	
3rd. The skinner has to read the python code to understand that the `self["finished"]`, `self["cancelable"]` and `self["backgroundable"]` are skin elements assigned to the colored buttons. Using the proper colored key names (key_green, key_read, etc), is much easier to know the key assignment.

Below are 2 screenshots that show the problem when a job is in progress and when it's completed. In the first, the double text on the blue button is shown, while in the second, the blue button text is still present despite the job is completed.

![jobview_in_progress_broken](https://user-images.githubusercontent.com/1540233/46700059-73e3d480-cc24-11e8-91a6-576bdefbb18d.jpg)
![jobview_completed_broken](https://user-images.githubusercontent.com/1540233/46700071-7b0ae280-cc24-11e8-90b6-511c31baf027.jpg)

***

With the simple changes I made, the same functionality is preserved, while now:

1st. There is no double assignment to the blue button or any other button.

2nd. There is no hard-coded text in the skin. All text needed for this screen is inside the python code and is translatable.

3rd. The proper color key names are used. The skinner can easily understand where to position each skin element, without the need of reading the python code. Furthermore, the automatic button system can be utilized to automatically show colored buttons for this screen. Skins already using this system need NO change to work properly with the updated code. Some code needs to be removed from existing skins, but it's not preventing them from working ok.

4th. I changed the text for the blue button to "Hide" instead of "Continue in background" or "Background". This way it needs less space and fits smaller button without problem.

Below are 2 screenshots from the fixed code.

![jobview_in_progress_fixed](https://user-images.githubusercontent.com/1540233/46700487-a3471100-cc25-11e8-8be7-2b2b763113af.jpg)
![jobview_completed_fixed](https://user-images.githubusercontent.com/1540233/46700497-a8a45b80-cc25-11e8-902e-26c3458b35d3.jpg)
