### PR TITLE
Add t2-mi plp_id scan option for e2

### DIFF
--- a/lib/dvb/db.cpp
+++ b/lib/dvb/db.cpp
@@ -467,11 +467,12 @@ static ePtr<eDVBFrontendParameters> parseFrontendData(char* line, int version)
 				pilot=eDVBFrontendParametersSatellite::Pilot_Unknown,
 				is_id = eDVBFrontendParametersSatellite::No_Stream_Id_Filter,
 				pls_code = eDVBFrontendParametersSatellite::PLS_Default_Gold_Code,
-				pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
-			sscanf(line+2, "%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d",
+				pls_mode = eDVBFrontendParametersSatellite::PLS_Gold,
+				t2mi_plp_id = eDVBFrontendParametersSatellite::No_T2MI_PLP_Id;
+			sscanf(line+2, "%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d",
 				&frequency, &symbol_rate, &polarisation, &fec, &orbital_position,
 				&inversion, &flags, &system, &modulation, &rolloff, &pilot,
-				&is_id, &pls_code, &pls_mode);
+				&is_id, &pls_code, &pls_mode, &t2mi_plp_id);
 			sat.frequency = frequency;
 			sat.symbol_rate = symbol_rate;
 			sat.polarisation = polarisation;
@@ -496,6 +497,8 @@ static ePtr<eDVBFrontendParameters> parseFrontendData(char* line, int version)
 				//else ...
 				if (strncmp(options, "MIS/PLS:", 8) == 0)
 					sscanf(options+8, "%d:%d:%d", &is_id, &pls_code, &pls_mode);
+				if (strncmp(options, "T2MI:", 5) == 0)
+					sscanf(options+5, "%d", &t2mi_plp_id);
 				options = next;
 			}
 			sat.is_id = is_id;
@@ -507,6 +510,7 @@ static ePtr<eDVBFrontendParameters> parseFrontendData(char* line, int version)
 				sat.pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
 				sat.pls_code = root2gold(sat.pls_code);
 			}
+			sat.t2mi_plp_id = t2mi_plp_id;
 			feparm->setDVBS(sat);
 			feparm->setFlags(flags);
 			break;
@@ -783,7 +787,7 @@ void eDVBDB::saveServicelist(const char *file)
 		fprintf(g, "eDVB services /5/\n");
 		fprintf(g, "# Transponders: t:dvb_namespace:transport_stream_id:original_network_id,FEPARMS\n");
 		fprintf(g, "#     DVBS  FEPARMS:   s:frequency:symbol_rate:polarisation:fec:orbital_position:inversion:flags\n");
-		fprintf(g, "#     DVBS2 FEPARMS:   s:frequency:symbol_rate:polarisation:fec:orbital_position:inversion:flags:system:modulation:rolloff:pilot[,MIS/PLS:is_id:pls_code:pls_mode]\n");
+		fprintf(g, "#     DVBS2 FEPARMS:   s:frequency:symbol_rate:polarisation:fec:orbital_position:inversion:flags:system:modulation:rolloff:pilot[,MIS/PLS:is_id:pls_code:pls_mode][,T2MI:t2mi_plp_id]\n");
 		fprintf(g, "#     DVBT  FEPARMS:   t:frequency:bandwidth:code_rate_HP:code_rate_LP:modulation:transmission_mode:guard_interval:hierarchy:inversion:flags:system:plp_id\n");
 		fprintf(g, "#     DVBC  FEPARMS:   c:frequency:symbol_rate:inversion:modulation:fec_inner:flags:system\n");
 		fprintf(g, "#     ATSC  FEPARMS:   a:frequency:inversion:modulation:flags:system\n");
@@ -832,6 +836,12 @@ void eDVBDB::saveServicelist(const char *file)
 					fprintf(f, ":%d:%d:%d", sat.is_id, sat.pls_code & 0x3FFFF, sat.pls_mode & 3);
 					if (g)
 						fprintf(g, ",MIS/PLS:%d:%d:%d", sat.is_id, sat.pls_code & 0x3FFFF, sat.pls_mode & 3);
+				}
+				if (static_cast<unsigned int>(sat.t2mi_plp_id) != eDVBFrontendParametersSatellite::No_T2MI_PLP_Id)
+				{
+					fprintf(f, ":%d", sat.t2mi_plp_id);
+					if (g)
+						fprintf(g, ",T2MI:%d", sat.t2mi_plp_id);
 				}
 
 			}
@@ -1315,7 +1325,7 @@ PyObject *eDVBDB::readSatellites(ePyObject sat_list, ePyObject sat_dict, ePyObje
 	}
 
 	int tmp, *dest = NULL,
-		modulation, system, freq, sr, pol, fec, inv, pilot, rolloff, is_id, pls_code, pls_mode, tsid, onid;
+		modulation, system, freq, sr, pol, fec, inv, pilot, rolloff, is_id, pls_code, pls_mode, t2mi_plp_id, tsid, onid;
 	char *end_ptr;
 
 	xmlNode *root_element = xmlDocGetRootElement(doc);
