### PR TITLE
data/fonts/Makefile.am: Fix install font

### DIFF
--- a/data/fonts/Makefile.am
+++ b/data/fonts/Makefile.am
@@ -17,6 +17,6 @@ dist_install_DATA = \
 	LiberationSans-Regular.ttf \
 	wqy-microhei.ttc
 
-install-exec-hook:
+install-data-hook:
 	cd $(DESTDIR)$(datadir)/fonts && \
 	$(LN_S) wqy-microhei.ttc fallback.font


### PR DESCRIPTION
Error: /image/usr/share/fonts: No such file or directory
make[4]: *** [Makefile:577: install-exec-hook] Error 1