### PR TITLE
MovieSelection: use suburi to play two files in parallel

### DIFF
--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -1018,6 +1018,14 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 		except Exception, e:
 			print "[ML] DVD Player not installed:", e
 
+	def playSuburi(self, path):
+		suburi = os.path.splitext(path)[0][:-7]
+		for ext in AUDIO_EXTENSIONS:
+			if os.path.exists("%s%s" % (suburi, ext)):
+				current = eServiceReference(4097, 0, "file://%s&suburi=file://%s%s" % (path, suburi, ext))
+				self.close(current)
+				return True
+
 	def __serviceStarted(self):
 		if not self.list.playInBackground:
 			return
@@ -1184,6 +1192,9 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 					return
 			elif ext in DVD_EXTENSIONS:
 				if self.playAsDVD(path):
+					return
+			elif "_suburi." in path:
+				if self.playSuburi(path):
 					return
 			self.movieSelected()
 


### PR DESCRIPTION
In https://github.com/OpenPLi/enigma2/commit/65962a39625aaf02f66ee9258181ec2d164916a6#diff-edf65e1563875233346cf1cf40ed3c76 is implemented suburi in service reference path string, which allows you to play two files in parallel.
But it is possible use only in bouquet or in plugins that create service reference with suburi in path.
This allows you to play files from a disk.
If a video file name ends with '_suburi' is checked if there is also an audio file with the same name without '_suburi' in end,
and if it exists then play this two files together.

It allows download separate Dash MP4 video and Dash MP4 Audio files from youtube and play together video and audio.