@@ -1382,6 +1392,7 @@ PyObject *eDVBDB::readSatellites(ePyObject sat_list, ePyObject sat_dict, ePyObje
 				is_id = eDVBFrontendParametersSatellite::No_Stream_Id_Filter;
 				pls_code = eDVBFrontendParametersSatellite::PLS_Default_Gold_Code;
 				pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
+				t2mi_plp_id = eDVBFrontendParametersSatellite::No_T2MI_PLP_Id;
 				tsid = -1;
 				onid = -1;
 
@@ -1400,6 +1411,7 @@ PyObject *eDVBDB::readSatellites(ePyObject sat_list, ePyObject sat_dict, ePyObje
 					else if (name == "is_id") dest = &is_id;
 					else if (name == "pls_code") dest = &pls_code;
 					else if (name == "pls_mode") dest = &pls_mode;
+					else if (name == "t2mi_plp_id") dest = &t2mi_plp_id;
 					else if (name == "tsid") dest = &tsid;
 					else if (name == "onid") dest = &onid;
 					else continue;
@@ -1422,7 +1434,7 @@ PyObject *eDVBDB::readSatellites(ePyObject sat_list, ePyObject sat_dict, ePyObje
 						pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
 						pls_code = root2gold(pls_code);
 					}
-					tuple = PyTuple_New(15);
+					tuple = PyTuple_New(16);
 					PyTuple_SET_ITEM(tuple, 0, PyInt_FromLong(0));
 					PyTuple_SET_ITEM(tuple, 1, PyInt_FromLong(freq));
 					PyTuple_SET_ITEM(tuple, 2, PyInt_FromLong(sr));
@@ -1436,8 +1448,9 @@ PyObject *eDVBDB::readSatellites(ePyObject sat_list, ePyObject sat_dict, ePyObje
 					PyTuple_SET_ITEM(tuple, 10, PyInt_FromLong(is_id));
 					PyTuple_SET_ITEM(tuple, 11, PyInt_FromLong(pls_mode & 3));
 					PyTuple_SET_ITEM(tuple, 12, PyInt_FromLong(pls_code & 0x3FFFF));
-					PyTuple_SET_ITEM(tuple, 13, PyInt_FromLong(tsid));
-					PyTuple_SET_ITEM(tuple, 14, PyInt_FromLong(onid));
+					PyTuple_SET_ITEM(tuple, 13, PyInt_FromLong(t2mi_plp_id));
+					PyTuple_SET_ITEM(tuple, 14, PyInt_FromLong(tsid));
+					PyTuple_SET_ITEM(tuple, 15, PyInt_FromLong(onid));
 					PyList_Append(tplist, tuple);
 					Py_DECREF(tuple);
 				}

--- a/lib/dvb/fastscan.cpp
+++ b/lib/dvb/fastscan.cpp
@@ -513,6 +513,7 @@ void eFastScan::parseResult()
 			fesat.is_id = eDVBFrontendParametersSatellite::No_Stream_Id_Filter;
 			fesat.pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
 			fesat.pls_code = eDVBFrontendParametersSatellite::PLS_Default_Gold_Code;
+			fesat.t2mi_plp_id = eDVBFrontendParametersSatellite::No_T2MI_PLP_Id;
 
 			parm->setDVBS(fesat);
 			db->addChannelToList(chid, parm);

--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -92,12 +92,14 @@ void eDVBFrontendParametersSatellite::set(const S2SatelliteDeliverySystemDescrip
 		is_id = descriptor.getInputStreamIdentifier();
 		pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
 		pls_code = descriptor.getScramblingSequenceIndex();
+		t2mi_plp_id = eDVBFrontendParametersSatellite::No_T2MI_PLP_Id;
 	}
 	else // default DVB-S2 physical layer scrambling sequence of index n = 0 is used
 	{
 		is_id = eDVBFrontendParametersSatellite::No_Stream_Id_Filter;
 		pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
 		pls_code = eDVBFrontendParametersSatellite::PLS_Default_Gold_Code;
+		t2mi_plp_id = eDVBFrontendParametersSatellite::No_T2MI_PLP_Id;
 	}
 }
 
@@ -128,9 +130,10 @@ void eDVBFrontendParametersSatellite::set(const SatelliteDeliverySystemDescripto
 	is_id = eDVBFrontendParametersSatellite::No_Stream_Id_Filter;
 	pls_mode = eDVBFrontendParametersSatellite::PLS_Gold;
 	pls_code = eDVBFrontendParametersSatellite::PLS_Default_Gold_Code;
+	t2mi_plp_id = eDVBFrontendParametersSatellite::No_T2MI_PLP_Id;
 	if (system == System_DVB_S2)
 	{
-		eDebug("[eDVBFrontendParametersSatellite] SAT DVB-S2 freq %d, %s, pos %d, sr %d, fec %d, modulation %d, rolloff %d, is_id %d, pls_mode %d, pls_code %d",
+		eDebug("[eDVBFrontendParametersSatellite] SAT DVB-S2 freq %d, %s, pos %d, sr %d, fec %d, modulation %d, rolloff %d, is_id %d, pls_mode %d, pls_code %d, t2mi_plp_id %d",
 			frequency,
 			polarisation ? "hor" : "vert",
 			orbital_position,
@@ -139,7 +142,8 @@ void eDVBFrontendParametersSatellite::set(const SatelliteDeliverySystemDescripto
 			rolloff,
 			is_id,
 			pls_mode,
-			pls_code);
+			pls_code,
+			t2mi_plp_id);
 	}
 	else
 	{
@@ -367,6 +371,8 @@ RESULT eDVBFrontendParameters::calculateDifference(const iDVBFrontendParameters 
 			else if (sat.pls_mode != osat.pls_mode)
 				diff = 1<<27;
 			else if (sat.pls_code != osat.pls_code)
+				diff = 1<<27;
+			else if (sat.t2mi_plp_id != osat.t2mi_plp_id)
 				diff = 1<<27;
 			else if (exact && sat.fec != osat.fec && sat.fec != eDVBFrontendParametersSatellite::FEC_Auto && osat.fec != eDVBFrontendParametersSatellite::FEC_Auto)
 				diff = 1<<27;
@@ -1414,7 +1420,7 @@ void eDVBFrontend::getFrontendStatus(ePtr<iDVBFrontendStatus> &dest)
 void eDVBFrontend::getTransponderData(ePtr<iDVBTransponderData> &dest, bool original)
 {
 	int type = -1;
-	struct dtv_property p[16];
+	struct dtv_property p[18];
 	struct dtv_properties cmdseq;
 	oparm.getSystem(type);
 	cmdseq.props = p;
@@ -1456,6 +1462,7 @@ void eDVBFrontend::getTransponderData(ePtr<iDVBTransponderData> &dest, bool orig
 			p[cmdseq.num++].cmd = DTV_GUARD_INTERVAL;
 			p[cmdseq.num++].cmd = DTV_HIERARCHY;
 			p[cmdseq.num++].cmd = DTV_STREAM_ID;
+			p[cmdseq.num++].cmd = DTV_ISDBT_SB_SEGMENT_IDX; /* FIXME HACK ALERT use unused by enigma2 ISDBT SEGMENT IDX to pass T2MI PLP ID */
 		}
 		else if (type == feATSC)
 		{
@@ -1986,7 +1993,7 @@ void eDVBFrontend::setFrontend(bool recvEvents)
 		if (recvEvents)
 			m_sn->start();
 		feEvent(-1); // flush events
-		struct dtv_property p[17];
+		struct dtv_property p[18];
 		struct dtv_properties cmdseq;
 		cmdseq.props = p;
 		cmdseq.num = 0;
@@ -2076,6 +2083,8 @@ void eDVBFrontend::setFrontend(bool recvEvents)
 				{
 					p[cmdseq.num].cmd = DTV_STREAM_ID, p[cmdseq.num].u.data = parm.is_id | (parm.pls_code << 8) | (parm.pls_mode << 26), cmdseq.num++;
 				}
+				/* FIXME HACK ALERT use unused by enigma2 ISDBT SEGMENT IDX to pass T2MI PLP ID */
+				p[cmdseq.num].cmd = DTV_ISDBT_SB_SEGMENT_IDX, p[cmdseq.num].u.data = (parm.t2mi_plp_id == eDVBFrontendParametersSatellite::No_T2MI_PLP_Id ? 0 : parm.t2mi_plp_id), cmdseq.num++;
 			}
 		}
 		else if (type == iDVBFrontend::feCable)
@@ -2338,7 +2347,7 @@ RESULT eDVBFrontend::prepare_sat(const eDVBFrontendParametersSatellite &feparm, 
 	res = m_sec->prepare(*this, feparm, satfrequency, 1 << m_slotid, tunetimeout);
 	if (!res)
 	{
-		eDebugNoSimulate("[eDVBFrontend%d] prepare_sat System %d Freq %d Pol %d SR %d INV %d FEC %d orbpos %d system %d modulation %d pilot %d, rolloff %d, is_id %d, pls_mode %d, pls_code %d",
+		eDebugNoSimulate("[eDVBFrontend%d] prepare_sat System %d Freq %d Pol %d SR %d INV %d FEC %d orbpos %d system %d modulation %d pilot %d, rolloff %d, is_id %d, pls_mode %d, pls_code %d, t2mi_plp_id %d",
 			m_dvbid,
 			feparm.system,
 			feparm.frequency,
@@ -2353,7 +2362,8 @@ RESULT eDVBFrontend::prepare_sat(const eDVBFrontendParametersSatellite &feparm, 
 			feparm.rolloff,
 			feparm.is_id,
 			feparm.pls_mode,
-			feparm.pls_code);
+			feparm.pls_code,
+			feparm.t2mi_plp_id);
 		if ((unsigned int)satfrequency < fe_info.frequency_min || (unsigned int)satfrequency > fe_info.frequency_max)
 		{
 			eDebugNoSimulate("[eDVBFrontend%d] %d mhz out of tuner range.. dont tune", m_dvbid, satfrequency / 1000);

--- a/lib/dvb/frontendparms.cpp
+++ b/lib/dvb/frontendparms.cpp
@@ -173,6 +173,11 @@ int eDVBTransponderData::getPLSCode() const
 	return -1;
 }
 
+int eDVBTransponderData::getT2MIPlpId() const
+{
+	return -1;
+}
+
 int eDVBTransponderData::getBandwidth() const
 {
 	return -1;
@@ -368,6 +373,16 @@ int eDVBSatelliteTransponderData::getPLSCode() const
 	unsigned int stream_id = getProperty(DTV_STREAM_ID);
 	if (stream_id == NO_STREAM_ID_FILTER) return transponderParameters.pls_code;
 	return (stream_id >> 8) & 0x3FFFF;
+}
+
+int eDVBSatelliteTransponderData::getT2MIPlpId() const
+{
+	if (originalValues) return transponderParameters.t2mi_plp_id;
+
+	/* FIXME HACK ALERT use unused by enigma2 ISDBT SEGMENT IDX to pass T2MI PLP ID */
+	unsigned int t2mi_plp_id = getProperty(DTV_ISDBT_SB_SEGMENT_IDX);
+	if (t2mi_plp_id == eDVBFrontendParametersSatellite::No_T2MI_PLP_Id) return transponderParameters.t2mi_plp_id;
+	return t2mi_plp_id;
 }
 
 DEFINE_REF(eDVBCableTransponderData);

--- a/lib/dvb/frontendparms.h
+++ b/lib/dvb/frontendparms.h
@@ -63,9 +63,13 @@ public:
 		PLS_Default_Gold_Code, PLS_Default_Root_Code
 	};
 
+	enum {
+		No_T2MI_PLP_Id = eDVBFrontendParametersSatellite::No_Stream_Id_Filter
+	};
+
 	bool no_rotor_command_on_tune;
 	unsigned int frequency, symbol_rate;
-	int polarisation, fec, inversion, orbital_position, system, modulation, rolloff, pilot, is_id, pls_mode, pls_code;
+	int polarisation, fec, inversion, orbital_position, system, modulation, rolloff, pilot, is_id, pls_mode, pls_code, t2mi_plp_id;
 };
 SWIG_ALLOW_OUTPUT_SIMPLE(eDVBFrontendParametersSatellite);
 
@@ -223,6 +227,7 @@ public:
 	int getIsId() const;
 	int getPLSMode() const;
 	int getPLSCode() const;
+	int getT2MIPlpId() const;
 	int getBandwidth() const;
 	int getCodeRateLp() const;
 	int getCodeRateHp() const;
@@ -257,6 +262,7 @@ public:
 	int getIsId() const;
 	int getPLSMode() const;
 	int getPLSCode() const;
+	int getT2MIPlpId() const;
 };
 
 class eDVBCableTransponderData : public eDVBTransponderData

--- a/lib/dvb/idvb.h
+++ b/lib/dvb/idvb.h
@@ -496,6 +496,7 @@ public:
 	virtual int getIsId() const = 0;
 	virtual int getPLSMode() const = 0;
 	virtual int getPLSCode() const = 0;
+	virtual int getT2MIPlpId() const = 0;
 	virtual int getBandwidth() const = 0;
 	virtual int getCodeRateLp() const = 0;
 	virtual int getCodeRateHp() const = 0;

--- a/lib/python/Components/ServiceScan.py
+++ b/lib/python/Components/ServiceScan.py
@@ -84,6 +84,8 @@ class ServiceScan:
 								tp_text = ("%s MIS %d") % (tp_text, tp.is_id)
 							if tp.pls_code > 0:
 								tp_text = ("%s Gold %d") % (tp_text, tp.pls_code)
+						if tp.t2mi_plp_id > tp.No_T2MI_PLP_Id and tp.system == tp.System_DVB_S2:
+							tp_text = ("%s T2MI %d") % (tp_text, tp.t2mi_plp_id)
 					elif tp_type == iDVBFrontend.feCable:
 						network = _("Cable")
 						tp = transponder.getDVBC()

--- a/lib/python/Components/TuneTest.py
+++ b/lib/python/Components/TuneTest.py
@@ -5,7 +5,7 @@ class Tuner:
 		self.frontend = frontend
 		self.ignore_rotor = ignore_rotor
 
-	# transponder = (0:frequency 1:symbolrate 2:polarisation 3:fec 4:inversion 5:orbpos 6:system 7:modulation 8:rolloff 9:pilot 10:is_id 11:pls_mode 12:pls_code 13:tsid 14:onid)
+	# transponder = (0:frequency 1:symbolrate 2:polarisation 3:fec 4:inversion 5:orbpos 6:system 7:modulation 8:rolloff 9:pilot 10:is_id 11:pls_mode 12:pls_code 13:t2mi_plp_id 14:tsid 15:onid)
 	def tune(self, transponder):
 		if self.frontend:
 			print "[TuneTest] tuning to transponder with data", transponder
@@ -28,6 +28,10 @@ class Tuner:
 				parm.is_id = eDVBFrontendParametersSatellite.No_Stream_Id_Filter
 				parm.pls_mode = eDVBFrontendParametersSatellite.PLS_Gold
 				parm.pls_code = eDVBFrontendParametersSatellite.PLS_Default_Gold_Code
+			if len(transponder) > 13:
+				parm.t2mi_plp_id = transponder[13]
+			else:
+				parm.t2mi_plp_id = eDVBFrontendParametersSatellite.No_T2MI_PLP_Id
 			self.tuneSatObj(parm)
 
 	def tuneSatObj(self, transponderObj):
@@ -182,8 +186,8 @@ class TuneTest:
 				pidsFailed = False
 				if self.checkPIDs:
 					if self.currTuned is not None:
-						if self.tsid != self.currTuned[13] or self.onid != self.currTuned[14]:
-							self.failedTune.append([self.currTuned, self.oldTuned, "pids_failed", {"real": (self.tsid, self.onid), "expected": (self.currTuned[13], self.currTuned[14])}, dict])  # last parameter is the frontend status
+						if self.tsid != self.currTuned[14] or self.onid != self.currTuned[15]:
+							self.failedTune.append([self.currTuned, self.oldTuned, "pids_failed", {"real": (self.tsid, self.onid), "expected": (self.currTuned[14], self.currTuned[15])}, dict])  # last parameter is the frontend status
 							pidsFailed = True
 						else:
 							self.successfullyTune.append([self.currTuned, self.oldTuned, dict])  # 3rd parameter is the frontend status
@@ -220,7 +224,7 @@ class TuneTest:
 			# check for tsid != -1 and onid != -1
 			print "index:", index
 			print "len(self.transponderlist):", len(self.transponderlist)
-			while (index < len(self.transponderlist) and (self.transponderlist[index][13] == -1 or self.transponderlist[index][14] == -1)):
+			while (index < len(self.transponderlist) and (self.transponderlist[index][14] == -1 or self.transponderlist[index][15] == -1)):
 			 	index += 1
 		print "FirstTransponder final index:", index
 		return index
@@ -233,7 +237,7 @@ class TuneTest:
 			# check for tsid != -1 and onid != -1
 			print "index:", index
 			print "len(self.transponderlist):", len(self.transponderlist)
-			while (index < len(self.transponderlist) and (self.transponderlist[index][13] == -1 or self.transponderlist[index][14] == -1)):
+			while (index < len(self.transponderlist) and (self.transponderlist[index][14] == -1 or self.transponderlist[index][15] == -1)):
 			 	index += 1
 
 		print "next transponder index:", index
@@ -283,7 +287,7 @@ class TuneTest:
 		self.progressCallback((self.getProgressLength(), self.tuningtransponder, self.STATUS_START, self.currTuned))
 		self.timer.start(100, True)
 
-	# transponder = (0:frequency 1:symbolrate 2:polarisation 3:fec 4:inversion 5:orbpos 6:system 7:modulation 8:rolloff 9:pilot 10:is_id 11:pls_mode 12:pls_code 13:tsid 14:onid)
+	# transponder = (0:frequency 1:symbolrate 2:polarisation 3:fec 4:inversion 5:orbpos 6:system 7:modulation 8:rolloff 9:pilot 10:is_id 11:pls_mode 12:pls_code 13:t2mi_plp_id 14:tsid 15:onid)
 	def addTransponder(self, transponder):
 		self.transponderlist.append(transponder)
 

--- a/lib/python/Plugins/SystemPlugins/DiseqcTester/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/DiseqcTester/plugin.py
@@ -227,7 +227,7 @@ class DiseqcTester(Screen, TuneTest, ResultParser):
 	def readTransponderList(self):
 		for sat in nimmanager.getSatListForNim(self.feid):
 			for transponder in nimmanager.getTransponders(sat[0], self.feid):
-				mytransponder = (transponder[1] / 1000, transponder[2] / 1000, transponder[3], transponder[4], transponder[7], sat[0], transponder[5], transponder[6], transponder[8], transponder[9], transponder[10], transponder[11], transponder[12], transponder[13], transponder[14])
+				mytransponder = (transponder[1] / 1000, transponder[2] / 1000, transponder[3], transponder[4], transponder[7], sat[0], transponder[5], transponder[6], transponder[8], transponder[9], transponder[10], transponder[11], transponder[12], transponder[13], transponder[14], transponder[15])
 				self.analyseTransponder(mytransponder)
 
 	def getIndexForTransponder(self, transponder):

--- a/lib/python/Plugins/SystemPlugins/FastScan/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/FastScan/plugin.py
@@ -250,6 +250,7 @@ class FastScanScreen(ConfigListScreen, Screen):
 		transponderParameters.is_id = eDVBFrontendParametersSatellite.No_Stream_Id_Filter
 		transponderParameters.pls_mode = eDVBFrontendParametersSatellite.PLS_Gold
 		transponderParameters.pls_code = eDVBFrontendParametersSatellite.PLS_Default_Gold_Code
+		transponderParameters.t2mi_plp_id = eDVBFrontendParametersSatellite.No_T2MI_PLP_Id
 		return transponderParameters
 
 	def startScan(self):

--- a/lib/python/Plugins/SystemPlugins/PositionerSetup/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/PositionerSetup/plugin.py
@@ -164,7 +164,8 @@ class PositionerSetup(Screen):
 			cur.get("pilot", eDVBFrontendParametersSatellite.Pilot_Unknown),
 			cur.get("is_id", 0),
 			cur.get("pls_mode", eDVBFrontendParametersSatellite.PLS_Gold),
-			cur.get("pls_code", eDVBFrontendParametersSatellite.PLS_Default_Gold_Code))
+			cur.get("pls_code", eDVBFrontendParametersSatellite.PLS_Default_Gold_Code),
+			cur.get("t2mi_plp_id", eDVBFrontendParametersSatellite.No_T2MI_PLP_Id))
 
 		self.tuner.tune(tp)
 		self.isMoving = False
@@ -1308,6 +1309,7 @@ class TunerScreen(ConfigListScreen, Screen):
 		self.tuning.sat.addNotifier(self.tuningSatChanged)
 		self.tuning.type.addNotifier(self.tuningTypeChanged)
 		self.scan_sat.system.addNotifier(self.systemChanged)
+		self.scan_sat.t2mi.addNotifier(self.t2miChanged)
 
 		self["actions"] = NumberActionMap(["SetupActions"],
 		{
@@ -1343,7 +1345,9 @@ class TunerScreen(ConfigListScreen, Screen):
 			"fec_s2": eDVBFrontendParametersSatellite.FEC_9_10,
 			"modulation": eDVBFrontendParametersSatellite.Modulation_QPSK,
 			"pls_mode": eDVBFrontendParametersSatellite.PLS_Gold,
-			"pls_code": eDVBFrontendParametersSatellite.PLS_Default_Gold_Code }
+			"pls_code": eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
+			"t2mi_plp_id":eDVBFrontendParametersSatellite.No_T2MI_PLP_Id }
+
 		if frontendData is not None:
 			ttype = frontendData.get("tuner_type", "UNKNOWN")
 			defaultSat["system"] = frontendData.get("system", eDVBFrontendParametersSatellite.System_DVB_S)
@@ -1358,6 +1362,7 @@ class TunerScreen(ConfigListScreen, Screen):
 				defaultSat["is_id"] = frontendData.get("is_id", 0)
 				defaultSat["pls_mode"] = frontendData.get("pls_mode", eDVBFrontendParametersSatellite.PLS_Gold)
 				defaultSat["pls_code"] = frontendData.get("pls_code", eDVBFrontendParametersSatellite.PLS_Default_Gold_Code)
+				defaultSat["t2mi_plp_id"] = frontendData.get("t2mi_plp_id", eDVBFrontendParametersSatellite.No_T2MI_PLP_Id)
 			else:
 				defaultSat["fec"] = frontendData.get("fec_inner", eDVBFrontendParametersSatellite.FEC_Auto)
 			defaultSat["modulation"] = frontendData.get("modulation", eDVBFrontendParametersSatellite.Modulation_QPSK)
@@ -1416,6 +1421,16 @@ class TunerScreen(ConfigListScreen, Screen):
 			(eDVBFrontendParametersSatellite.PLS_Gold, _("Gold")),
 			(eDVBFrontendParametersSatellite.PLS_Combo, _("Combo"))])
 		self.scan_sat.pls_code = ConfigInteger(default = defaultSat.get("pls_code", eDVBFrontendParametersSatellite.PLS_Default_Gold_Code), limits = (0, 262142))
+		if defaultSat.get("t2mi_plp_id",eDVBFrontendParametersSatellite.No_T2MI_PLP_Id) != eDVBFrontendParametersSatellite.No_T2MI_PLP_Id and defaultSat.get("t2mi_plp_id",eDVBFrontendParametersSatellite.No_T2MI_PLP_Id) != 0:
+			self.scan_sat.t2mi  = ConfigSelection(default = "on", choices = [("on", _("On")),("off", _("Off"))])
+			self.scan_sat.t2mi_pid = ConfigInteger(default = (defaultSat.get("t2mi_plp_id",eDVBFrontendParametersSatellite.No_T2MI_PLP_Id)>>16)&0x1fff, limits = (0, 8192))
+			self.scan_sat.t2mi_plp = ConfigInteger(default = (defaultSat.get("t2mi_plp_id",eDVBFrontendParametersSatellite.No_T2MI_PLP_Id))&0xff, limits = (0, 255))
+		else:
+			self.scan_sat.t2mi  = ConfigSelection(default = "off", choices = [("on", _("On")),("off", _("Off"))])
+			self.scan_sat.t2mi_pid = ConfigInteger(default = 0, limits = (0, 8192))
+			self.scan_sat.t2mi_plp = ConfigInteger(default = 0, limits = (0, 255))
+		self.t2mi_pid_memory = self.scan_sat.t2mi_pid.value
+		self.t2mi_plp_memory = self.scan_sat.t2mi_plp.value
 
 	def initialSetup(self):
 		currtp = self.transponderToString([None, self.scan_sat.frequency.value, self.scan_sat.symbolrate.value, self.scan_sat.polarization.value])
@@ -1429,6 +1444,8 @@ class TunerScreen(ConfigListScreen, Screen):
 		self.list.append(getConfigListEntry(_('Tune'), self.tuning.type))
 		self.list.append(getConfigListEntry(_('Satellite'), self.tuning.sat))
 		nim = nimmanager.nim_slots[self.feid]
+
+		self.t2mi_Entry = None
 
 		if self.tuning.type.value == "manual_transponder":
 			if nim.isCompatible("DVB-S2"):
@@ -1453,6 +1470,11 @@ class TunerScreen(ConfigListScreen, Screen):
 					self.list.append(getConfigListEntry(_('Input Stream ID'), self.scan_sat.is_id))
 					self.list.append(getConfigListEntry(_('PLS Mode'), self.scan_sat.pls_mode))
 					self.list.append(getConfigListEntry(_('PLS Code'), self.scan_sat.pls_code))
+				self.t2mi_Entry = getConfigListEntry(_('T2MI'), self.scan_sat.t2mi)
+				self.list.append(self.t2mi_Entry)
+				if self.scan_sat.t2mi.value == "on":
+					self.list.append(getConfigListEntry( _('T2MI PID'), self.scan_sat.t2mi_pid))
+					self.list.append(getConfigListEntry( _('T2MI PLP ID'), self.scan_sat.t2mi_plp))
 		else: # "predefined_transponder"
 			self.list.append(getConfigListEntry(_("Transponder"), self.tuning.transponder))
 			currtp = self.transponderToString([None, self.scan_sat.frequency.value, self.scan_sat.symbolrate.value, self.scan_sat.polarization.value])
@@ -1468,6 +1490,19 @@ class TunerScreen(ConfigListScreen, Screen):
 		self.createSetup()
 
 	def systemChanged(self, *parm):
+		self.createSetup()
+
+	def t2miChanged(self, *parm):
+		if self.scan_sat.t2mi.value == "on":
+			if self.t2mi_pid_memory == 0:
+				self.t2mi_pid_memory = 4096;
+			self.scan_sat.t2mi_pid.value = self.t2mi_pid_memory
+			self.scan_sat.t2mi_plp.value = self.t2mi_plp_memory
+		else:
+			self.t2mi_pid_memory = self.scan_sat.t2mi_pid.value
+			self.t2mi_plp_memory = self.scan_sat.t2mi_plp.value
+			self.scan_sat.t2mi_pid.value = 0
+			self.scan_sat.t2mi_plp.value = 0
 		self.createSetup()
 
 	def transponderToString(self, tr, scale = 1):
@@ -1498,13 +1533,18 @@ class TunerScreen(ConfigListScreen, Screen):
 		ConfigListScreen.keyRight(self)
 
 	def keyGo(self):
-		returnvalue = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 1)
+		returnvalue = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 1, -1)
 		satpos = int(self.tuning.sat.value)
 		if self.tuning.type.value == "manual_transponder":
 			if self.scan_sat.system.value == eDVBFrontendParametersSatellite.System_DVB_S2:
 				fec = self.scan_sat.fec_s2.value
 			else:
 				fec = self.scan_sat.fec.value
