### PR TITLE
enigma2: control debug level using tmp file

### DIFF
--- a/tools/enigma2.sh.in
+++ b/tools/enigma2.sh.in
@@ -24,6 +24,11 @@ if [ -d /home/root ]; then
 	cd
 fi
 
+# debug file exists?
+if [ -s /tmp/enigma_debug_lvl ]; then
+	source /tmp/enigma_debug_lvl
+fi
+
 # any debuglevel passed?
 if [ -z $ENIGMA_DEBUG_LVL ]; then
 	DEBUG_LVL=3
@@ -33,91 +38,86 @@ fi
 
 LIBS=@libdir@/libopen.so.0.0.0
 
-# enigma main loop
-while : ; do
-
-	# start enigma
-	sync
-	if [ $ENIGMA_DEBUG_LVL -lt 4 ]; then
-		LD_PRELOAD=$LIBS ENIGMA_DEBUG_LVL=$DEBUG_LVL @bindir@/enigma2
-	else
-		LD_PRELOAD=$LIBS ENIGMA_DEBUG_LVL=$DEBUG_LVL @bindir@/enigma2 > /home/root/enigma.log 2&>1
-	fi
+# start enigma
+sync
+if [ $ENIGMA_DEBUG_LVL -lt 4 ]; then
+	LD_PRELOAD=$LIBS ENIGMA_DEBUG_LVL=$DEBUG_LVL @bindir@/enigma2
+else
+	LD_PRELOAD=$LIBS ENIGMA_DEBUG_LVL=$DEBUG_LVL @bindir@/enigma2 > /home/root/enigma.log 2&>1
+fi
 
 
-	# enigma2 exit codes:
-	#
-	#  1 - halt
-	#  2 - reboot
-	#  3 - restart enigma in normal mode
-	#  4 - front processor upgrade
-	#  5 - install new settings
-	#  6 - restart enigma in debug mode
-	# 42 - offline update
-	# 43 - restart for autoinstall
-	#
-	# >128 signal
+# enigma2 exit codes:
+#
+#  1 - halt
+#  2 - reboot
+#  3 - restart enigma in normal mode
+#  4 - front processor upgrade
+#  5 - install new settings
+#  6 - restart enigma in debug mode
+# 42 - offline update
+# 43 - restart for autoinstall
+#
+# >128 signal
 
-	ret=$?
-	case $ret in
-		1)
-			/sbin/halt
-			;;
-		2)
-			/sbin/reboot
-			;;
-		3)
-			DEBUG_LVL=3
-			;;
-		4)
-			/sbin/rmmod lcd
-			/usr/sbin/fpupgrade --upgrade 2>&1 | tee /home/root/fpupgrade.log
-			sleep 1;
-			/sbin/rmmod fp
-			/sbin/modprobe fp
-			/sbin/reboot
-			;;
-		5)
-			if ! grep -q config.misc.RestartUI /etc/enigma2/settings; then
-				echo "config.misc.RestartUI=true" >>/etc/enigma2/settings
-			fi
-			;;
-		6)
-			DEBUG_LVL=4
-			;;
-		42)
-			df -P | grep -v "tmpfs " | awk '{print $6}' | tail -n +3 > /tmp/upgrade_mountpoints.txt
-			while read line; do
-				if [  -f $line/var/lib/opkg/status ]; then
-				DESTS=$DESTS" --add-dest "$line":"$line
-			fi
-			done < /tmp/upgrade_mountpoints.txt
-			# bind the console (when available)
-			[ -f /sys/class/vtconsole/vtcon1/bind ] && echo 1 > /sys/class/vtconsole/vtcon1/bind
-			( opkg upgrade sysvinit && opkg upgrade sysvinit-pidof && opkg upgrade initscripts-functions && opkg upgrade busybox && opkg upgrade kmod && opkg list-upgradable $DESTS | cut -f 1 -d ' ' | xargs opkg upgrade $DESTS ) 2>&1 | tee /home/root/ipkgupgrade.log
-			/sbin/reboot
-			;;
-		43)
-			#auto install and autobackup
-			[ -f /sys/class/vtconsole/vtcon1/bind ] && echo 1 > /sys/class/vtconsole/vtcon1/bind
-			/etc/init.d/settings-restore.sh
-			/etc/init.d/avahi-daemon stop
-			ifdown eth1
-			ip addr flush dev eth1 scope global
-			ifdown eth0
-			ip addr flush dev eth0 scope global
-			/etc/init.d/networking stop
-			killall -9 udhcpc
-			rm /var/run/udhcpc*
-			/etc/init.d/dbus-1 reload
-			/etc/init.d/networking start
-			/etc/init.d/avahi-daemon start
-			touch /etc/.doAutoinstall
-			break
-			;;
-		*)
-			break
-			;;
-	esac
-
-done
+ret=$?
+case $ret in
+	1)
+		/sbin/halt
+		;;
+	2)
+		/sbin/reboot
+		;;
+	3)
+		echo ENIGMA_DEBUG_LVL=3 > /tmp/enigma_debug_lvl
+		;;
+	4)
+		/sbin/rmmod lcd
+		/usr/sbin/fpupgrade --upgrade 2>&1 | tee /home/root/fpupgrade.log
+		sleep 1;
+		/sbin/rmmod fp
+		/sbin/modprobe fp
+		/sbin/reboot
+		;;
+	5)
+		if ! grep -q config.misc.RestartUI /etc/enigma2/settings; then
+			echo "config.misc.RestartUI=true" >>/etc/enigma2/settings
+		fi
+		;;
+	6)
+		echo ENIGMA_DEBUG_LVL=4 > /tmp/enigma_debug_lvl
+		;;
+	42)
+		df -P | grep -v "tmpfs " | awk '{print $6}' | tail -n +3 > /tmp/upgrade_mountpoints.txt
+		while read line; do
+			if [  -f $line/var/lib/opkg/status ]; then
+			DESTS=$DESTS" --add-dest "$line":"$line
+		fi
+		done < /tmp/upgrade_mountpoints.txt
+		# bind the console (when available)
+		[ -f /sys/class/vtconsole/vtcon1/bind ] && echo 1 > /sys/class/vtconsole/vtcon1/bind
+		( opkg upgrade sysvinit && opkg upgrade sysvinit-pidof && opkg upgrade initscripts-functions && opkg upgrade busybox && opkg upgrade kmod && opkg list-upgradable $DESTS | cut -f 1 -d ' ' | xargs opkg upgrade $DESTS ) 2>&1 | tee /home/root/ipkgupgrade.log
+		/sbin/reboot
+		;;
+	43)
+		#auto install and autobackup
+		[ -f /sys/class/vtconsole/vtcon1/bind ] && echo 1 > /sys/class/vtconsole/vtcon1/bind
+		/etc/init.d/settings-restore.sh
+		/etc/init.d/avahi-daemon stop
+		ifdown eth1
+		ip addr flush dev eth1 scope global
+		ifdown eth0
+		ip addr flush dev eth0 scope global
+		/etc/init.d/networking stop
+		killall -9 udhcpc
+		rm /var/run/udhcpc*
+		/etc/init.d/dbus-1 reload
+		/etc/init.d/networking start
+		/etc/init.d/avahi-daemon start
+		touch /etc/.doAutoinstall
+		break
+		;;
+	*)
+		break
+		;;
+esac


### PR DESCRIPTION
Store next debug level on /tmp/enigma_debug_lvl and once gui is respawn "source" the file to get the ENIGMA_DEBUG_LVL.

This makes enigma2 main loop in script not required any more. The inittab will handle the respawn of gui as we used to.