### PR TITLE
Add enumeration for Gold and Root PLS codes

### DIFF
--- a/lib/dvb/db.cpp
+++ b/lib/dvb/db.cpp
@@ -466,7 +466,7 @@ static ePtr<eDVBFrontendParameters> parseFrontendData(char* line, int version)
 				rolloff=eDVBFrontendParametersSatellite::RollOff_alpha_0_35,
 				pilot=eDVBFrontendParametersSatellite::Pilot_Unknown,
 				is_id = NO_STREAM_ID_FILTER,
-				pls_code = 0,
+				pls_code = eDVBFrontendParametersSatellite::PLS_Default_Gold_Code,
 				pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
 			sscanf(line+2, "%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d",
 				&frequency, &symbol_rate, &polarisation, &fec, &orbital_position,
@@ -1380,7 +1380,7 @@ PyObject *eDVBDB::readSatellites(ePyObject sat_list, ePyObject sat_dict, ePyObje
 				pilot = eDVBFrontendParametersSatellite::Pilot_Unknown;
 				rolloff = eDVBFrontendParametersSatellite::RollOff_alpha_0_35;
 				is_id = NO_STREAM_ID_FILTER;
-				pls_code = 0;
+				pls_code = eDVBFrontendParametersSatellite::PLS_Default_Gold_Code;
 				pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
 				tsid = -1;
 				onid = -1;

--- a/lib/dvb/db.cpp
+++ b/lib/dvb/db.cpp
@@ -465,7 +465,7 @@ static ePtr<eDVBFrontendParameters> parseFrontendData(char* line, int version)
 				modulation=eDVBFrontendParametersSatellite::Modulation_QPSK,
 				rolloff=eDVBFrontendParametersSatellite::RollOff_alpha_0_35,
 				pilot=eDVBFrontendParametersSatellite::Pilot_Unknown,
-				is_id = NO_STREAM_ID_FILTER,
+				is_id = eDVBFrontendParametersSatellite::No_Stream_Id_Filter,
 				pls_code = eDVBFrontendParametersSatellite::PLS_Default_Gold_Code,
 				pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
 			sscanf(line+2, "%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d",
@@ -1379,7 +1379,7 @@ PyObject *eDVBDB::readSatellites(ePyObject sat_list, ePyObject sat_dict, ePyObje
 				inv = eDVBFrontendParametersSatellite::Inversion_Unknown;
 				pilot = eDVBFrontendParametersSatellite::Pilot_Unknown;
 				rolloff = eDVBFrontendParametersSatellite::RollOff_alpha_0_35;
-				is_id = NO_STREAM_ID_FILTER;
+				is_id = eDVBFrontendParametersSatellite::No_Stream_Id_Filter;
 				pls_code = eDVBFrontendParametersSatellite::PLS_Default_Gold_Code;
 				pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
 				tsid = -1;

--- a/lib/dvb/fastscan.cpp
+++ b/lib/dvb/fastscan.cpp
@@ -512,7 +512,7 @@ void eFastScan::parseResult()
 			fesat.pilot = eDVBFrontendParametersSatellite::Pilot_Unknown;
 			fesat.is_id = NO_STREAM_ID_FILTER;
 			fesat.pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
-			fesat.pls_code = 0;
+			fesat.pls_code = eDVBFrontendParametersSatellite::PLS_Default_Gold_Code;
 
 			parm->setDVBS(fesat);
 			db->addChannelToList(chid, parm);

--- a/lib/dvb/fastscan.cpp
+++ b/lib/dvb/fastscan.cpp
@@ -510,7 +510,7 @@ void eFastScan::parseResult()
 			fesat.modulation = (*it)->getModulation();
 			fesat.rolloff = (*it)->getRollOff();
 			fesat.pilot = eDVBFrontendParametersSatellite::Pilot_Unknown;
-			fesat.is_id = NO_STREAM_ID_FILTER;
+			fesat.is_id = eDVBFrontendParametersSatellite::No_Stream_Id_Filter;
 			fesat.pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
 			fesat.pls_code = eDVBFrontendParametersSatellite::PLS_Default_Gold_Code;
 

--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -97,7 +97,7 @@ void eDVBFrontendParametersSatellite::set(const S2SatelliteDeliverySystemDescrip
 	{
 		is_id = NO_STREAM_ID_FILTER;
 		pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
-		pls_code = 0;
+		pls_code = eDVBFrontendParametersSatellite::PLS_Default_Root_Code;
 	}
 }
 
@@ -127,7 +127,7 @@ void eDVBFrontendParametersSatellite::set(const SatelliteDeliverySystemDescripto
 	rolloff = descriptor.getRollOff();
 	is_id = NO_STREAM_ID_FILTER;
 	pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
-	pls_code = 0;
+	pls_code = eDVBFrontendParametersSatellite::PLS_Default_Root_Code;
 	if (system == System_DVB_S2)
 	{
 		eDebug("[eDVBFrontendParametersSatellite] SAT DVB-S2 freq %d, %s, pos %d, sr %d, fec %d, modulation %d, rolloff %d, is_id %d, pls_mode %d, pls_code %d",

--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -95,7 +95,7 @@ void eDVBFrontendParametersSatellite::set(const S2SatelliteDeliverySystemDescrip
 	}
 	else // default DVB-S2 physical layer scrambling sequence of index n = 0 is used
 	{
-		is_id = NO_STREAM_ID_FILTER;
+		is_id = eDVBFrontendParametersSatellite::No_Stream_Id_Filter;
 		pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
 		pls_code = eDVBFrontendParametersSatellite::PLS_Default_Gold_Code;
 	}
@@ -125,7 +125,7 @@ void eDVBFrontendParametersSatellite::set(const SatelliteDeliverySystemDescripto
 		modulation = Modulation_QPSK;
 	}
 	rolloff = descriptor.getRollOff();
-	is_id = NO_STREAM_ID_FILTER;
+	is_id = eDVBFrontendParametersSatellite::No_Stream_Id_Filter;
 	pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
 	pls_code = eDVBFrontendParametersSatellite::PLS_Default_Gold_Code;
 	if (system == System_DVB_S2)

--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -97,7 +97,7 @@ void eDVBFrontendParametersSatellite::set(const S2SatelliteDeliverySystemDescrip
 	{
 		is_id = NO_STREAM_ID_FILTER;
 		pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
-		pls_code = eDVBFrontendParametersSatellite::PLS_Default_Root_Code;
+		pls_code = eDVBFrontendParametersSatellite::PLS_Default_Gold_Code;
 	}
 }
 
@@ -127,7 +127,7 @@ void eDVBFrontendParametersSatellite::set(const SatelliteDeliverySystemDescripto
 	rolloff = descriptor.getRollOff();
 	is_id = NO_STREAM_ID_FILTER;
 	pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
-	pls_code = eDVBFrontendParametersSatellite::PLS_Default_Root_Code;
+	pls_code = eDVBFrontendParametersSatellite::PLS_Default_Gold_Code;
 	if (system == System_DVB_S2)
 	{
 		eDebug("[eDVBFrontendParametersSatellite] SAT DVB-S2 freq %d, %s, pos %d, sr %d, fec %d, modulation %d, rolloff %d, is_id %d, pls_mode %d, pls_code %d",
@@ -2711,7 +2711,7 @@ int eDVBFrontend::isCompatibleWith(ePtr<iDVBFrontendParameters> &feparm)
 		{
 			return 0;
 		}
-		bool multistream = (static_cast<unsigned int>(parm.is_id) != NO_STREAM_ID_FILTER || (parm.pls_code & 0x3FFFF) != 0 ||
+		bool multistream = (static_cast<unsigned int>(parm.is_id) != NO_STREAM_ID_FILTER || (parm.pls_code & 0x3FFFF) != eDVBFrontendParametersSatellite::PLS_Default_Gold_Code ||
 					(parm.pls_mode & 3) != eDVBFrontendParametersSatellite::PLS_Gold);
 		if (parm.system == eDVBFrontendParametersSatellite::System_DVB_S2 && multistream && !is_multistream())
 		{

--- a/lib/dvb/frontendparms.h
+++ b/lib/dvb/frontendparms.h
@@ -59,6 +59,10 @@ public:
 		No_Stream_Id_Filter = NO_STREAM_ID_FILTER
 	};
 
+	enum {
+		PLS_Default_Gold_Code, PLS_Default_Root_Code
+	};
+
 	bool no_rotor_command_on_tune;
 	unsigned int frequency, symbol_rate;
 	int polarisation, fec, inversion, orbital_position, system, modulation, rolloff, pilot, is_id, pls_mode, pls_code;

--- a/lib/python/Components/TuneTest.py
+++ b/lib/python/Components/TuneTest.py
@@ -27,7 +27,7 @@ class Tuner:
 			else:
 				parm.is_id = eDVBFrontendParametersSatellite.No_Stream_Id_Filter
 				parm.pls_mode = eDVBFrontendParametersSatellite.PLS_Gold
-				parm.pls_code = 0 # default gold PLS code
+				parm.pls_code = eDVBFrontendParametersSatellite.PLS_Default_Gold_Code
 			self.tuneSatObj(parm)
 
 	def tuneSatObj(self, transponderObj):

--- a/lib/python/Plugins/SystemPlugins/FastScan/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/FastScan/plugin.py
@@ -249,7 +249,7 @@ class FastScanScreen(ConfigListScreen, Screen):
 		transponderParameters.pilot = self.transponders[number][9]
 		transponderParameters.is_id = eDVBFrontendParametersSatellite.No_Stream_Id_Filter
 		transponderParameters.pls_mode = eDVBFrontendParametersSatellite.PLS_Gold
-		transponderParameters.pls_code = 0
+		transponderParameters.pls_code = eDVBFrontendParametersSatellite.PLS_Default_Gold_Code
 		return transponderParameters
 
 	def startScan(self):

--- a/lib/python/Plugins/SystemPlugins/PositionerSetup/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/PositionerSetup/plugin.py
@@ -164,7 +164,7 @@ class PositionerSetup(Screen):
 			cur.get("pilot", eDVBFrontendParametersSatellite.Pilot_Unknown),
 			cur.get("is_id", 0),
 			cur.get("pls_mode", eDVBFrontendParametersSatellite.PLS_Gold),
-			cur.get("pls_code", 0))
+			cur.get("pls_code", eDVBFrontendParametersSatellite.PLS_Default_Gold_Code))
 
 		self.tuner.tune(tp)
 		self.isMoving = False
@@ -1343,7 +1343,7 @@ class TunerScreen(ConfigListScreen, Screen):
 			"fec_s2": eDVBFrontendParametersSatellite.FEC_9_10,
 			"modulation": eDVBFrontendParametersSatellite.Modulation_QPSK,
 			"pls_mode": eDVBFrontendParametersSatellite.PLS_Gold,
-			"pls_code": 0 }
+			"pls_code": eDVBFrontendParametersSatellite.PLS_Default_Gold_Code }
 		if frontendData is not None:
 			ttype = frontendData.get("tuner_type", "UNKNOWN")
 			defaultSat["system"] = frontendData.get("system", eDVBFrontendParametersSatellite.System_DVB_S)
@@ -1357,7 +1357,7 @@ class TunerScreen(ConfigListScreen, Screen):
 				defaultSat["pilot"] = frontendData.get("pilot", eDVBFrontendParametersSatellite.Pilot_Unknown)
 				defaultSat["is_id"] = frontendData.get("is_id", 0)
 				defaultSat["pls_mode"] = frontendData.get("pls_mode", eDVBFrontendParametersSatellite.PLS_Gold)
-				defaultSat["pls_code"] = frontendData.get("pls_code", 0)
+				defaultSat["pls_code"] = frontendData.get("pls_code", eDVBFrontendParametersSatellite.PLS_Default_Gold_Code)
 			else:
 				defaultSat["fec"] = frontendData.get("fec_inner", eDVBFrontendParametersSatellite.FEC_Auto)
 			defaultSat["modulation"] = frontendData.get("modulation", eDVBFrontendParametersSatellite.Modulation_QPSK)
@@ -1415,7 +1415,7 @@ class TunerScreen(ConfigListScreen, Screen):
 			(eDVBFrontendParametersSatellite.PLS_Root, _("Root")),
 			(eDVBFrontendParametersSatellite.PLS_Gold, _("Gold")),
 			(eDVBFrontendParametersSatellite.PLS_Combo, _("Combo"))])
-		self.scan_sat.pls_code = ConfigInteger(default = defaultSat.get("pls_code", 0), limits = (0, 262142))
+		self.scan_sat.pls_code = ConfigInteger(default = defaultSat.get("pls_code", eDVBFrontendParametersSatellite.PLS_Default_Gold_Code), limits = (0, 262142))
 
 	def initialSetup(self):
 		currtp = self.transponderToString([None, self.scan_sat.frequency.value, self.scan_sat.symbolrate.value, self.scan_sat.polarization.value])

--- a/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
@@ -118,7 +118,7 @@ class Satfinder(ScanSetup, ServiceScan):
 				self.pls_code_memory = self.scan_sat.pls_code.value
 				self.scan_sat.is_id.value = eDVBFrontendParametersSatellite.No_Stream_Id_Filter
 				self.scan_sat.pls_mode.value = eDVBFrontendParametersSatellite.PLS_Gold
-				self.scan_sat.pls_code.value = 0
+				self.scan_sat.pls_code.value = eDVBFrontendParametersSatellite.PLS_Default_Gold_Code
 			self.createSetup()
 			self.retune()
 
@@ -171,7 +171,7 @@ class Satfinder(ScanSetup, ServiceScan):
 					else:
 						self.scan_sat.is_id.value = eDVBFrontendParametersSatellite.No_Stream_Id_Filter
 						self.scan_sat.pls_mode.value = eDVBFrontendParametersSatellite.PLS_Gold
-						self.scan_sat.pls_code.value = 0
+						self.scan_sat.pls_code.value = eDVBFrontendParametersSatellite.PLS_Default_Gold_Code
 			elif self.tuning_type.value == "predefined_transponder":
 				self.updatePreDefTransponders()
 				self.preDefTransponderEntry = getConfigListEntry(_("Transponder"), self.preDefTransponders)

--- a/lib/python/Screens/AutoDiseqc.py
+++ b/lib/python/Screens/AutoDiseqc.py
@@ -38,7 +38,7 @@ class AutoDiseqc(Screen, ConfigListScreen):
 			eDVBFrontendParametersSatellite.Pilot_Unknown,
 			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
 			eDVBFrontendParametersSatellite.PLS_Gold,
-			0,  # default gold PLS code
+			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
 			1079,
 			1,
 			"Astra 1 19.2e"),
@@ -57,7 +57,7 @@ class AutoDiseqc(Screen, ConfigListScreen):
 			eDVBFrontendParametersSatellite.Pilot_Unknown,
 			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
 			eDVBFrontendParametersSatellite.PLS_Gold,
-			0,  # default gold PLS code
+			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
 			3224,
 			3,
 			"Astra 3 23.5e"),
@@ -76,7 +76,7 @@ class AutoDiseqc(Screen, ConfigListScreen):
 			eDVBFrontendParametersSatellite.Pilot_Unknown,
 			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
 			eDVBFrontendParametersSatellite.PLS_Gold,
-			0,  # default gold PLS code
+			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
 			2004,
 			2,
 			"Astra 2 28.2e"),
@@ -95,7 +95,7 @@ class AutoDiseqc(Screen, ConfigListScreen):
 			eDVBFrontendParametersSatellite.Pilot_Unknown,
 			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
 			eDVBFrontendParametersSatellite.PLS_Gold,
-			0,  # default gold PLS code
+			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
 			12400,
 			318,
 			"Hotbird 13.0e"),
@@ -114,7 +114,7 @@ class AutoDiseqc(Screen, ConfigListScreen):
 			eDVBFrontendParametersSatellite.Pilot_Unknown,
 			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
 			eDVBFrontendParametersSatellite.PLS_Gold,
-			0,  # default gold PLS code
+			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
  			20100,
  			366,
  			"Eutelsat 16A 16.0e"),