+
+			if self.scan_sat.t2mi_pid.value > 0 and self.scan_sat.t2mi_plp.value >= 0:
+				t2mi_plp_id = (self.scan_sat.t2mi_pid.value<<16)|self.scan_sat.t2mi_plp.value
+			else:
+				t2mi_plp_id = eDVBFrontendParametersSatellite.No_T2MI_PLP_Id
 			returnvalue = (
 				self.scan_sat.frequency.value,
 				self.scan_sat.symbolrate.value,
@@ -1518,11 +1558,12 @@ class TunerScreen(ConfigListScreen, Screen):
 				self.scan_sat.pilot.value,
 				self.scan_sat.is_id.value,
 				self.scan_sat.pls_mode.value,
-				self.scan_sat.pls_code.value)
+				self.scan_sat.pls_code.value,
+				t2mi_plp_id)
 		elif self.tuning.type.value == "predefined_transponder":
 			transponder = nimmanager.getTransponders(satpos)[self.tuning.transponder.index]
 			returnvalue = (transponder[1] / 1000, transponder[2] / 1000,
-				transponder[3], transponder[4], 2, satpos, transponder[5], transponder[6], transponder[8], transponder[9], transponder[10], transponder[11], transponder[12])
+				transponder[3], transponder[4], 2, satpos, transponder[5], transponder[6], transponder[8], transponder[9], transponder[10], transponder[11], transponder[12], transponder[13])
 		self.close(returnvalue)
 
 	def keyCancel(self):

