### PR TITLE
scan: remove CRLF from channel and provider name

### DIFF
--- a/lib/base/estring.cpp
+++ b/lib/base/estring.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <regex>
 #include <cctype>
 #include <climits>
 #include <string>
@@ -868,4 +869,12 @@ std::string urlDecode(const std::string &s)
 		}
 	}
 	return res;
+}
+
+std::string strip_non_graph(std::string &s)
+{
+	s = std::regex_replace(s, std::regex("[[^:graph:]]"), " ");
+	s = std::regex_replace(s, std::regex("\\s{2,}"), " ");
+	s = std::regex_replace(s, std::regex("^\\s+|\\s+$"), "");
+	return s;
 }

--- a/lib/base/estring.cpp
+++ b/lib/base/estring.cpp
@@ -871,7 +871,7 @@ std::string urlDecode(const std::string &s)
 	return res;
 }
 
-std::string strip_non_graph(std::string &s)
+std::string strip_non_graph(std::string s)
 {
 	s = std::regex_replace(s, std::regex("[[^:graph:]]"), " ");
 	s = std::regex_replace(s, std::regex("\\s{2,}"), " ");

--- a/lib/base/estring.h
+++ b/lib/base/estring.h
@@ -30,6 +30,6 @@ inline std::string convertDVBUTF8(const std::string &string, int table=-1, int t
 }
 
 std::string urlDecode(const std::string &s);
-std::string strip_non_graph(std::string &s);
+std::string strip_non_graph(std::string s);
 
 #endif // __E_STRING__

--- a/lib/base/estring.h
+++ b/lib/base/estring.h
@@ -30,5 +30,6 @@ inline std::string convertDVBUTF8(const std::string &string, int table=-1, int t
 }
 
 std::string urlDecode(const std::string &s);
+std::string strip_non_graph(std::string &s);
 
 #endif // __E_STRING__

--- a/lib/dvb/scan.cpp
+++ b/lib/dvb/scan.cpp
@@ -1104,9 +1104,9 @@ void eDVBScan::channelDone()
 			if( m_chid_current )
 				tsonid = ( m_chid_current.transport_stream_id.get() << 16 )
 					| m_chid_current.original_network_id.get();
-			service->m_service_name = convertDVBUTF8(sname,-1,tsonid,0);
+			service->m_service_name = replace_all(replace_all(convertDVBUTF8(sname,-1,tsonid,0), "\r", ""), "\n", "");
 			service->genSortName();
-			service->m_provider_name = convertDVBUTF8(pname,-1,tsonid,0);
+			service->m_provider_name = replace_all(replace_all(convertDVBUTF8(pname,-1,tsonid,0), "\r", ""), "\n", "");
 		}
 
 		if (!(m_flags & scanOnlyFree) || !m_pmt_in_progress->second.scrambled) {
@@ -1539,10 +1539,10 @@ RESULT eDVBScan::processSDT(eDVBNamespace dvbnamespace, const ServiceDescription
 
 					ref.setServiceType(servicetype);
 					int tsonid=(sdt.getTransportStreamId() << 16) | sdt.getOriginalNetworkId();
-					service->m_service_name = convertDVBUTF8(d.getServiceName(),-1,tsonid,0);
+					service->m_service_name = replace_all(replace_all(convertDVBUTF8(d.getServiceName(),-1,tsonid,0), "\r", ""), "\n", "");
 					service->genSortName();
 
-					service->m_provider_name = convertDVBUTF8(d.getServiceProviderName(),-1,tsonid,0);
+					service->m_provider_name = replace_all(replace_all(convertDVBUTF8(d.getServiceProviderName(),-1,tsonid,0), "\r", ""), "\n", "");
 					SCAN_eDebug("[eDVBScan]   name '%s', provider_name '%s'", service->m_service_name.c_str(), service->m_provider_name.c_str());
 					break;
 				}

--- a/lib/dvb/scan.cpp
+++ b/lib/dvb/scan.cpp
@@ -1104,9 +1104,9 @@ void eDVBScan::channelDone()
 			if( m_chid_current )
 				tsonid = ( m_chid_current.transport_stream_id.get() << 16 )
 					| m_chid_current.original_network_id.get();
-			service->m_service_name = replace_all(replace_all(convertDVBUTF8(sname,-1,tsonid,0), "\r", ""), "\n", "");
+			service->m_service_name = strip_non_graph(convertDVBUTF8(sname,-1,tsonid,0));
 			service->genSortName();
-			service->m_provider_name = replace_all(replace_all(convertDVBUTF8(pname,-1,tsonid,0), "\r", ""), "\n", "");
+			service->m_provider_name = strip_non_graph(convertDVBUTF8(pname,-1,tsonid,0));
 		}
 
 		if (!(m_flags & scanOnlyFree) || !m_pmt_in_progress->second.scrambled) {
@@ -1539,10 +1539,10 @@ RESULT eDVBScan::processSDT(eDVBNamespace dvbnamespace, const ServiceDescription
 
 					ref.setServiceType(servicetype);
 					int tsonid=(sdt.getTransportStreamId() << 16) | sdt.getOriginalNetworkId();
-					service->m_service_name = replace_all(replace_all(convertDVBUTF8(d.getServiceName(),-1,tsonid,0), "\r", ""), "\n", "");
+					service->m_service_name = strip_non_graph(convertDVBUTF8(d.getServiceName(),-1,tsonid,0));
 					service->genSortName();
 
-					service->m_provider_name = replace_all(replace_all(convertDVBUTF8(d.getServiceProviderName(),-1,tsonid,0), "\r", ""), "\n", "");
+					service->m_provider_name = strip_non_graph(convertDVBUTF8(d.getServiceProviderName(),-1,tsonid,0));
 					SCAN_eDebug("[eDVBScan]   name '%s', provider_name '%s'", service->m_service_name.c_str(), service->m_provider_name.c_str());
 					break;
 				}


### PR DESCRIPTION
It seems some channels on 5E include CRLF on channel name.

[eDVBScan] SID 27ce: is scrambled!
[eDVBScan]   name 'Viasat History HD
', provider_name 'AMB'
[eDVBScan]   descr<5d>

Resulting in lamedb corruption, since we expect all data in one line.

This commit replaces CRLF with an empty string to fix that issue.