### PR TITLE
Console: set 'Exit' on red button when finished

### DIFF
--- a/lib/python/Screens/Console.py
+++ b/lib/python/Screens/Console.py
@@ -70,6 +70,7 @@ class Console(Screen):
 				self.cancel()
 			else:
 				self["text"].appendText(_("\nPress OK or Exit to abort!"))
+				self["key_red"].setText(_("Exit"))
 
 	def cancel(self):
 		if self.run == len(self.cmdlist):


### PR DESCRIPTION
It's strange to see the button cancel when the execution is finished and there is no longer anything to cancel.