### PR TITLE
Pixmap caching

### DIFF
--- a/lib/gdi/Makefile.inc
+++ b/lib/gdi/Makefile.inc
@@ -20,6 +20,7 @@ gdi_libenigma_gdi_a_SOURCES = \
 	gdi/lcd.cpp \
 	gdi/picexif.cpp \
 	gdi/picload.cpp \
+	gdi/pixmapcache.cpp \
 	gdi/region.cpp
 
 gdiincludedir = $(pkgincludedir)/lib/gdi
@@ -40,6 +41,7 @@ gdiinclude_HEADERS = \
 	gdi/lcd.h \
 	gdi/picexif.h \
 	gdi/picload.h \
+	gdi/pixmapcache.h \
 	gdi/region.h
 
 if HAVE_LIBSDL

--- a/lib/gdi/epng.cpp
+++ b/lib/gdi/epng.cpp
@@ -185,6 +185,11 @@ my_error_exit (j_common_ptr cinfo)
 	longjmp(myerr->setjmp_buffer, 1);
 }
 
+int loadJPG(ePtr<gPixmap> &result, const char *filename, int cached)
+{
+	return loadJPG(result, filename, ePtr<gPixmap>(), cached);
+}
+
 int loadJPG(ePtr<gPixmap> &result, const char *filename, ePtr<gPixmap> alpha, int cached)
 {
 	if (cached && (result = PixmapCache::Get(filename)))

--- a/lib/gdi/epng.cpp
+++ b/lib/gdi/epng.cpp
@@ -4,75 +4,17 @@
 #include <stdio.h>
 #include <lib/base/cfile.h>
 #include <lib/gdi/epng.h>
+#include <lib/gdi/pixmapcache.h>
 #include <unistd.h>
-
-#include <map>
-#include <string>
-#include <lib/base/elock.h>
 
 extern "C" {
 #include <jpeglib.h>
 }
 
-/* Keep a table of already-loaded pixmaps, and return the old one when
- * needed. The "dispose" method isn't very efficient, but not having
- * to load the same pixmap twice will probably make up for that.
- * There is a race condition, when two threads load the same image,
- * the worst case scenario is then that the pixmap is loaded twice. This
- * isn't any worse than before, and all the UI pixmaps will be loaded
- * from the same thread anyway. */
-
-typedef std::map<std::string, gPixmap*> NameToPixmap;
-static eSingleLock pixmapTableLock;
-static NameToPixmap pixmapTable;
-
-static void pixmapDisposed(gPixmap* pixmap)
-{
-	eSingleLocker lock(pixmapTableLock);
-	for (NameToPixmap::iterator it = pixmapTable.begin();
-		 it != pixmapTable.end();
-		 ++it)
-	{
-		 if (it->second == pixmap)
-		 {
-			 pixmapTable.erase(it);
-			 break;
-		 }
-
-	}
-}
-
-static int pixmapFromTable(ePtr<gPixmap> &result, const char *filename)
-{
-	/* Prevent a deadlock: assigning a pixmap to result may cause the
-	 * previous to be destroyed, which would call pixmapDisposed which
-	 * in turn would aquire the lock a second time. */
-	ePtr<gPixmap> disposeMeOutsideTheLock(result);
-	{
-		eSingleLocker lock(pixmapTableLock);
-		NameToPixmap::iterator it = pixmapTable.find(filename);
-		if (it != pixmapTable.end())
-		{
-			result = it->second; /* Yay, re-use the pixmap */
-			return 0;
-		}
-		else
-		{
-			return -1;
-		}
-	}
-}
-
-static void pixmapToTable(ePtr<gPixmap> &result, const char *filename)
-{
-	eSingleLocker lock(pixmapTableLock);
-	pixmapTable[filename] = result;
-}
-
 /* TODO: I wonder why this function ALWAYS returns 0 */
-int loadPNG(ePtr<gPixmap> &result, const char *filename, int accel)
+int loadPNG(ePtr<gPixmap> &result, const char *filename, int accel, int cached)
 {
-	if (pixmapFromTable(result, filename) == 0)
+	if (cached && (result = PixmapCache::Get(filename)))
 		return 0;
 
 	CFile fp(filename, "rb");
@@ -175,7 +117,7 @@ int loadPNG(ePtr<gPixmap> &result, const char *filename, int accel)
 	png_get_IHDR(png_ptr, info_ptr, &width, &height, &bit_depth, &color_type, 0, 0, 0);
 	channels = png_get_channels(png_ptr, info_ptr);
 
-	result = new gPixmap(width, height, bit_depth * channels, pixmapDisposed, accel);
+	result = new gPixmap(width, height, bit_depth * channels, cached ? PixmapCache::PixmapDisposed : NULL, accel);
 	gUnmanagedSurface *surface = result->surface;
 
 	png_bytep *rowptr = new png_bytep[height];
@@ -217,7 +159,10 @@ int loadPNG(ePtr<gPixmap> &result, const char *filename, int accel)
 		}
 		surface->clut.start = 0;
 	}