--- a/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
@@ -119,6 +119,7 @@ class Satfinder(ScanSetup, ServiceScan):
 				self.scan_sat.is_id.value = eDVBFrontendParametersSatellite.No_Stream_Id_Filter
 				self.scan_sat.pls_mode.value = eDVBFrontendParametersSatellite.PLS_Gold
 				self.scan_sat.pls_code.value = eDVBFrontendParametersSatellite.PLS_Default_Gold_Code
+
 			self.createSetup()
 			self.retune()
 
@@ -273,6 +274,8 @@ class Satfinder(ScanSetup, ServiceScan):
 			self.scan_sat.fec_s2, self.scan_sat.fec, self.scan_sat.modulation,
 			self.scan_sat.rolloff,
 			self.scan_sat.is_id, self.scan_sat.pls_mode, self.scan_sat.pls_code,
+			self.scan_sat.t2mi_pid,
+			self.scan_sat.t2mi_plp,
 			self.scan_ter.channel, self.scan_ter.frequency, self.scan_ter.inversion,
 			self.scan_ter.bandwidth, self.scan_ter.fechigh, self.scan_ter.feclow,
 			self.scan_ter.modulation, self.scan_ter.transmission,
@@ -414,6 +417,10 @@ class Satfinder(ScanSetup, ServiceScan):
 				fec = self.scan_sat.fec_s2.value
 			else:
 				fec = self.scan_sat.fec.value