@@ -133,7 +133,7 @@ class AutoDiseqc(Screen, ConfigListScreen):
 			eDVBFrontendParametersSatellite.Pilot_Unknown,
 			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
 			eDVBFrontendParametersSatellite.PLS_Gold,
-			0, # default gold PLS code
+			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
 			706,
 			1536,
 			"Thor 5/6/7 0.8w"),
@@ -152,7 +152,7 @@ class AutoDiseqc(Screen, ConfigListScreen):
 			eDVBFrontendParametersSatellite.Pilot_Unknown,
 			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
 			eDVBFrontendParametersSatellite.PLS_Gold,
-			0, # default gold PLS code
+			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
 			1388,
 			1388,
 			"Hispasat 30.0w"),

--- a/lib/python/Screens/ScanSetup.py
+++ b/lib/python/Screens/ScanSetup.py
@@ -728,7 +728,7 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 					else:
 						self.scan_sat.is_id.value = eDVBFrontendParametersSatellite.No_Stream_Id_Filter
 						self.scan_sat.pls_mode.value = eDVBFrontendParametersSatellite.PLS_Gold
-						self.scan_sat.pls_code.value = 0
+						self.scan_sat.pls_code.value = eDVBFrontendParametersSatellite.PLS_Default_Gold_Code
 			elif self.scan_type.value == "predefined_transponder" and self.satList[index_to_scan]:
 				self.updateSatList()
 				self.preDefSatList = getConfigListEntry(_('Satellite'), self.scan_satselection[index_to_scan])
