### PR TITLE
pmtparse: sanitize access to audio vector

### DIFF
--- a/lib/dvb/pmtparse.cpp
+++ b/lib/dvb/pmtparse.cpp
@@ -609,6 +609,13 @@ RESULT eDVBPMTParser::eStreamData::getCaIds(std::vector<int> &caids, std::vector
 
 RESULT eDVBPMTParser::eStreamData::getDefaultAudioPid(int &result) const
 {
-	result = audioStreams[defaultAudioPid];
+	if (audioStreams.size() > defaultAudioPid)
+	{
+		result = audioStreams[defaultAudioPid];
+	}
+	else
+	{
+		result = -1;
+	}
 	return 0;
 }


### PR DESCRIPTION
In commit 2884f3bb it is possible to access an empty audio vector, resulting in "Segmentation fault".

This commit checks if defaultAudioPid index is within the vector bounds. When out of bounds value -1 is returned.