### PR TITLE
JobView - Change function of "cancel" button

### DIFF
--- a/lib/python/Screens/TaskView.py
+++ b/lib/python/Screens/TaskView.py
@@ -51,7 +51,7 @@ class JobView(InfoBarNotifications, Screen, ConfigListScreen):
 			"green": self.ok,
 			"red": self.abort,
 			"blue": self.background,
-			"cancel": self.ok,
+			"cancel": self.abort,
 			"ok": self.ok,
 		}, -2)
 


### PR DESCRIPTION
Cancel button should be assigned to the "abort" function, like the red button is. Same change is done in OpenATV recently https://github.com/openatv/enigma2/commit/8d17a4d3ddc9552d4fa31a7e5702a1388a9ddbc4.