### PR TITLE
Define all variables used to save timer in TimerEntry

### DIFF
--- a/RecordTimer.py
+++ b/RecordTimer.py
@@ -155,10 +155,8 @@ class RecordTimerEntry(timer.TimerEntry, object):
 
 		if serviceref and serviceref.isRecordable():
 			self.service_ref = serviceref
-		else:
-			self.service_ref = ServiceReference(None)
+
 		self.eit = eit
-		self.dontSave = False
 		self.name = name
 		self.description = description
 		self.disabled = disabled
@@ -208,8 +206,6 @@ class RecordTimerEntry(timer.TimerEntry, object):
 		self.change_frontend = False
 		self.InfoBarInstance = Screens.InfoBar.InfoBar.instance
 		self.ts_dialog = None
-		self.log_entries = []
-		self.flags = set()
 		self.resetState()
 
 	def __repr__(self):

--- a/timer.py
+++ b/timer.py
@@ -6,6 +6,7 @@ from time import time, localtime, mktime
 from enigma import eTimer
 
 from Components.config import config
+from ServiceReference import ServiceReference
 from Tools import Directories
 from Tools.XMLTools import stringToXML
 
@@ -19,9 +20,25 @@ class TimerEntry:
 	StateEnded    = 3
 
 	def __init__(self, begin, end):
+		self.dontSave = False
 		self.begin = begin
 		self.prepare_time = 20
 		self.end = end
+		self.service_ref = ServiceReference(None)
+		self.name = ""
+		self.description = ""
+		self.eit = None
+		self.dirname = None
+		self.tags = None
+		self.justplay = False
+		self.always_zap = False
+		self.pipzap = False
+		self.zap_wakeup = "always"
+		self.rename_repeat = True
+		self.conflict_detection = True
+		self.descramble = True
+		self.record_ecm = False
+		self.log_entries = []
 		self.state = 0
 		self.findRunningEvent = True
 		self.findNextEvent = False
@@ -30,8 +47,9 @@ class TimerEntry:
 		#newdate = datetime.datetime(begindate.tm_year, begindate.tm_mon, begindate.tm_mday 0, 0, 0);
 		self.repeatedbegindate = begin
 		self.backoff = 0
-
 		self.disabled = False
+		self.afterEvent = RecordTimer.AFTEREVENT.AUTO
+		self.flags = set()
 
 	def resetState(self):
 		self.state = self.StateWaiting


### PR DESCRIPTION
This fix GSOD in plugin EPGRefresh and possibly in other cases when all variables for TimerEntry not are defined.
Looks like before commit https://github.com/OpenPLi/enigma2/commit/4565097de4205fea0efca43a3ead1206dfc65b76 EPGRefresh timers not saved in file.
I hope if in the plugin are introduced timers then they need to be saved in file.