### PR TITLE
[Cosmetic] Add format to the "Show menu or plugin numbers" when enabled.

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -10,6 +10,7 @@
 		<item level="1" text="Sort order for setup entries" description="This option allows you to alphabetically sort setup menu entries.">config.usage.sort_settings</item>
 		<item level="1" text="Show menu paths" description="This option allows you to show menu paths.">config.usage.menu_path</item>
 		<item level="0" text="Show menu or plugin numbers" description="This option allows you to show menu and/or plugin number quick links.">config.usage.menu_show_numbers</item>
+		<item level="0" text="Menu numbers format" description="This option allows you to show menu number format.">config.usage.show_numbers_format</item>
 		<item level="2" text="Show softcam setup in extensions menu" description="This option allows you to add the softcam setup in the extensions menu." requires="HasSoftcamInstalled">config.misc.softcam_setup.extension_menu</item>
 		<item level="1" text="Zap mode" requires="ZapMode" description="Configure the way in which the receiver changes channels.">config.misc.zapmode</item>
 		<item level="2" text="Enable teletext caching" description="When enabled, teletext pages will be cached, allowing faster access.">config.usage.enable_tt_caching</item>

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -81,6 +81,11 @@ def InitUsageConfig():
 		("default", _("Default")),
 		("user", _("user defined")),])
 	config.usage.menu_show_numbers = ConfigSelection(default = "no", choices = [("no", _("no")), ("menu&plugins", _("in menu and plugins")), ("menu", _("in menu only")), ("plugins", _("in plugins only"))])
+	config.usage.show_numbers_format = ConfigSelection(default = "default", choices = [
+		("default", _("Default")),
+		("singledot", _("1. ")),
+		("singlebracket", _("1 ) ")),
+		("doublebracket", _("( 1 )")),])
 	config.usage.menu_path = ConfigSelection(default = "off", choices = [
 		("off", _("Disabled")),
 		("small", _("Small")),

--- a/lib/python/Screens/Menu.py
+++ b/lib/python/Screens/Menu.py
@@ -286,7 +286,14 @@ class Menu(Screen, ProtectedScreen):
 			self.list.sort(key=lambda x: int(x[3]))
 
 		if config.usage.menu_show_numbers.value in ("menu&plugins", "menu") or showNumericHelp:
-			self.list = [(str(x[0] + 1) + " " +x[1][0], x[1][1], x[1][2]) for x in enumerate(self.list)]
+			if config.usage.show_numbers_format.value == "singledot":
+				self.list = [(str(x[0] + 1) + ".    " +x[1][0], x[1][1], x[1][2]) for x in enumerate(self.list)]
+			elif config.usage.show_numbers_format.value == "singlebracket":
+				self.list = [(str(x[0] + 1) + " )    " +x[1][0], x[1][1], x[1][2]) for x in enumerate(self.list)]
+			elif config.usage.show_numbers_format.value == "doublebracket":
+				self.list = [("( " + str(x[0] + 1) + " )    " +x[1][0], x[1][1], x[1][2]) for x in enumerate(self.list)]
+			else:
+				self.list = [(str(x[0] + 1) + " " +x[1][0], x[1][1], x[1][2]) for x in enumerate(self.list)]
 
 		self["menu"].updateList(self.list)
 


### PR DESCRIPTION
Samples:
* 1.
* 1 )
* ( 1 )
Default is the default format as usual.

Preview:

![1_0_1_2B_190_2C0_67D0000_0_0_0_20190319200851](https://user-images.githubusercontent.com/15664372/54608240-e6ce6280-4a82-11e9-8f46-ff80c7b475a6.jpg)
