### PR TITLE
libopen: remove hardcoded patch to libc

### DIFF
--- a/tools/libopen.c
+++ b/tools/libopen.c
@@ -17,7 +17,7 @@ int open64(const char *pathname, int flags, ...)
 	{
 		void *handle;
 		char *error;
-		handle = dlopen("/lib/libc.so.6", RTLD_LAZY);
+		handle = dlopen("libc.so.6", RTLD_LAZY);
 		if (!handle)
 		{
 			fputs(dlerror(), stderr);
@@ -55,7 +55,7 @@ int open(const char *pathname, int flags, ...)
 	{
 		void *handle;
 		char *error;
-		handle = dlopen("/lib/libc.so.6", RTLD_LAZY);
+		handle = dlopen("libc.so.6", RTLD_LAZY);
 		if (!handle)
 		{
 			fputs(dlerror(), stderr);
@@ -93,7 +93,7 @@ FILE *fopen64(const char *pathname, const char *mode)
 	{
 		void *handle;
 		char *error;
-		handle = dlopen("/lib/libc.so.6", RTLD_LAZY);
+		handle = dlopen("libc.so.6", RTLD_LAZY);
 		if (!handle)
 		{
 			fputs(dlerror(), stderr);
@@ -132,7 +132,7 @@ FILE *fopen(const char *pathname, const char *mode)
 	{
 		void *handle;
 		char *error;
-		handle = dlopen("/lib/libc.so.6", RTLD_LAZY);
+		handle = dlopen("libc.so.6", RTLD_LAZY);
 		if (!handle)
 		{
 			fputs(dlerror(), stderr);
@@ -171,7 +171,7 @@ int socket(int domain, int type, int protocol)
 	{
 		void *handle;
 		char *error;
-		handle = dlopen("/lib/libc.so.6", RTLD_LAZY);
+		handle = dlopen("libc.so.6", RTLD_LAZY);
 		if (!handle)
 		{
 			fputs(dlerror(), stderr);
@@ -209,7 +209,7 @@ int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 	{
 		void *handle;
 		char *error;
-		handle = dlopen("/lib/libc.so.6", RTLD_LAZY);
+		handle = dlopen("libc.so.6", RTLD_LAZY);
 		if (!handle)
 		{
 			fputs(dlerror(), stderr);
@@ -246,7 +246,7 @@ int socketpair(int d, int type, int protocol, int sv[2])
 	{
 		void *handle;
 		char *error;
-		handle = dlopen("/lib/libc.so.6", RTLD_LAZY);
+		handle = dlopen("libc.so.6", RTLD_LAZY);
 		if (!handle)
 		{
 			fputs(dlerror(), stderr);
@@ -289,7 +289,7 @@ int pipe(int modus[2])
 	{
 		void *handle;
 		char *error;
-		handle = dlopen("/lib/libc.so.6", RTLD_LAZY);
+		handle = dlopen("libc.so.6", RTLD_LAZY);
 		if (!handle)
 		{
 			fputs(dlerror(), stderr);


### PR DESCRIPTION
When using multilib the 64bit libc located under /lib64 folder.
This commit removes the hardcoded path to libc, it will be resolved
automatically to the proper location.