### PR TITLE
pvrparse: use video enumeration from eDVBVideo class

### DIFF
--- a/lib/dvb/decoder.h
+++ b/lib/dvb/decoder.h
@@ -40,7 +40,7 @@ private:
 	int m_width, m_height, m_framerate, m_aspect, m_progressive, m_gamma;
 	static int readApiSize(int fd, int &xres, int &yres, int &aspect);
 public:
-	enum { MPEG2, MPEG4_H264, VC1 = 3, MPEG4_Part2, VC1_SM, MPEG1, H265_HEVC, AVS = 16 };
+	enum { UNKNOWN = -1, MPEG2, MPEG4_H264, VC1 = 3, MPEG4_Part2, VC1_SM, MPEG1, H265_HEVC, AVS = 16 };
 	eDVBVideo(eDVBDemux *demux, int dev);
 	void stop();
 	int startPid(int pid, int type=MPEG2);

--- a/lib/dvb/pvrparse.cpp
+++ b/lib/dvb/pvrparse.cpp
@@ -1,4 +1,5 @@
 #include <lib/dvb/pvrparse.h>
+#include <lib/dvb/decoder.h>
 #include <lib/base/cfile.h>
 #include <lib/base/eerror.h>
 #include <sys/types.h>
@@ -943,25 +944,25 @@ int eMPEGStreamParserTS::processPacket(const unsigned char *pkt, off_t offset)
 //			eDebug("[eMPEGStreamParserTS] SC %02x %02x %02x %02x, %02x", pkt[0], pkt[1], pkt[2], pkt[3], pkt[4]);
 			unsigned int sc = pkt[3];
 