+			if self.scan_sat.t2mi_pid.value > 0 and self.scan_sat.t2mi_plp.value >= 0:
+				t2mi_plp_id = (self.scan_sat.t2mi_pid.value<<16)|self.scan_sat.t2mi_plp.value
+			else:
+				t2mi_plp_id = eDVBFrontendParametersSatellite.No_T2MI_PLP_Id
 			transponder = (
 				self.scan_sat.frequency.value,
 				self.scan_sat.symbolrate.value,
@@ -427,7 +434,9 @@ class Satfinder(ScanSetup, ServiceScan):
 				self.scan_sat.pilot.value,
 				self.scan_sat.is_id.value,
 				self.scan_sat.pls_mode.value,
-				self.scan_sat.pls_code.value)
+				self.scan_sat.pls_code.value,
+				t2mi_plp_id)
+
 			if self.initcomplete:
 				self.tuner.tune(transponder)
 			self.transponder = transponder
@@ -436,7 +445,7 @@ class Satfinder(ScanSetup, ServiceScan):
 			if len(tps) > self.preDefTransponders.index:
 				tp = tps[self.preDefTransponders.index]
 				transponder = (tp[1] / 1000, tp[2] / 1000,
-					tp[3], tp[4], 2, satpos, tp[5], tp[6], tp[8], tp[9], tp[10], tp[11], tp[12])
+					tp[3], tp[4], 2, satpos, tp[5], tp[6], tp[8], tp[9], tp[10], tp[11], tp[12], tp[13])
 				if self.initcomplete:
 					self.tuner.tune(transponder)
 				self.transponder = transponder
