### PR TITLE
SoftwareUpdate.py: Remove useless import of HardwareInfo

### DIFF
--- a/lib/python/Screens/SoftwareUpdate.py
+++ b/lib/python/Screens/SoftwareUpdate.py
@@ -13,7 +13,6 @@ from Components.Sources.StaticText import StaticText
 from Components.Slider import Slider
 from Tools.BoundFunction import boundFunction
 from Tools.Directories import fileExists
-from Tools.HardwareInfo import HardwareInfo
 from enigma import eTimer, getBoxType, eDVBDB
 from urllib2 import urlopen
 import datetime, os


### PR DESCRIPTION
We're using getBoxType in this file so remove what we don't have.