### PR TITLE
frontend.cpp: use new eDVBFrontendParametersSatellite::PLS_Default_Go…

### DIFF
--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -97,7 +97,7 @@ void eDVBFrontendParametersSatellite::set(const S2SatelliteDeliverySystemDescrip
 	{
 		is_id = NO_STREAM_ID_FILTER;
 		pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
-		pls_code = eDVBFrontendParametersSatellite::PLS_Default_Root_Code;
+		pls_code = eDVBFrontendParametersSatellite::PLS_Default_Gold_Code;
 	}
 }
 
@@ -127,7 +127,7 @@ void eDVBFrontendParametersSatellite::set(const SatelliteDeliverySystemDescripto
 	rolloff = descriptor.getRollOff();
 	is_id = NO_STREAM_ID_FILTER;
 	pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
-	pls_code = eDVBFrontendParametersSatellite::PLS_Default_Root_Code;
+	pls_code = eDVBFrontendParametersSatellite::PLS_Default_Gold_Code;
 	if (system == System_DVB_S2)
 	{
 		eDebug("[eDVBFrontendParametersSatellite] SAT DVB-S2 freq %d, %s, pos %d, sr %d, fec %d, modulation %d, rolloff %d, is_id %d, pls_mode %d, pls_code %d",
@@ -2711,7 +2711,7 @@ int eDVBFrontend::isCompatibleWith(ePtr<iDVBFrontendParameters> &feparm)
 		{
 			return 0;
 		}
-		bool multistream = (static_cast<unsigned int>(parm.is_id) != NO_STREAM_ID_FILTER || (parm.pls_code & 0x3FFFF) != 0 ||
+		bool multistream = (static_cast<unsigned int>(parm.is_id) != NO_STREAM_ID_FILTER || (parm.pls_code & 0x3FFFF) != eDVBFrontendParametersSatellite::PLS_Default_Gold_Code ||
 					(parm.pls_mode & 3) != eDVBFrontendParametersSatellite::PLS_Gold);
 		if (parm.system == eDVBFrontendParametersSatellite::System_DVB_S2 && multistream && !is_multistream())
 		{


### PR DESCRIPTION
…ld_Code variable in multistream test.

And fix a copy/paste error.