### PR TITLE
Make skin xmls to be searched by default in current skin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ aclocal-copy
 compile
 .dirstamp
 mipsel-oe-linux-libtool
+/.vs

--- a/skin.py
+++ b/skin.py
@@ -42,7 +42,7 @@ class SkinError(Exception):
 
 dom_skins = [ ]
 
-def addSkin(name, scope = SCOPE_SKIN):
+def addSkin(name, scope = SCOPE_CURRENT_SKIN):
 	# read the skin
 	filename = resolveFilename(scope, name)
 	if fileExists(filename):
@@ -99,10 +99,7 @@ addSkin('skin_box.xml')
 addSkin('skin_second_infobar.xml')
 
 display_skin_id = 1
-if fileExists(resolveFilename(SCOPE_CURRENT_SKIN, 'skin_display.xml')):
-  addSkin('skin_display.xml', SCOPE_CURRENT_SKIN)
-else:
-  addSkin('skin_display.xml')
+addSkin('skin_display.xml')
 addSkin('skin_text.xml')
 addSkin('skin_subtitles.xml')
 

--- a/skin.py
+++ b/skin.py
@@ -42,7 +42,7 @@ class SkinError(Exception):
 
 dom_skins = [ ]
 
-def addSkin(name, scope = SCOPE_SKIN):
+def addSkin(name, scope = SCOPE_CURRENT_SKIN):
 	# read the skin
 	filename = resolveFilename(scope, name)
 	if fileExists(filename):
@@ -99,12 +99,8 @@ addSkin('skin_box.xml')
 addSkin('skin_second_infobar.xml')
 
 display_skin_id = 1
-displaySkinXml = 'skin_display.xml';
-displaySkinFilename = resolveFilename(SCOPE_CURRENT_SKIN, displaySkinXml)
-if fileExists(displaySkinFilename):
-  addSkin(displaySkinXml, SCOPE_CURRENT_SKIN)
-else:
-  addSkin(displaySkinXml)
+
+addSkin(displaySkinXml)
 
 addSkin('skin_text.xml')
 

--- a/skin.py
+++ b/skin.py
@@ -97,8 +97,15 @@ if not name or not res:
 addSkin('skin_box.xml')
 # add optional discrete second infobar
 addSkin('skin_second_infobar.xml')
+
 display_skin_id = 1
-addSkin('skin_display.xml')
+displaySkinXml = 'skin_display.xml';
+displaySkinFilename = resolveFilename(SCOPE_CURRENT_SKIN, displaySkinXml)
+if fileExists(displaySkinFilename):
+  addSkin(displaySkinXml, SCOPE_CURRENT_SKIN)
+else:
+  addSkin(displaySkinXml)
+
 addSkin('skin_text.xml')
 
 addSkin('skin_subtitles.xml')


### PR DESCRIPTION
Make skin_*. xml files to be searched by default in current skin directory instead in global skins directory.
That will allow putting skin xmls inside current skin directory and in this way they will be made skin specific which will override the definition in global skins directory.