### PR TITLE
keymap.xml - changes in virtualkeyboard shortcuts for edit text

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -77,12 +77,12 @@
 		<key id="KEY_EXIT" mapto="cancel" flags="m" />
 		<key id="KEY_OK" mapto="select" flags="m" />
 		<key id="KEY_UP" mapto="up" flags="mr" />
-		<key id="KEY_PREVIOUS" mapto="first" flags="m" />
-		<key id="KEY_REWIND" mapto="prev" flags="mr" />
+		<key id="KEY_PREVIOUS" mapto="backspace" flags="m" />
+		<key id="KEY_REWIND" mapto="first" flags="mr" />
 		<key id="KEY_LEFT" mapto="left" flags="mr" />
 		<key id="KEY_RIGHT" mapto="right" flags="mr" />
-		<key id="KEY_FASTFORWARD" mapto="next" flags="mr" />
-		<key id="KEY_NEXT" mapto="last" flags="m" />
+		<key id="KEY_FASTFORWARD" mapto="last" flags="mr" />
+		<key id="KEY_NEXT" mapto="delete" flags="m" />
 		<key id="KEY_DOWN" mapto="down" flags="mr" />
 		<key id="KEY_LAST" mapto="backspace" flags="mr" />
 		<key id="KEY_STOP" mapto="backspace" flags="mr" />
@@ -126,6 +126,8 @@
 		<key id="KEY_KP7" mapto="7" flags="m" />
 		<key id="KEY_KP8" mapto="8" flags="m" />
 		<key id="KEY_KP9" mapto="9" flags="m" />
+		<key id="KEY_CHANNELUP" mapto="next" flags="mr"/>
+		<key id="KEY_CHANNELDOWN" mapto="prev" flags="mr"/>
 	</map>
 
 	<map context="InputActions">


### PR DESCRIPTION
PREV/NEXT keys used again as backspace/delete - same as used in NumericalTextInput
CH+/CH- keys used again as cursor one position right/left
rewind/forward keys used as home/end