### PR TITLE
[BoundFunction.py] Pass copy of kwargs in boundFunction calls

### DIFF
--- a/lib/python/Tools/BoundFunction.py
+++ b/lib/python/Tools/BoundFunction.py
@@ -4,6 +4,6 @@ class boundFunction:
 		self.args = args
 		self.kwargs = kwargs
 	def __call__(self, *args, **kwargs):
-		newkwargs = self.kwargs
+		newkwargs = dict(self.kwargs)
 		newkwargs.update(kwargs)
 		return self.fnc(*self.args + args, **newkwargs)


### PR DESCRIPTION
This error detection and its correction was supplied by Prl.