@@ -866,7 +866,7 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 				self.pls_code_memory = self.scan_sat.pls_code.value
 				self.scan_sat.is_id.value = eDVBFrontendParametersSatellite.No_Stream_Id_Filter
 				self.scan_sat.pls_mode.value = eDVBFrontendParametersSatellite.PLS_Gold
-				self.scan_sat.pls_code.value = 0
+				self.scan_sat.pls_code.value = eDVBFrontendParametersSatellite.PLS_Default_Gold_Code
 			self.createSetup()
 
 	def createConfig(self, frontendData):
@@ -882,7 +882,7 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 			"modulation": eDVBFrontendParametersSatellite.Modulation_QPSK,
 			"is_id": eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
 			"pls_mode": eDVBFrontendParametersSatellite.PLS_Gold,
-			"pls_code": 0 }
+			"pls_code": eDVBFrontendParametersSatellite.PLS_Default_Gold_Code }
 		defaultCab = {
 			"frequency": 466000,
 			"inversion": eDVBFrontendParametersCable.Inversion_Unknown,


### PR DESCRIPTION
- Add default Gold and Root PLS codes enum 
- frontend.cpp: use new eDVBFrontendParametersSatellite::PLS_Default_Gold_Code variable in multistream test.
-  Change NO_STREAM_ID_FILTER with eDVBFrontendParametersSatellite::No_Stream_Id_Filter