### PR TITLE
Add Support for Gamma Curve (aka SDR/HDR/HLG)

### DIFF
--- a/lib/dvb/decoder.cpp
+++ b/lib/dvb/decoder.cpp
@@ -245,7 +245,7 @@ int eDVBVideo::m_close_invalidates_attributes = -1;
 
 eDVBVideo::eDVBVideo(eDVBDemux *demux, int dev)
 	: m_demux(demux), m_dev(dev),
-	m_width(-1), m_height(-1), m_framerate(-1), m_aspect(-1), m_progressive(-1)
+	m_width(-1), m_height(-1), m_framerate(-1), m_aspect(-1), m_progressive(-1), m_gamma(-1)
 {
 	char filename[128];
 	sprintf(filename, "/dev/dvb/adapter%d/video%d", demux ? demux->adapter : 0, dev);
@@ -553,6 +553,21 @@ void eDVBVideo::video_event(int)
 				eDebugNoNewLine("PROGRESSIVE_CHANGED %d\n", m_progressive);
 				/* emit */ m_event(event);
 			}
+			else if (evt.type == 17 /*VIDEO_EVENT_GAMMA_CHANGED*/)
+			{
+				struct iTSMPEGDecoder::videoEvent event;
+				event.type = iTSMPEGDecoder::videoEvent::eventGammaChanged;
+				/*
+				 * Possible gamma values
+				 * 0: Traditional gamma - SDR luminance range
+				 * 1: Traditional gamma - HDR luminance range
+				 * 2: SMPTE ST2084 (aka HDR10)
+				 * 3: Hybrid Log-gamma
+				 */
+				m_gamma = event.gamma = evt.u.frame_rate;
+				eDebugNoNewLine("GAMMA_CHANGED %d\n", m_gamma);
+				/* emit */ m_event(event);
+			}
 			else
 				eDebugNoNewLine("unhandled DVBAPI Video Event %d\n", evt.type);
 		}
@@ -640,6 +655,21 @@ int eDVBVideo::getFrameRate()
 		}
 	}
 	return m_framerate;
+}
+
+int eDVBVideo::getGamma()
+{
+	/* when closing the video device invalidates the attributes, we can rely on VIDEO_EVENTs */
+	if (!m_close_invalidates_attributes)
+	{
+		if (m_gamma == -1)
+		{
+			char tmp[64];
+			sprintf(tmp, "/proc/stb/vmpeg/%d/gamma", m_dev);
+			CFile::parseIntHex(&m_gamma, tmp);
+		}
+	}
+	return m_gamma;
 }
 
 DEFINE_REF(eDVBPCR);
@@ -1317,5 +1347,12 @@ int eTSMPEGDecoder::getVideoAspect()
 {
 	if (m_video)
 		return m_video->getAspect();
+	return -1;
+}
+
+int eTSMPEGDecoder::getVideoGamma()
+{
+	if (m_video)
+		return m_video->getGamma();
 	return -1;
 }

--- a/lib/dvb/decoder.h
+++ b/lib/dvb/decoder.h
@@ -37,7 +37,7 @@ private:
 	ePtr<eSocketNotifier> m_sn;
 	void video_event(int what);
 	sigc::signal1<void, struct iTSMPEGDecoder::videoEvent> m_event;
-	int m_width, m_height, m_framerate, m_aspect, m_progressive;
+	int m_width, m_height, m_framerate, m_aspect, m_progressive, m_gamma;
 	static int readApiSize(int fd, int &xres, int &yres, int &aspect);
 public:
 	enum { MPEG2, MPEG4_H264, VC1 = 3, MPEG4_Part2, VC1_SM, MPEG1, H265_HEVC, AVS = 16 };
@@ -57,6 +57,7 @@ public:
 	int getProgressive();
 	int getFrameRate();
 	int getAspect();
+	int getGamma();
 };
 
 class eDVBPCR: public iObject
@@ -173,6 +174,7 @@ public:
 	int getVideoProgressive();
 	int getVideoFrameRate();
 	int getVideoAspect();
+	int getVideoGamma();
 	static RESULT setHwPCMDelay(int delay);
 	static RESULT setHwAC3Delay(int delay);
 };

