### PR TITLE
Properly display temperature on hisi boxes

### DIFF
--- a/lib/python/Components/About.py
+++ b/lib/python/Components/About.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import sys, os, time
+import re
 from Tools.HardwareInfo import HardwareInfo
 
 def getVersionString():
@@ -109,6 +110,11 @@ def getCPUInfoString():
 		elif os.path.isfile("/sys/devices/virtual/thermal/thermal_zone0/temp"):
 			try:
 				temperature = int(open("/sys/devices/virtual/thermal/thermal_zone0/temp").read().strip())/1000
+			except:
+				pass
+		elif os.path.isfile("/proc/hisi/msp/pm_cpu"):
+			try:
+				temperature = re.search('temperature = (\d+) degree', open("/proc/hisi/msp/pm_cpu").read()).group(1)
 			except:
 				pass
 		if temperature:


### PR DESCRIPTION
The hisi boxes use /proc/hisi/msp/pm_cpu file that contains the following info:
CPU: freq = 1600000(kHz), current volt = 1160(mv)
CPU: AVS = On, hpm offset = 0 hpm target = 0x153
Tsensor: temperature = 67 degree
CPU: Temp Control is Quit

This commit uses regular expression to extract the temperature when this file exists.

Also is better fix for #1763 