### PR TITLE
Add support for "Timer" button in new Vu+ RCUs

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -291,6 +291,7 @@
 
 	<map context="InfobarTimerButtonActions">
 		<key id="KEY_PROGRAM" mapto="timerSelection" flags="b"/>
+		<key id="KEY_EDIT" mapto="timerSelection" flags="b"/>
 	</map>
 
 	<map context="InfobarVmodeButtonActions">
@@ -609,6 +610,7 @@
 		<key id="KEY_NEXT" mapto="nextService" flags="m"/>
 		<key id="KEY_PREVIOUS" mapto="prevService" flags="m"/>
 		<key id="KEY_PROGRAM" mapto="timerAdd" flags="m"/>
+		<key id="KEY_EDIT" mapto="timerAdd" flags="m"/>
 		<key id="KEY_TV" mapto="preview" flags="m"/>
 		<key id="KEY_TV2" mapto="preview" flags="m"/>
 		<key id="KEY_REWIND" mapto="prevDay" flags="m"/>
@@ -629,6 +631,7 @@
 		<key id="KEY_NEXT" mapto="nextService" flags="m"/>
 		<key id="KEY_PREVIOUS" mapto="prevService" flags="m"/>
 		<key id="KEY_PROGRAM" mapto="timerAdd" flags="m"/>
+		<key id="KEY_EDIT" mapto="timerAdd" flags="m"/>
 		<key id="KEY_TV" mapto="preview" flags="m"/>
 		<key id="KEY_TV2" mapto="preview" flags="m"/>
 		<key id="KEY_RADIO" mapto="window" flags="m"/>
@@ -646,6 +649,7 @@
 		<key id="KEY_INFO" mapto="contextMenu" flags="m"/>
 		<key id="KEY_MENU" mapto="contextMenu" flags="m"/>
 		<key id="KEY_PROGRAM" mapto="timerAdd" flags="m"/>
+		<key id="KEY_EDIT" mapto="timerAdd" flags="m"/>
 	</map>
 
 	<map context="EventViewEPGActions">
@@ -897,6 +901,8 @@
 		<key id="KEY_SCREEN" mapto="activatePiP" flags="m"/>
 		<key id="KEY_PROGRAM" mapto="timer" flags="b"/>
 		<key id="KEY_PROGRAM" mapto="timer_long" flags="l"/>
+		<key id="KEY_EDIT" mapto="timer" flags="b"/>
+		<key id="KEY_EDIT" mapto="timer_long" flags="l"/>
 		<key id="KEY_PLAYPAUSE" mapto="playpause" flags="m"/>
 		<key id="KEY_LIST" mapto="playlist" flags="m"/>
 		<key id="KEY_TIME" mapto="timeshift" flags="m"/>


### PR DESCRIPTION
On the new VU+ RCUs there is a button "Timer". It is labeled as "timer" but it sends KEY_EDIT.
This code adds support for it to control Timer functions and also to be available for mapping in hotkeys.