--- a/lib/dvb/idvb.h
+++ b/lib/dvb/idvb.h
@@ -755,13 +755,15 @@ public:
 		enum { eventUnknown = 0,
 			eventSizeChanged = VIDEO_EVENT_SIZE_CHANGED,
 			eventFrameRateChanged = VIDEO_EVENT_FRAME_RATE_CHANGED,
-			eventProgressiveChanged = 16
+			eventProgressiveChanged = 16,
+			eventGammaChanged = 17
 		} type;
 		unsigned char aspect;
 		unsigned short height;
 		unsigned short width;
 		bool progressive;
 		unsigned short framerate;
+		unsigned short gamma;
 	};
 
 	virtual RESULT connectVideoEvent(const sigc::slot1<void, struct videoEvent> &event, ePtr<eConnection> &connection) = 0;
@@ -771,6 +773,7 @@ public:
 	virtual int getVideoProgressive() = 0;
 	virtual int getVideoFrameRate() = 0;
 	virtual int getVideoAspect() = 0;
+	virtual int getVideoGamma() = 0;
 };
 
 #endif //SWIG

--- a/lib/python/Components/Converter/PliExtraInfo.py
+++ b/lib/python/Components/Converter/PliExtraInfo.py
@@ -152,7 +152,8 @@ class PliExtraInfo(Poll, Converter, object):
 		yres = info.getInfo(iServiceInformation.sVideoHeight)
 		mode = ("i", "p", " ")[info.getInfo(iServiceInformation.sProgressive)]
 		fps  = str((info.getInfo(iServiceInformation.sFrameRate) + 500) / 1000)
-		return str(xres) + "x" + str(yres) + mode + fps
+		gamma = ("SDR", "HDR", "HDR10", "HLG", "")[info.getInfo(iServiceInformation.sGamma)]
+		return str(xres) + "x" + str(yres) + mode + fps + addspace(gamma)
 
 	def createVideoCodec(self, info):
 		return codec_data.get(info.getInfo(iServiceInformation.sVideoType), "N/A")

--- a/lib/python/Screens/ServiceInfo.py
+++ b/lib/python/Screens/ServiceInfo.py
@@ -152,6 +152,9 @@ class ServiceInfo(Screen):
 					aspect = self.getServiceInfoValue(iServiceInformation.sAspect)
 					aspect = aspect in ( 1, 2, 5, 6, 9, 0xA, 0xD, 0xE ) and "4:3" or "16:9"
 					resolution += " - ["+aspect+"]"
+				gamma = ("SDR", "HDR", "HDR10", "HLG", "")[self.info.getInfo(iServiceInformation.sGamma)]
+				if gamma:
+					resolution += " - " + gamma
 			if "%3a//" in refstr and reftype not in (1,257,4098,4114):
 				fillList = [(_("Service name"), name, TYPE_TEXT),
 					(_("Videocodec, size & format"), resolution, TYPE_TEXT),

--- a/lib/service/iservice.h
+++ b/lib/service/iservice.h
@@ -393,6 +393,8 @@ public:
 		sHideVBI,
 		sCenterDVBSubs,
 
+		sGamma,
+
 		sUser = 0x100
 	};
 	enum {
@@ -930,6 +932,8 @@ public:
 		evStopped,
 
 		evHBBTVInfo,
+
+		evVideoGammaChanged,
 
 		evUser = 0x100
 	};

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -1919,6 +1919,9 @@ int eDVBServicePlay::getInfo(int w)
 			return aspect;
 		break;
 	}
+	case sGamma:
+		if (m_decoder) return m_decoder->getVideoGamma();
+		break;
 	case sIsCrypted:
 		if (no_program_info) return false;
 		return program.isCrypted();
@@ -3554,6 +3557,9 @@ void eDVBServicePlay::video_event(struct iTSMPEGDecoder::videoEvent event)
 			break;
 		case iTSMPEGDecoder::videoEvent::eventProgressiveChanged:
 			m_event((iPlayableService*)this, evVideoProgressiveChanged);
+			break;
+		case iTSMPEGDecoder::videoEvent::eventGammaChanged:
+			m_event((iPlayableService*)this, evVideoGammaChanged);
 			break;
 		default:
 			break;


### PR DESCRIPTION
This commit adds support for reporting current gamma curve to Enigma2.
It uses video event with id 17. The framerate property will have one
of the following possible gamma values:
0: Traditional gamma - SDR luminance range
1: Traditional gamma - HDR luminance range
2: SMPTE ST2084 (aka HDR10)
3: Hybrid Log-gamma