-	pixmapToTable(result, filename);
+
+	if (cached)
+		PixmapCache::Set(filename, result);
+
 	//eDebug("[ePNG] %s: after  %dx%dx%dbpcx%dchan coltyp=%d cols=%d trans=%d", filename, (int)width, (int)height, bit_depth, channels, color_type, num_palette, num_trans);
 
 	png_read_end(png_ptr, end_info);
@@ -240,8 +185,11 @@ my_error_exit (j_common_ptr cinfo)
 	longjmp(myerr->setjmp_buffer, 1);
 }
 
-int loadJPG(ePtr<gPixmap> &result, const char *filename, ePtr<gPixmap> alpha)
+int loadJPG(ePtr<gPixmap> &result, const char *filename, ePtr<gPixmap> alpha, int cached)
 {
+	if (cached && (result = PixmapCache::Get(filename)))
+		return 0;
+
 	struct jpeg_decompress_struct cinfo;
 	struct my_error_mgr jerr;
 	JSAMPARRAY buffer;
@@ -291,7 +239,7 @@ int loadJPG(ePtr<gPixmap> &result, const char *filename, ePtr<gPixmap> alpha)
 		}
 	}
 
-	result = new gPixmap(eSize(cinfo.output_width, cinfo.output_height), grayscale ? 8 : 32);
+	result = new gPixmap(cinfo.output_width, cinfo.output_height, grayscale ? 8 : 32, cached ? PixmapCache::PixmapDisposed : NULL);
 
 	row_stride = cinfo.output_width * cinfo.output_components;
 	buffer = (*cinfo.mem->alloc_sarray)((j_common_ptr) &cinfo, JPOOL_IMAGE, row_stride, 1);
@@ -329,6 +277,10 @@ int loadJPG(ePtr<gPixmap> &result, const char *filename, ePtr<gPixmap> alpha)
 			}
 		}
 	}
+
+	if (cached)
+		PixmapCache::Set(filename, result);
+
 	(void) jpeg_finish_decompress(&cinfo);
 	jpeg_destroy_decompress(&cinfo);
 	return 0;

--- a/lib/gdi/epng.h
+++ b/lib/gdi/epng.h
@@ -3,8 +3,8 @@
 
 #include <lib/gdi/gpixmap.h>
 
-SWIG_VOID(int) loadPNG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, int accel = 0);
-SWIG_VOID(int) loadJPG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, ePtr<gPixmap> alpha = 0);
+SWIG_VOID(int) loadPNG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, int accel = 0, int cached = 1);
+SWIG_VOID(int) loadJPG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, ePtr<gPixmap> alpha = 0, int cached = 0);
 
 int savePNG(const char *filename, gPixmap *pixmap);
 

--- a/lib/gdi/epng.h
+++ b/lib/gdi/epng.h
@@ -4,7 +4,8 @@
 #include <lib/gdi/gpixmap.h>
 
 SWIG_VOID(int) loadPNG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, int accel = 0, int cached = 1);
-SWIG_VOID(int) loadJPG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, ePtr<gPixmap> alpha = 0, int cached = 0);
+SWIG_VOID(int) loadJPG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, int cached = 0);
+SWIG_VOID(int) loadJPG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, ePtr<gPixmap> alpha, int cached = 0);
 
 int savePNG(const char *filename, gPixmap *pixmap);
 