@@ -470,7 +479,8 @@ class Satfinder(ScanSetup, ServiceScan):
 				self.transponder[9], # pilot
 				self.transponder[10],# input stream id
 				self.transponder[11],# pls mode
-				self.transponder[12] # pls code
+				self.transponder[12], # pls code
+				self.transponder[13] # t2mi_plp_id
 			)
 		elif self.DVB_type.value == "DVB-T":
 			parm = buildTerTransponder(

--- a/lib/python/Screens/AutoDiseqc.py
+++ b/lib/python/Screens/AutoDiseqc.py
@@ -39,6 +39,7 @@ class AutoDiseqc(Screen, ConfigListScreen):
 			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
 			eDVBFrontendParametersSatellite.PLS_Gold,
 			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
+			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
 			1079,
 			1,
 			"Astra 1 19.2e"),
@@ -58,6 +59,7 @@ class AutoDiseqc(Screen, ConfigListScreen):
 			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
 			eDVBFrontendParametersSatellite.PLS_Gold,
 			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
+			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
 			3224,
 			3,
 			"Astra 3 23.5e"),
@@ -77,6 +79,7 @@ class AutoDiseqc(Screen, ConfigListScreen):
 			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
 			eDVBFrontendParametersSatellite.PLS_Gold,
 			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
+			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
 			2004,
 			2,
 			"Astra 2 28.2e"),
@@ -96,6 +99,7 @@ class AutoDiseqc(Screen, ConfigListScreen):
 			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
 			eDVBFrontendParametersSatellite.PLS_Gold,
 			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
+			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
 			12400,
 			318,
 			"Hotbird 13.0e"),
@@ -115,6 +119,7 @@ class AutoDiseqc(Screen, ConfigListScreen):
 			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
 			eDVBFrontendParametersSatellite.PLS_Gold,
 			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
+			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
  			20100,
  			366,
  			"Eutelsat 16A 16.0e"),
@@ -134,6 +139,7 @@ class AutoDiseqc(Screen, ConfigListScreen):
 			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
 			eDVBFrontendParametersSatellite.PLS_Gold,
 			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
+			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
 			706,
 			1536,
 			"Thor 5/6/7 0.8w"),
@@ -153,6 +159,7 @@ class AutoDiseqc(Screen, ConfigListScreen):
 			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
 			eDVBFrontendParametersSatellite.PLS_Gold,
 			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
+			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
 			1388,
 			1388,
 			"Hispasat 30.0w"),
@@ -171,9 +178,10 @@ class AutoDiseqc(Screen, ConfigListScreen):
 	SAT_TABLE_IS_ID = 10
 	SAT_TABLE_PLS_MODE = 11
 	SAT_TABLE_PLS_CODE = 12
-	SAT_TABLE_TSID = 13
-	SAT_TABLE_ONID = 14
-	SAT_TABLE_NAME = 15
+	SAT_TABLE_T2MI_PLP_ID = 13
+	SAT_TABLE_TSID = 14
+	SAT_TABLE_ONID = 15
+	SAT_TABLE_NAME = 16
 
 	def __init__(self, session, feid, nr_of_ports, simple_tone, simple_sat_change):
 		self.skin = AutoDiseqc.skin

--- a/lib/python/Screens/ScanSetup.py
+++ b/lib/python/Screens/ScanSetup.py
@@ -50,6 +50,7 @@ def getInitialTransponderList(tlist, pos, feid = None):
 			parm.is_id = x[10]
 			parm.pls_mode = x[11]
 			parm.pls_code = x[12]
+			parm.t2mi_plp_id = x[13]
 			tlist.append(parm)
 
 def getInitialCableTransponderList(tlist, nim):
@@ -670,7 +671,7 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 		self.TerrestrialTransponders = None
 		self.TerrestrialRegionEntry = None
 		self.TerrestrialCompleteEntry = None
-		self.is_id_boolEntry = None
+		self.typeEntry = None
 		nim = nimmanager.nim_slots[index_to_scan]
 		if self.DVB_type.value == "DVB-S":
 			self.typeOfScanEntry = getConfigListEntry(_("Type of scan"), self.scan_type)
@@ -719,9 +720,9 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 					self.list.append(getConfigListEntry(_('Roll-off'), self.scan_sat.rolloff))
 					self.list.append(getConfigListEntry(_('Pilot'), self.scan_sat.pilot))
 					if nim.isMultistream():
-						self.is_id_boolEntry = getConfigListEntry(_('Transport Stream Type'), self.scan_sat.is_id_bool)
-						self.list.append(self.is_id_boolEntry)
-						if self.scan_sat.is_id_bool.value:
+						self.typeEntry = getConfigListEntry(_('Transport Stream Type'), self.scan_sat.type)
+						self.list.append(self.typeEntry)
+						if self.scan_sat.type.value == "multistream":
 							self.list.append(getConfigListEntry(_('Input Stream ID'), self.scan_sat.is_id))
 							self.list.append(getConfigListEntry(_('PLS Mode'), self.scan_sat.pls_mode))
 							self.list.append(getConfigListEntry(_('PLS Code'), self.scan_sat.pls_code))
@@ -729,6 +730,9 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 						self.scan_sat.is_id.value = eDVBFrontendParametersSatellite.No_Stream_Id_Filter
 						self.scan_sat.pls_mode.value = eDVBFrontendParametersSatellite.PLS_Gold
 						self.scan_sat.pls_code.value = eDVBFrontendParametersSatellite.PLS_Default_Gold_Code
+					if self.scan_sat.type.value == "t2mi":
+						self.list.append(getConfigListEntry( _('T2MI PID'), self.scan_sat.t2mi_pid))
+						self.list.append(getConfigListEntry( _('T2MI PLP ID'), self.scan_sat.t2mi_plp))
 			elif self.scan_type.value == "predefined_transponder" and self.satList[index_to_scan]:
 				self.updateSatList()
 				self.preDefSatList = getConfigListEntry(_('Satellite'), self.scan_satselection[index_to_scan])
@@ -855,8 +859,8 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 			cur == self.TerrestrialCompleteEntry or \
 			(self.modulationEntry and self.systemEntry[1].value == eDVBFrontendParametersSatellite.System_DVB_S2 and cur == self.modulationEntry):
 			self.createSetup()
-		elif cur == self.is_id_boolEntry:
-			if self.is_id_boolEntry[1].value:
+		elif cur == self.typeEntry:
+			if self.scan_sat.type.value == "multistream":
 				self.scan_sat.is_id.value = 0 if self.is_id_memory < 0 else self.is_id_memory
 				self.scan_sat.pls_mode.value = self.pls_mode_memory
 				self.scan_sat.pls_code.value = self.pls_code_memory
@@ -867,6 +871,17 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 				self.scan_sat.is_id.value = eDVBFrontendParametersSatellite.No_Stream_Id_Filter
 				self.scan_sat.pls_mode.value = eDVBFrontendParametersSatellite.PLS_Gold
 				self.scan_sat.pls_code.value = eDVBFrontendParametersSatellite.PLS_Default_Gold_Code
