### PR TITLE
fixed id.po

### DIFF
--- a/po/id.po
+++ b/po/id.po
@@ -9075,7 +9075,7 @@ msgid "Timeshift Live"
 msgstr ""
 
 msgid "Timeshift is running. Select an action.\n"
-msgstr "Timeshift sedang berjalan. Pilih tindakan."
+msgstr "Timeshift sedang berjalan. Pilih tindakan.\n"
 
 msgid "Timeshift location"
 msgstr "Lokasi timeshift"


### PR DESCRIPTION
- missing '\n' in translate corrupts build!