### PR TITLE
About: fix skin name for skins with setup plugin, thx Vasiliks

### DIFF
--- a/lib/python/Screens/About.py
+++ b/lib/python/Screens/About.py
@@ -65,7 +65,7 @@ class About(Screen):
 
 		self["FPVersion"] = StaticText(fp_version)
 
-		AboutText += _('Skin & Resolution: %s (%sx%s)\n') % (config.skin.primary_skin.value[0:-9], getDesktop(0).size().width(), getDesktop(0).size().height())
+		AboutText += _('Skin & Resolution: %s (%sx%s)\n') % (config.skin.primary_skin.value.split('/')[0], getDesktop(0).size().width(), getDesktop(0).size().height())
 
 		self["TunerHeader"] = StaticText(_("Detected NIMs:"))
 		AboutText += "\n" + _("Detected NIMs:") + "\n"


### PR DESCRIPTION
For example, here is the skin MetrixHD which uses for the settings plugin and therefore saves the skin name as MetrixHD/skin.MySkin.xml
Of course, such name is not displayed correctly.
This fixes such problems.