+			self.createSetup()
+			if self.scan_sat.type.value == "t2mi":
+				if self.t2mi_pid_memory == 0:
+					self.t2mi_pid_memory = 4096;
+				self.scan_sat.t2mi_pid.value = self.t2mi_pid_memory
+				self.scan_sat.t2mi_plp.value = self.t2mi_plp_memory
+			else:
+				self.t2mi_pid_memory = self.scan_sat.t2mi_pid.value
+				self.t2mi_plp_memory = self.scan_sat.t2mi_plp.value
+				self.scan_sat.t2mi_pid.value = 0
+				self.scan_sat.t2mi_plp.value = 0
 			self.createSetup()
 
 	def createConfig(self, frontendData):
@@ -882,7 +897,9 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 			"modulation": eDVBFrontendParametersSatellite.Modulation_QPSK,
 			"is_id": eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
 			"pls_mode": eDVBFrontendParametersSatellite.PLS_Gold,
-			"pls_code": eDVBFrontendParametersSatellite.PLS_Default_Gold_Code }
+			"pls_code": eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
+			"t2mi_plp_id": eDVBFrontendParametersSatellite.No_T2MI_PLP_Id }
+
 		defaultCab = {
 			"frequency": 466000,
 			"inversion": eDVBFrontendParametersCable.Inversion_Unknown,
@@ -924,6 +941,7 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 					defaultSat["is_id"] = frontendData.get("is_id", defaultSat["is_id"])
 					defaultSat["pls_mode"] = frontendData.get("pls_mode", defaultSat["pls_mode"])
 					defaultSat["pls_code"] = frontendData.get("pls_code", defaultSat["pls_code"])
+					defaultSat["t2mi_plp_id"] = frontendData.get("t2mi_plp_id", eDVBFrontendParametersSatellite.No_T2MI_PLP_Id)
 				else:
 					defaultSat["fec"] = frontendData.get("fec_inner", eDVBFrontendParametersSatellite.FEC_Auto)
 				defaultSat["modulation"] = frontendData.get("modulation", eDVBFrontendParametersSatellite.Modulation_QPSK)
@@ -1058,16 +1076,24 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 			(eDVBFrontendParametersSatellite.Pilot_On, _("On")),
 			(eDVBFrontendParametersSatellite.Pilot_Unknown, _("Auto"))])
 		self.scan_sat.is_id = ConfigInteger(default = defaultSat["is_id"], limits = (eDVBFrontendParametersSatellite.No_Stream_Id_Filter, 255))
-		self.scan_sat.is_id_bool = ConfigSelection(default = defaultSat["is_id"] != eDVBFrontendParametersSatellite.No_Stream_Id_Filter, choices = [(True, _("Multistream")),(False, _("Ordinary"))])
+		self.scan_sat.type = ConfigSelection(default = "ordinary", choices = [("multistream", _("Multistream")),("ordinary", _("Ordinary")),("t2mi", _("T2MI"))])
 		self.scan_sat.pls_mode = ConfigSelection(default = defaultSat["pls_mode"], choices = [
 			(eDVBFrontendParametersSatellite.PLS_Root, _("Root")),
 			(eDVBFrontendParametersSatellite.PLS_Gold, _("Gold")),
 			(eDVBFrontendParametersSatellite.PLS_Combo, _("Combo"))])
 		self.scan_sat.pls_code = ConfigInteger(default = defaultSat["pls_code"], limits = (0, 262142))
 		
-		self.is_id_memory = self.scan_sat.is_id.value # used to prevent is_id value being lost when self.scan_sat.is_id_bool state changes
+		self.is_id_memory = self.scan_sat.is_id.value # used to prevent is_id value being lost when self.scan_sat.type state changes
 		self.pls_mode_memory = self.scan_sat.pls_mode.value
 		self.pls_code_memory = self.scan_sat.pls_code.value
+		if defaultSat.get("t2mi_plp_id",eDVBFrontendParametersSatellite.No_T2MI_PLP_Id) != eDVBFrontendParametersSatellite.No_T2MI_PLP_Id and defaultSat.get("t2mi_plp_id",eDVBFrontendParametersSatellite.No_T2MI_PLP_Id) != 0:
+			self.scan_sat.t2mi_pid = ConfigInteger(default = ((defaultSat.get("t2mi_plp_id",eDVBFrontendParametersSatellite.No_T2MI_PLP_Id)>>16)&0x1fff), limits = (0, 8192))
+			self.scan_sat.t2mi_plp = ConfigInteger(default = ((defaultSat.get("t2mi_plp_id",eDVBFrontendParametersSatellite.No_T2MI_PLP_Id))&0xff), limits = (0, 255))
+		else:
+			self.scan_sat.t2mi_pid = ConfigInteger(default = 0, limits = (0, 8192))
+			self.scan_sat.t2mi_plp = ConfigInteger(default = 0, limits = (0, 255))
+		self.t2mi_pid_memory = self.scan_sat.t2mi_pid.value
+		self.t2mi_plp_memory = self.scan_sat.t2mi_plp.value
 
 		# cable
 		self.scan_cab.frequency = ConfigFloat(default = [defaultCab["frequency"] / 1000, defaultCab["frequency"] % 1000], limits = [(50, 999), (0,999)])
@@ -1252,8 +1278,8 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 	def updateStatus(self):
 		print "updatestatus"
 
-	def addSatTransponder(self, tlist, frequency, symbol_rate, polarisation, fec, inversion, orbital_position, system, modulation, rolloff, pilot, is_id, pls_mode, pls_code):
-		print "Add Sat: frequ: " + str(frequency) + " symbol: " + str(symbol_rate) + " pol: " + str(polarisation) + " fec: " + str(fec) + " inversion: " + str(inversion) + " modulation: " + str(modulation) + " system: " + str(system) + " rolloff" + str(rolloff) + " pilot" + str(pilot) + " is_id" + str(is_id) + " pls_mode" + str(pls_mode) + " pls_code" + str(pls_code)
+	def addSatTransponder(self, tlist, frequency, symbol_rate, polarisation, fec, inversion, orbital_position, system, modulation, rolloff, pilot, is_id, pls_mode, pls_code, t2mi_plp_id):
+		print "Add Sat: frequ: " + str(frequency) + " symbol: " + str(symbol_rate) + " pol: " + str(polarisation) + " fec: " + str(fec) + " inversion: " + str(inversion) + " modulation: " + str(modulation) + " system: " + str(system) + " rolloff" + str(rolloff) + " pilot" + str(pilot) + " is_id" + str(is_id) + " pls_mode" + str(pls_mode) + " pls_code" + str(pls_code) + " t2mi_plp_id" + str(t2mi_plp_id)
 		print "orbpos: " + str(orbital_position)
 		parm = eDVBFrontendParametersSatellite()
 		parm.modulation = modulation
@@ -1269,6 +1295,7 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 		parm.is_id = is_id
 		parm.pls_mode = pls_mode
 		parm.pls_code = pls_code
+		parm.t2mi_plp_id = t2mi_plp_id
 		tlist.append(parm)
 
 	def addCabTransponder(self, tlist, frequency, symbol_rate, modulation, fec, inversion):
@@ -1336,6 +1363,10 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 					else:
 						fec = self.scan_sat.fec_s2.value
 					print "add sat transponder"