-			if (m_streamtype < 0) /* unknown */
+			if (m_streamtype < eDVBVideo::MPEG2) /* unknown */
 			{
 				if ((sc == 0x00) || (sc == 0xb3) || (sc == 0xb8))
 				{
 					eDebug("[eMPEGStreamParserTS] - detected MPEG2 stream");
-					m_streamtype = 0;
+					m_streamtype = eDVBVideo::MPEG2;
 				}
 				else if (sc == 0x09)
 				{
 					eDebug("[eMPEGStreamParserTS] - detected H264 stream");
-					m_streamtype =  1;
+					m_streamtype =  eDVBVideo::MPEG4_H264;
 				}
-				else
+				else /* TODO: detect H265 */
 					continue;
 			}
 
 			switch(m_streamtype)
 			{
-				case(0): // mpeg2
+				case(eDVBVideo::MPEG2): // mpeg2
 				{
 					if ((sc == 0x00) || (sc == 0xb3) || (sc == 0xb8)) /* picture, sequence, group start code */
 					{
@@ -992,7 +993,7 @@ int eMPEGStreamParserTS::processPacket(const unsigned char *pkt, off_t offset)
 					break;
 				}
 
-				case(1): // h.264 */
+				case(eDVBVideo::MPEG4_H264): // h.264 */
 				{
 					if (sc == 0x09)
 					{
@@ -1015,7 +1016,7 @@ int eMPEGStreamParserTS::processPacket(const unsigned char *pkt, off_t offset)
 					break;
 				}
 
-				case(7): // h.265
+				case(eDVBVideo::H265_HEVC): // h.265
 				{
 					int nal_unit_type = (sc >> 1);
 					if (nal_unit_type == 35) /* H265 NAL unit access delimiter */
@@ -1066,7 +1067,7 @@ inline int eMPEGStreamParserTS::wantPacket(const unsigned char *pkt) const
 	if (hdr[1] & 0x40)	 /* pusi set: yes. */
 		return 1;
 
-	return m_streamtype == 0; /* we need all packets for MPEG2, but only PUSI packets for H.264 */
+	return m_streamtype == eDVBVideo::MPEG2; /* we need all packets for MPEG2, but only PUSI packets for H.264 */
 }
 
 void eMPEGStreamParserTS::parseData(off_t offset, const void *data, unsigned int len)
@@ -1200,12 +1201,13 @@ void eMPEGStreamParserTS::setPid(int _pid, iDVBTSRecorder::timing_pid_type pidty
 {
 	m_pktptr = 0;
 	/*
-	 * Currently, eMPEGStreamParserTS can only parse video, mpeg2 (streamtype 0), h264 (streamtype 1) and h265 (streamtype 7).
+	 * Currently, eMPEGStreamParserTS can only parse video, mpeg2, h264 and h265.
 	 * Also, streamtype -1 should be accepted, which will cause the streamtype to be autodetected.
 	 * Do not try to parse audio pids, which might lead to false hits,
 	 * and waste cpu time.
 	 */
-	if (pidtype == iDVBTSRecorder::video_pid && (streamtype < 2 || streamtype == 7))
+	if (pidtype == iDVBTSRecorder::video_pid && (streamtype == eDVBVideo::MPEG2 ||
+		streamtype == eDVBVideo::MPEG4_H264 || streamtype == eDVBVideo::H265_HEVC))
 	{
 		m_pid = _pid;
 		m_streamtype = streamtype;

--- a/lib/dvb/pvrparse.cpp
+++ b/lib/dvb/pvrparse.cpp
@@ -944,7 +944,7 @@ int eMPEGStreamParserTS::processPacket(const unsigned char *pkt, off_t offset)
 //			eDebug("[eMPEGStreamParserTS] SC %02x %02x %02x %02x, %02x", pkt[0], pkt[1], pkt[2], pkt[3], pkt[4]);
 			unsigned int sc = pkt[3];
 
-			if (m_streamtype < eDVBVideo::MPEG2) /* unknown */
+			if (m_streamtype == eDVBVideo::UNKNOWN)
 			{
 				if ((sc == 0x00) || (sc == 0xb3) || (sc == 0xb8))
 				{
@@ -962,7 +962,7 @@ int eMPEGStreamParserTS::processPacket(const unsigned char *pkt, off_t offset)
 
 			switch(m_streamtype)
 			{
-				case(eDVBVideo::MPEG2): // mpeg2
+				case eDVBVideo::MPEG2:
 				{
 					if ((sc == 0x00) || (sc == 0xb3) || (sc == 0xb8)) /* picture, sequence, group start code */
 					{
@@ -993,7 +993,7 @@ int eMPEGStreamParserTS::processPacket(const unsigned char *pkt, off_t offset)
 					break;
 				}
 
-				case(eDVBVideo::MPEG4_H264): // h.264 */
+				case eDVBVideo::MPEG4_H264:
 				{
 					if (sc == 0x09)
 					{
@@ -1016,7 +1016,7 @@ int eMPEGStreamParserTS::processPacket(const unsigned char *pkt, off_t offset)
 					break;
 				}
 
-				case(eDVBVideo::H265_HEVC): // h.265
+				case eDVBVideo::H265_HEVC:
 				{
 					int nal_unit_type = (sc >> 1);
 					if (nal_unit_type == 35) /* H265 NAL unit access delimiter */
@@ -1036,11 +1036,14 @@ int eMPEGStreamParserTS::processPacket(const unsigned char *pkt, off_t offset)
 					break;
 				}
 
-				default:
+				case eDVBVideo::UNKNOWN:
+				case eDVBVideo::VC1:
+				case eDVBVideo::MPEG4_Part2:
+				case eDVBVideo::VC1_SM:
+				case eDVBVideo::MPEG1
+				case eDVBVideo::AVS:
 				{
-					eDebug("[eMPEGStreamParserTS]: unknown streamtype: %d ", m_streamtype);
-
-					break;
+					break; /* TODO: add parser for above codecs */
 				}
 			}
 		}

--- a/lib/dvb/pvrparse.cpp
+++ b/lib/dvb/pvrparse.cpp
@@ -1040,7 +1040,7 @@ int eMPEGStreamParserTS::processPacket(const unsigned char *pkt, off_t offset)
 				case eDVBVideo::VC1:
 				case eDVBVideo::MPEG4_Part2:
 				case eDVBVideo::VC1_SM:
-				case eDVBVideo::MPEG1
+				case eDVBVideo::MPEG1:
 				case eDVBVideo::AVS:
 				{
 					break; /* TODO: add parser for above codecs */

--- a/lib/dvb/pvrparse.cpp
+++ b/lib/dvb/pvrparse.cpp
@@ -1205,12 +1205,13 @@ void eMPEGStreamParserTS::setPid(int _pid, iDVBTSRecorder::timing_pid_type pidty
 	m_pktptr = 0;
 	/*
 	 * Currently, eMPEGStreamParserTS can only parse video, mpeg2, h264 and h265.
-	 * Also, streamtype -1 should be accepted, which will cause the streamtype to be autodetected.
+	 * Also, streamtype UNKNOWN should be accepted, which will cause the streamtype to be autodetected.
 	 * Do not try to parse audio pids, which might lead to false hits,
 	 * and waste cpu time.
 	 */
-	if (pidtype == iDVBTSRecorder::video_pid && (streamtype == eDVBVideo::MPEG2 ||
-		streamtype == eDVBVideo::MPEG4_H264 || streamtype == eDVBVideo::H265_HEVC))
+	if (pidtype == iDVBTSRecorder::video_pid && (streamtype == eDVBVideo::UNKNOWN ||
+		streamtype == eDVBVideo::MPEG2 || streamtype == eDVBVideo::MPEG4_H264 ||
+		streamtype == eDVBVideo::H265_HEVC))
 	{
 		m_pid = _pid;
 		m_streamtype = streamtype;
@@ -1219,7 +1220,7 @@ void eMPEGStreamParserTS::setPid(int _pid, iDVBTSRecorder::timing_pid_type pidty
 	{
 		/* invalidate pid */
 		m_pid = -1;
-		m_streamtype = -1;
+		m_streamtype = eDVBVideo::UNKNOWN;
 	}
 }
 


### PR DESCRIPTION
This will prevent unwanted fails with hardcoded values in the future.