### PR TITLE
Standby.py: Remove useless import

### DIFF
--- a/lib/python/Screens/Standby.py
+++ b/lib/python/Screens/Standby.py
@@ -14,7 +14,6 @@ from Components.SystemInfo import SystemInfo
 from GlobalActions import globalActionMap
 from enigma import eDVBVolumecontrol, eTimer, eDVBLocalTimeHandler, eServiceReference, eStreamServer
 from Components.Sources.StreamService import StreamServiceList
-from Tools.HardwareInfo import HardwareInfo
 
 inStandby = None
 


### PR DESCRIPTION
I did cleanup all enimga2 python files before of useless imports, please keep them clean :(

Also https://github.com/OpenPLi/enigma2-plugins is full of useless imports, I have to clean them too I guess ...