+					if self.scan_sat.t2mi_pid.value > 0 and self.scan_sat.t2mi_plp.value >= 0:
+						t2mi_plp_id = (self.scan_sat.t2mi_pid.value<<16)|self.scan_sat.t2mi_plp.value
+					else:
+						t2mi_plp_id = eDVBFrontendParametersSatellite.No_T2MI_PLP_Id
 					self.addSatTransponder(tlist, self.scan_sat.frequency.value,
 								self.scan_sat.symbolrate.value,
 								self.scan_sat.polarization.value,
@@ -1348,7 +1379,8 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 								self.scan_sat.pilot.value,
 								self.scan_sat.is_id.value,
 								self.scan_sat.pls_mode.value,
-								self.scan_sat.pls_code.value)
+								self.scan_sat.pls_code.value,
+								t2mi_plp_id)
 				removeAll = False
 			elif self.scan_type.value == "predefined_transponder":
 				nimsats = self.satList[index_to_scan]
@@ -1358,7 +1390,7 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 					tps = nimmanager.getTransponders(orbpos, index_to_scan)
 					if len(tps) and len(tps) > self.preDefTransponders.index:
 						tp = tps[self.preDefTransponders.index]
-						self.addSatTransponder(tlist, tp[1] / 1000, tp[2] / 1000, tp[3], tp[4], tp[7], orbpos, tp[5], tp[6], tp[8], tp[9], tp[10], tp[11], tp[12])
+						self.addSatTransponder(tlist, tp[1] / 1000, tp[2] / 1000, tp[3], tp[4], tp[7], orbpos, tp[5], tp[6], tp[8], tp[9], tp[10], tp[11], tp[12], tp[13])
 				removeAll = False
 			elif self.scan_type.value == "single_satellite":
 				sat = self.satList[index_to_scan][self.scan_satselection[index_to_scan].index]
@@ -1513,6 +1545,10 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 				fec = self.scan_sat.fec_s2.value
 			else:
 				fec = self.scan_sat.fec.value
+			if self.scan_sat.t2mi_pid.value > 0 and self.scan_sat.t2mi_plp.value >= 0:
+				t2mi_plp_id = (self.scan_sat.t2mi_pid.value<<16)|self.scan_sat.t2mi_plp.value
+			else:
+				t2mi_plp_id = eDVBFrontendParametersSatellite.No_T2MI_PLP_Id
 			compare = [
 				0, # DVB type
 				self.scan_sat.frequency.value*1000,  # 1
@@ -1526,7 +1562,8 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 				self.scan_sat.pilot.value,           # 9
 				self.scan_sat.is_id.value,           # 10
 				self.scan_sat.pls_mode.value,        # 11
-				self.scan_sat.pls_code.value         # 12
+				self.scan_sat.pls_code.value,        # 12
+				t2mi_plp_id                          # 13
 				# tsid
 				# onid
 			]
@@ -1551,13 +1588,16 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 					tp_text = ("%s MIS %d") % (tp_text, tp[10])
 				if tp[12] > 0:
 					tp_text = ("%s Gold %d") % (tp_text, tp[12])
+				if tp[13] > eDVBFrontendParametersSatellite.No_T2MI_PLP_Id:
+					tp_text = ("%s T2MI %d") % (tp_text, tp[13])
+
 			return tp_text
 		return _("Invalid transponder data")
 
 	def compareTransponders(self, tp, compare):
 		frequencyTolerance = 2000 #2 MHz
 		symbolRateTolerance = 10
-		return abs(tp[1] - compare[1]) <= frequencyTolerance and abs(tp[2] - compare[2]) <= symbolRateTolerance and tp[3] == compare[3] and (not tp[4] or tp[4] == compare[4]) and (tp[5] == eDVBFrontendParametersSatellite.System_DVB_S or tp[10] == -1 or tp[10] == compare[10])
+		return abs(tp[1] - compare[1]) <= frequencyTolerance and abs(tp[2] - compare[2]) <= symbolRateTolerance and tp[3] == compare[3] and (not tp[4] or tp[4] == compare[4]) and (tp[5] == eDVBFrontendParametersSatellite.System_DVB_S or tp[10] == -1 or tp[10] == compare[10] or tp[13] == compare[13])
 
 	def predefinedTerrTranspondersList(self):
 		default = None

--- a/lib/python/Screens/ServiceInfo.py
+++ b/lib/python/Screens/ServiceInfo.py
@@ -306,6 +306,7 @@ class ServiceInfo(Screen):
 				tuner = (_("NIM & Type"), chr(ord('A') + frontendData["tuner_number"]) + " - " + frontendData["tuner_type"], TYPE_TEXT)
 			if frontendDataOrg["tuner_type"] == "DVB-S":
 				issy = lambda x: 0 if x == -1 else x
+				t2mi = lambda x: None if x == -1 else str(x)
 				return (tuner,
 					(_("System & Modulation"), frontendData["system"] + " " + frontendData["modulation"], TYPE_TEXT),
 					(_("Orbital position"), frontendData["orbital_position"], TYPE_VALUE_DEC),
@@ -314,7 +315,8 @@ class ServiceInfo(Screen):
 					(_("Inversion, Pilot & Roll-off"), frontendData["inversion"] + " - " + str(frontendData.get("pilot", None)) + " - " + str(frontendData.get("rolloff", None)), TYPE_TEXT),
 					(_("Input Stream ID"), issy(frontendData.get("is_id", 0)), TYPE_VALUE_DEC),
 					(_("PLS Mode"), frontendData.get("pls_mode", None), TYPE_TEXT),
-					(_("PLS Code"), frontendData.get("pls_code", 0), TYPE_VALUE_DEC))
+					(_("PLS Code"), frontendData.get("pls_code", 0), TYPE_VALUE_DEC),
+					(_("T2MI PLP ID"), t2mi(frontendData.get("t2mi_plp_id", -1)), TYPE_TEXT))
 			elif frontendDataOrg["tuner_type"] == "DVB-C":
 				return (tuner,
 					(_("Modulation"), frontendData["modulation"], TYPE_TEXT),

--- a/lib/python/Tools/Transponder.py
+++ b/lib/python/Tools/Transponder.py
@@ -121,6 +121,7 @@ def ConvertToHumanReadable(tp, tunertype = None):
 			ret["pls_mode"] = None
 			ret["is_id"] = None
 			ret["pls_code"] = None
+			ret["t2mi_plp_id"] = None
 	elif tunertype == "DVB-C":
 		ret["tuner_type"] = _("Cable")
 		ret["modulation"] = {

--- a/lib/python/python_helpers.cpp
+++ b/lib/python/python_helpers.cpp
@@ -107,6 +107,8 @@ void transponderDataToDict(ePyObject &dest, ePtr<iDVBTransponderData> data)
 		if (value >= 0) PutToDict(dest, "pls_mode", value);
 		value = data->getPLSCode();
 		if (value >= 0) PutToDict(dest, "pls_code", value);
+		value = data->getT2MIPlpId();
+		if (value >= -1) PutToDict(dest, "t2mi_plp_id", value);
 
 		/* additional terrestrial fields */
 		value = data->getBandwidth();


### PR DESCRIPTION
Tuners which can do multistream should been able to t2-mi but the stream should been decap first (like done with the plugin astra-sm)
As there is no info provide by the demod or tuner if it has the capability to handle t2-mi the option will been only available when the tuner can do multistream

todo: t2-mi cluster stream should been decap first to get the pmt info
todo: add in transponder list the plp_id for t2-mi transponders

(based on the original patch for Openatv)
Credits go to:
From: zhtq 36952536+zhtq@users.noreply.github.com
Date: Mon, 28 Jan 2019 11:13:01 +0100
Subject: [PATCH] add t2mi support)