### PR TITLE
ChoiceBox: add add sanity check in getDescrLineHeight

### DIFF
--- a/lib/python/Screens/ChoiceBox.py
+++ b/lib/python/Screens/ChoiceBox.py
@@ -103,7 +103,7 @@ class ChoiceBox(Screen):
 
 		def getMaxDescriptionHeight():
 			def getDescrLineHeight(text):
-				if len(text)==3:
+				if len(text) > 2 and isinstance(text[2], str):
 					self["description"].setText(text[2])
 					return self["description"].instance.calculateSize().height()
 				return 0


### PR DESCRIPTION
This fix GSOD in plugin MediaScanner where text[2] is session.

Also changes the text length check to use the description if more parameters are added in the future.