### PR TITLE
Fix "Mountain Time" zone resetting after restart

### DIFF
--- a/data/timezone.xml
+++ b/data/timezone.xml
@@ -8,7 +8,7 @@
 	<zone name="(GMT-08:00) Pacific Time (US and Canada), Tijuana" zone="America/Tijuana" />
 	<zone name="(GMT-07:00) Arizona" zone="MST" />
 	<zone name="(GMT-07:00) Chihuahua, La Paz, Mazatlan" zone="MST7MDT" />
-	<zone name="(GMT-07:00) Mountain Time (US &amp; Canada) " zone="MST7MDT" />
+	<zone name="(GMT-07:00) Mountain Time (US and Canada)" zone="MST7MDT" />
 	<zone name="(GMT-06:00) Central America" zone="CST6CDT" />
 	<zone name="(GMT-06:00) Central Time (US and Canada)" zone="CST6CDT" />
 	<zone name="(GMT-06:00) Guadalajara, Mexico City, Monterrey" zone="CST6CDT" />


### PR DESCRIPTION
The extra space character at the end of the "name" attribute was breaking the timezone parser, and the timezone of the box was set back to the default one (Amsterdam gmt+1).

Also changed the "&" with "and" for consistency with other timezones.