--- a/lib/gdi/pixmapcache.cpp
+++ b/lib/gdi/pixmapcache.cpp
@@ -1,0 +1,163 @@
+#include <lib/gdi/pixmapcache.h>
+
+#include <algorithm>
+#include <map>
+#include <string>
+#include <lib/base/elock.h>
+
+uint PixmapCache::MaximumSize = 256;
+
+/* Keep a table of already-loaded pixmaps, and return the old one when
+ * needed. The "dispose" method isn't very efficient, but not called unless
+ * a pixmap is being replaced by another when the cache is full and even then,
+ * not loading the same pixmap repeatedly will probably make up for that.
+ * There is a race condition, when two threads load the same image,
+ * the worst case scenario is then that the pixmap is loaded twice. This
+ * isn't any worse than before, and all the UI pixmaps will be loaded
+ * from the same thread anyway. */
+
+// cache objects work best when we manage the ref counting manually. ePtr brings memory protection violations on shutdown
+struct CacheItem
+{
+public:
+	CacheItem()
+	{
+	}
+
+	CacheItem& operator=(const CacheItem& p)
+	{
+		pixmap = p.pixmap;
+		filesize = p.filesize;
+		modifiedDate = p.modifiedDate;
+		lastUsed = p.lastUsed;
+		return *this;
+	}
+
+	CacheItem(gPixmap* p, off_t s, time_t m)
+	{
+		pixmap = p;
+		filesize = s;
+		modifiedDate = m;
+		lastUsed = ::time(0);
+	};
+
+	gPixmap* pixmap;
+	off_t filesize;
+	time_t modifiedDate;
+	int lastUsed;
+};
+
+typedef std::map<std::string, CacheItem> NameToPixmap;
+
+static bool CompareLastUsed(NameToPixmap::value_type i, NameToPixmap::value_type j) 
+{ 
+	return i.second.lastUsed < j.second.lastUsed;
+}
+
+static eSingleLock pixmapCacheLock;
+static NameToPixmap pixmapCache;
+
+void PixmapCache::PixmapDisposed(gPixmap* pixmap)
+{
+	eSingleLocker lock(pixmapCacheLock);
+
+	for (NameToPixmap::iterator it = pixmapCache.begin();
+		 it != pixmapCache.end();
+		 ++it)
+	{
+		if (it->second.pixmap == pixmap)
+		{
+			pixmapCache.erase(it);
+			eDebug("[PixmapCache] %s removed from cache. Cache size %d", it->first.c_str(), pixmapCache.size());
+			break;
+		}
+	}
+}
+
+gPixmap* PixmapCache::Get(const char *filename)
+{
+	gPixmap* disposePixmap = NULL;
+	{
+		eSingleLocker lock(pixmapCacheLock);
+		NameToPixmap::iterator it = pixmapCache.find(filename);
+		if (it != pixmapCache.end())
+		{
+			// find out whether the image has been modified
+			// if so, it'll need to be reloaded from disk
+			struct stat img_stat;
+			if (stat(filename, &img_stat) == 0 && img_stat.st_mtime == it->second.modifiedDate && img_stat.st_size == it->second.filesize)
+			{
+				eDebug("[PixmapCache] Found %s (%dx%d)", filename, it->second.pixmap->size().width(), it->second.pixmap->size().height());
+				// file still exists and hasn't been modified
+				it->second.lastUsed = ::time(0);
+				return it->second.pixmap;
+			}
+			else
+			{
+				// file no longer exists, has been modified or changed size, so remove from the cache
+				pixmapCache.erase(it);
+				eDebug("[PixmapCache] %s was modified on disk. Pretending it's not in the cache", filename);
+				disposePixmap = it->second.pixmap;
+			}
+		}
+	}
+
+	// Release might cause a callback into PixmapDisposed
+	// Avoid the risk of a deadlock by doing the release outside the lock
+	if (disposePixmap)
+		disposePixmap->Release();
+
+	return NULL;
+}
+
+void PixmapCache::Set(const char *filename, gPixmap* pixmap)
+{
+	gPixmap* disposePixmap = NULL;
+	{
+		eSingleLocker lock(pixmapCacheLock);
+		struct stat img_stat;
+		if (stat(filename, &img_stat) == 0)
+		{
+			NameToPixmap::iterator it = pixmapCache.find(filename);
+			if (it != pixmapCache.end())
+			{
+				// need to release the pixmap being replaced after we've finished updating the cache
+				disposePixmap = it->second.pixmap;
+				eDebug("[PixmapCache] Replacing outdated %s (%dx%d)", filename, disposePixmap->size().width(), disposePixmap->size().height());
+
+				// swap in the updated pixmap
+				pixmap->AddRef();
+				it->second.pixmap = pixmap;
+				it->second.filesize = img_stat.st_size;
+				it->second.modifiedDate = img_stat.st_mtime;
+			}
+			else
+			{
+				eDebug("[PixmapCache] Cache size %d", pixmapCache.size());
+
+				if (pixmapCache.size() > MaximumSize)
+				{
+					// find the least recently used
+					NameToPixmap::iterator it = std::min_element(pixmapCache.begin(), pixmapCache.end(), &CompareLastUsed);
+					if (it != pixmapCache.end())
+					{
+						pixmapCache.erase(it);
+						// need to release the pixmap being removed after we've finished updating the cache
+						disposePixmap = it->second.pixmap;
+						eDebug("[PixmapCache] Removing least recently used %s (%dx%d)", it->first.c_str(), disposePixmap->size().width(), disposePixmap->size().height());
+					}
+				}
+
+				eDebug("[PixmapCache] Adding to png cache %s (%dx%d)", filename, pixmap->size().width(), pixmap->size().height());
+				pixmap->AddRef();
+				NameToPixmap::value_type pr = std::make_pair(std::string(filename), CacheItem(pixmap, img_stat.st_size, img_stat.st_mtime));
+				pixmapCache.insert(pr);
+			}
+		}
+	}
+
+	// Release might cause a callback into PixmapDisposed
+	// Avoid the risk of a deadlock by doing the release outside the lock
+	if (disposePixmap)
+		disposePixmap->Release();
+}

