### PR TITLE
ConfigList - there is no reason not to use an empty string from Virtu…

### DIFF
--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -211,7 +211,7 @@ class ConfigListScreen:
 		self.session.openWithCallback(self.VirtualKeyBoardCallback, VirtualKeyBoard, title=self["config"].getCurrent()[0], text=self["config"].getCurrent()[1].getValue())
 
 	def VirtualKeyBoardCallback(self, callback=None):
-		if callback is not None and len(callback):
+		if callback is not None:
 			self["config"].getCurrent()[1].setValue(callback)
 			self["config"].invalidate(self["config"].getCurrent())
 		self["config"].showHelp()


### PR DESCRIPTION
…alKeyboard

When there was used test for length returned string from VK, then was not possible with VK remove string in config field.