--- a/lib/gdi/pixmapcache.h
+++ b/lib/gdi/pixmapcache.h
@@ -1,0 +1,20 @@
+#ifndef __pixmapcache_h
+#define __pixmapcache_h
+
+#include <lib/gdi/gpixmap.h>
+
+#ifndef SWIG
+
+class PixmapCache
+{
+private:
+	static uint MaximumSize;
+public:
+	static void PixmapDisposed(gPixmap *pixmap);
+	static gPixmap* Get(const char *filename);
+	static void Set(const char *filename, gPixmap *pixmap);
+};
+
+#endif
+
+#endif

--- a/lib/python/Tools/LoadPixmap.py
+++ b/lib/python/Tools/LoadPixmap.py
@@ -1,13 +1,14 @@
 from enigma import loadPNG, loadJPG
 
-def LoadPixmap(path, desktop = None, cached = False):
+# if cached is not supplied, defaults to caching PNGs and not caching JPGs
+def LoadPixmap(path, desktop=None, cached=None):
 	if path[-4:] == ".png":
-		ptr = loadPNG(path)
+		ptr = loadPNG(path, 0, 0 if cached == 0 else 1)
 	elif path[-4:] == ".jpg":
-		ptr = loadJPG(path)
+		ptr = loadJPG(path, 0, 1 if cached == 1 else 0)
 	elif path[-1:] == ".":
-		alpha = loadPNG(path + "a.png")
-		ptr = loadJPG(path + "rgb.jpg", alpha)
+		alpha = loadPNG(path + "a.png", 0)
+		ptr = loadJPG(path + "rgb.jpg", alpha, 0)
 	else:
 		raise Exception("neither .png nor .jpg, please fix file extension")
 	if ptr and desktop:

--- a/lib/python/Tools/LoadPixmap.py
+++ b/lib/python/Tools/LoadPixmap.py
@@ -1,13 +1,18 @@
 from enigma import loadPNG, loadJPG
 
-# if cached is not supplied, defaults to caching PNGs and not caching JPGs
+# If cached is not supplied, LoadPixmap defaults to caching PNGs and not caching JPGs
+# Split alpha channel JPGs are never cached as the C++ layer's caching is based on
+# a single file per image in the cache
 def LoadPixmap(path, desktop=None, cached=None):
 	if path[-4:] == ".png":
-		ptr = loadPNG(path, 0, 0 if cached == 0 else 1)
+		# cache unless caller explicity requests to not cache
+		ptr = loadPNG(path, 0, 0 if cached == False else 1)
 	elif path[-4:] == ".jpg":
-		ptr = loadJPG(path, 0, 1 if cached == 1 else 0)
+		# don't cache unless caller explicity requests caching
+		ptr = loadJPG(path, 1 if cached == True else 0)
 	elif path[-1:] == ".":
-		alpha = loadPNG(path + "a.png", 0)
+		# caching mechanism isn't suitable for multi file images, so it's explicitly disabled
+		alpha = loadPNG(path + "a.png", 0, 0)
 		ptr = loadJPG(path + "rgb.jpg", alpha, 0)
 	else:
 		raise Exception("neither .png nor .jpg, please fix file extension")


### PR DESCRIPTION
C++ layer pixmap caching:
loadPNG and loadJPG have been updated to allow caching using an additional defaulted parameter.
loadPNG defaults to cached
loadJPG defaults to not cached
Caching is implemented in a helper class in pixmapcache.cpp. The cache holds a reference to the pixmap in the same manner as the previous caching. Images are reloaded from disk when the file modified time or the file size changes.
If the cache reaches a size of 256 images, the least recently referenced pixmap is removed. This is, I think, the same behaviour.
LoadPixmap has been updated to pass its cached parameter through or to use the default rules if it is not supplied by the caller.

I found that the cache caused protection fault crashes on exiting the enigma2 process when the cache held ePtr<gPixmap>, so I switched to using a gPixmap* and manually managing the refcounts. Since then, no crashes.

2nd commit in the pull request fixes a crash when using LoadPixmap to load JPGs
Verbose logging of pixmap caching has also been removed

This code has been tested for several weeks without any problems being found.