### PR TITLE
Update VirtualKeyBoard

### DIFF
--- a/doc/VIRTUALKEYBOARD
+++ b/doc/VIRTUALKEYBOARD
@@ -4,39 +4,40 @@ A Guide to the VirtualKeyBoard Screen
 Written by IanSav - 18-Aug-2018
 Updated by IanSav -  4-Sep-2018
 Updated by IanSav - 12-Nov-2018
-Updated by IanSav - 25-Mar-2019 *
+Updated by IanSav - 25-Mar-2019
+Updated by IanSav -  8-Apr-2019 *
 
 This document explains the changes and updates to the VirtualKeyBoard of 
 Enigma2.  The code is located in:
 	/usr/lib/enigma2/python/Screens/VirtualKeyBoard.py
 
-The revised virtual keyboard is dynamically created based on the data 
+The revised VirtualKeyBoard is dynamically created based on the data 
 defined in the "self.locales" data in the "__init__" method of the 
 "VirtualKeyBoard" class.  To make creating new locales based on common 
 languages easier a number of base language definitions are provided. 
 (Currently English, French, German, Russian, Scandinavian and Spanish.) 
 The locales are based on the list at https://lh.2xlibre.net/locales/.
 
-* The maximum width of the keyboard has been set at 14 buttons.  This 
+The maximum width of the keyboard has been set at 14 buttons.  This 
 limitation is set by the skin allocation of space for the keyboard and then 
 confirmed in this code in the "virtualKeyBoardEntryComponent" method.  If 
 the "keyList" data describes a keyboard less than 14 characters then that 
 keyboard will be centred in the 14 wide keyboard space.  The button layouts 
 for each of the keyboards is based on the layouts at http://kbdlayout.info/.
 
-Each element of the "keyList" data is a button displayed on the virtual 
-keyboard.  Certain button names are mapped to images that will be used 
-for that button.  The current image button definitions are listed in 
+Each element of the "keyList" data is a button displayed on the 
+VirtualKeyBoard.  Certain button names are mapped to images that will be 
+used for that button.  The current image button definitions are listed in 
 the "self.keyImages" dictionary in the "__init__" method of the 
 "VirtualKeyBoard" class. To make future updates easier all non English 
 characters are represented by their unicode numeric code 
 (https://en.wikipedia.org/wiki/List_of_Unicode_characters).
 
-* Any sequence of identical button definitions on any single row of a 
+Any sequence of identical button definitions on any single row of a 
 "keyList" entry will be used to generate a single wide button on the 
 screen occupying all the defined positions.
 
-* This revision also allows the four colour buttons to be assigned to any 
+This revision also allows the four colour buttons to be assigned to any 
 keyboard key by nominating the key text in the "self.keyHiglights" 
 dictionary in the "__init__" method of the "VirtualKeyBoard" class. 
 This change will allow for colour button text to be localised rather than 
@@ -45,52 +46,54 @@ the ENTER and SHIFT button graphics should default to the GREEN and BLUE
 borders, respectively, but can now be changed.
 
 This revision also adds the ability to define the foreground colours of the 
-characters on the virtual keyboard.  The colour selections for the unshifted 
+characters on the VirtualKeyBoard.  The colour selections for the unshifted 
 and three predefined shift levels are defined as white, white, cyan and 
 magenta respectively.  These colours match the default SHIFT button 
 images.  These colours can be overridden by a skin author via the 
 "VirtualKeyBoardShiftColors" skin parameter.  (The number of shift levels 
 can be increased if required.)
 
-* The updated virtual keyboard has a new and optional calling parameter 
+* The updated VirtualKeyBoard has a new and optional calling parameter 
 "style=".  This calling parameter can be used to adjust the text of the 
 GREEN button and the optional text on the keypad button for the "Enter" 
 key.  The values that can be used are:
-	VKB_DONE_GRAPHIC
-	VKB_ENTER_GRAPHIC
-	VKB_OK_GRAPHIC
-	VKB_SAVE_GRAPHIC
+	VKB_DONE_ICON
+	VKB_ENTER_ICON
+	VKB_OK_ICON
+	VKB_SAVE_ICON
+	VKB_SEARCH_ICON
 	VKB_DONE_TEXT
 	VKB_ENTER_TEXT
 	VKB_OK_TEXT
 	VKB_SAVE_TEXT
-The first four options change the GREEN button text to "Done", "Enter", 
-"OK" and "Save" respectively but keep the keypad grid image of the 
-"ENTER" button.  The next four options change both the GREEN button and 
-the text used on the keypad grid.
+	VKB_SEARCH_TEXT
+The first five options change the GREEN button text to "Done", "Enter", 
+"OK", "Save" and "Search" respectively but keep the keypad grid image of 
+the "ENTER" button.  The next five options change both the GREEN button 
+and the text used on the keypad grid.
 
-* This revision includes two optional new parameters to give skin designers 
+This revision includes two optional new parameters to give skin designers 
 more control of the VirtualKeyBoard display:
 
-* The "VirtualKeyBoardAlignment" parameter takes two comma separated 
+The "VirtualKeyBoardAlignment" parameter takes two comma separated 
 decimal values.  The first value specifies the horizontal alignment of the 
 data in each of the keyboard keymap cells.  The second value specifies the 
 vertical alignment of the data in each of the keyboard keymap cells.
 
-* The horizontal "VirtualKeyBoardAlignment" values are:
+The horizontal "VirtualKeyBoardAlignment" values are:
 	0 - Auto - Default  (Auto=Left on left button, Centre on middle 
 				buttons, Right on right button).
 	1 - Left
 	2 - Centre
 	3 - Right
 
-* The vertical "VirtualKeyBoardAlignment" values are:
+The vertical "VirtualKeyBoardAlignment" values are:
 	0 - Auto - Default  (Auto=Centre)
 	1 - Top
 	2 - Centre
 	3 - Bottom
 
-* The "VirtualKeyBoardPadding" parameter takes two comma separated 
+The "VirtualKeyBoardPadding" parameter takes two comma separated 
 decimal values.  The first value specifies the horizontal (left and right) 
 padding of the data in each of the keyboard keymap cells.  The second 
 value specifies the vertical (top and bottom) padding of the data in each 
@@ -100,9 +103,9 @@ of a cell can come to the edges of that cell.  The default is 4 pixels for
 the cell to stay clear of the default highlighting and current cell overlay 
 indicators.
 
-* To further assist with changing the skin of the Virtual KeyBoard the 
+To further assist with changing the skin of the VirtualKeyBoard the 
 various colour highlights and button images no longer contain any part of 
-the virtual keyboard background image.  They are now standalone images on 
+the VirtualKeyBoard background image.  They are now standalone images on 
 a transparent background.  These images are now placed on top of the 
 background cell image rather than replacing it.  These images now blend 
 in with *any* selected image chosen for the cell background.  For most 
@@ -119,8 +122,13 @@ Internet address entry easier.  To ensure that longer key text can fit in
 the screen space available any text longer than one character will be drawn 
 at 56% of the "VirtualKeyBoard" skin font parameter assigned font size.
 
+* As mentioned in the previous paragraph buttons can be assigned short text 
+messages to ease user data entry.  Please note that text will now be used 
+exactly as entered in all locales.  If translation is required please ensure 
+that the text is enclosed in the the standard "_(" ")" tokens.
+
 This revision also adds HELP button text to assist users with using the 
-updated Virtual KeyBoard interface.
+updated VirtualKeyBoard interface.
 
 If the VirtualKeyBoard interface is to be re-skinned then the following
 "name=" screen widgets should be defined:
@@ -249,7 +257,7 @@ Removing legacy VirtualKeyBoard support:
 	"VirtualKeyboard" entries are used by the old code while 
 	"VirtualKeyBoard" entries are used by the new code.
 
-	* From the buttons directory in the skin delete:
+	From the buttons directory in the skin delete:
 		vkey_all.png
 		vkey_blue.png
 		vkey_clr.png
@@ -264,7 +272,7 @@ Removing legacy VirtualKeyBoard support:
 	Please do not delete any of these images if they are shared by other 
 	skins that continue to support the older VirtualKeyBoard code.
 	
-	* NOTE: The image "vkey_bg.png" is no longer used by the new 
+	NOTE: The image "vkey_bg.png" is no longer used by the new 
 	VirtualKeyBoard but must not be removed as it is used by 
 	"NTIVirtualKeyBoard.pyo"!  When this tool is removed from the 
 	base build the old image can be removed.

--- a/lib/python/Screens/VirtualKeyBoard.py
+++ b/lib/python/Screens/VirtualKeyBoard.py
@@ -57,12 +57,12 @@ class VirtualKeyBoard(Screen, HelpableScreen):
 			VKB_OK_ICON: ("OK", u"ENTERICON"),
 			VKB_SAVE_ICON: ("Save", u"ENTERICON"),
 			VKB_SEARCH_ICON: ("Search", u"ENTERICON"),
-			VKB_DONE_TEXT: ("Done", u"Done"),
-			VKB_ENTER_TEXT: ("Done", u"Enter"),
-			VKB_OK_TEXT: ("OK", u"OK"),
-			VKB_SAVE_TEXT: ("Save", u"Save"),
-			VKB_SEARCH_TEXT: ("Search", u"Search")
-		}.get(style, ("Enter", u"ENTER"))
+			VKB_DONE_TEXT: ("Done", _("Done")),
+			VKB_ENTER_TEXT: ("Done", _("Enter")),
+			VKB_OK_TEXT: ("OK", _("OK")),
+			VKB_SAVE_TEXT: ("Save", _("Save")),
+			VKB_SEARCH_TEXT: ("Search", _("Search"))
+		}.get(style, ("Enter", u"ENTERICON"))
 		self.bg = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_bg.png"))  # Legacy support only!
 		self.bg_l = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_bg_l.png"))
 		self.bg_m = LoadPixmap(path=resolveFilename(SCOPE_CURRENT_SKIN, "buttons/vkey_bg_m.png"))
@@ -457,8 +457,10 @@ class VirtualKeyBoard(Screen, HelpableScreen):
 			"de_DE": [_("German"), _("Germany"), self.german],
 			"de_CH": [_("German"), _("Switzerland"), self.germanSwiss(self.german)],
 			"el_GR": [_("Greek (Modern)"), _("Greece"), self.greek],
-			"lv_LV": [_("Latvian"), _("Latvia"), self.latvian],
-			"lv_EN": [_("Latvian"), _("Standard"), self.latvianStandard(self.english)],
+			"hu_HU": [_("Hungarian"), _("Hungary"), self.hungarian(self.german)],
+			"lv_LL": [_("Latvian"), _("Latvia"), self.latvian],
+			"lv_LV": [_("Latvian"), _("QWERTY"), self.latvianQWERTY(self.english)],
+			"lv_ST": [_("Latvian"), _("Standard"), self.latvianStandard(self.english)],
 			"lt_LT": [_("Lithuanian"), _("Lithuania"), self.lithuanian(self.english)],
 			"nb_NO": [_("Norwegian"), _("Norway"), self.norwegian(self.scandinavian)],
 			"fa_IR": [_("Persian"), _("Iran, Islamic Republic"), self.persian(self.english)],
@@ -677,6 +679,43 @@ class VirtualKeyBoard(Screen, HelpableScreen):
 		keyList[2][3][8] = u""
 		return keyList
 
+	def hungarian(self, base):
+		keyList = copy.deepcopy(base)
+		keyList[0][0][0] = u"0"
+		keyList[0][0][10] = u"\u00F6"
+		keyList[0][0][11] = u"\u00FC"
+		keyList[0][0][12] = u"\u00F3"
+		keyList[0][1][11] = u"\u0151"
+		keyList[0][1][12] = u"\u00FA"
+		keyList[0][1][13] = u"\u0171"
+		keyList[0][2][10] = u"\u00E9"
+		keyList[0][2][11] = u"\u00E1"
+		keyList[0][3][1] = u"\u00ED"
+		keyList[1][0] = [u"\u00A7", u"'", u"\"", u"+", u"!", u"%", u"/", u"=", u"(", u")", u"\u00D6", u"\u00DC", u"\u00D3", u"BACSPACEICON"]
+		keyList[1][1][11] = u"\u0150"
+		keyList[1][1][12] = u"\u00DA"
+		keyList[1][1][13] = u"\u0170"
+		keyList[1][2][10] = u"\u00C9"
+		keyList[1][2][11] = u"\u00C1"
+		keyList[1][3][1] = u"\u00CD"
+		keyList[1][3][9] = u"?"
+		del keyList[2]
+		keyList.append([
+			[u"", u"~", u"\u02C7", u"^", u"\u02D8", u"\u00B0", u"\u02DB", u"`", u"\u02D9", u"\u00B4", u"\u02DD", u"\u00A8", u"\u00B8", u"BACKSPACEICON"],
+			[u"FIRSTICON", u"\\", u"|", u"\u00C4", u"", u"", u"", u"\u20AC", u"\u00CD", u"", u"", u"\u00F7", u"\u00D7", u"\u00A4"],
+			[u"LASTICON", u"\u00E4", u"\u0111", u"\u0110", u"[", u"]", u"", u"\u00ED", u"\u0142", u"\u0141", u"$", u"\u00DF", self.green, self.green],
+			[u"SHIFTICON", u"<", u">", u"#", u"&", u"@", u"{", u"}", u"<", u";", u">", u"*", u"SHIFTICON", u"SHIFTICON"],
+			self.footer
+		])
+		return keyList
+
+	def latvianQWERTY(self, base):
+		keyList = self.latvianStandard(base)
+		keyList[0][1][13] = u"\u00B0"
+		keyList[2][1][9] = u"\u00F5"
+		keyList[3][1][9] = u"\u00D5"
+		return keyList
+
 	def latvianStandard(self, base):
 		keyList = copy.deepcopy(base)
 		keyList[0][3][1] = u"\\"
@@ -691,7 +730,7 @@ class VirtualKeyBoard(Screen, HelpableScreen):
 		keyList.append([
 			[u"", u"", u"", u"", u"\u00A7", u"\u00B0", u"", u"\u00B1", u"\u00D7", u"", u"", u"\u2014", u"", u"BACKSPACEICON"],
 			[u"FIRSTICON", u"", u"", u"\u0112", u"\u0156", u"", u"", u"\u016A", u"\u012A", u"\u014C", u"", u"", u"", u""],
-			[u"LASTICON", u"\u0100", u"\u0160", u"", u"", u"\u0122", u"", u"", u"\u0136", u"\u013B", u"", u"", self.green, self.green],
+			[u"LASTICON", u"\u0100", u"\u0160", u"", u"", u"\u0122", u"", u"", u"\u0136", u"\u013B", u"", u"\u00A8", self.green, self.green],
 			[u"SHIFTICON", u"", u"\u017D", u"", u"\u010C", u"", u"", u"\u0145", u"", u"", u"", u"", u"SHIFTICON", u"SHIFTICON"],
 			self.footer
 		])
@@ -924,7 +963,7 @@ class VirtualKeyBoard(Screen, HelpableScreen):
 					# print "[VirtualKeyBoard] DEBUG: Left=%d, Top=%d, Width=%d, Height=%d, Image Width=%d, Image Height=%d" % (left, top, w, h, wImage, hImage)
 				else:  # Display the cell text.
 					if len(key) > 1:  # NOTE: UTF8 / Unicode glyphs only count as one character here.
-						text.append(MultiContentEntryText(pos=(xData, self.padding[1]), size=(w, h), font=1, flags=alignH | alignV, text=_(key.encode("utf-8")), color=self.shiftColors[self.shiftLevel]))
+						text.append(MultiContentEntryText(pos=(xData, self.padding[1]), size=(w, h), font=1, flags=alignH | alignV, text=key.encode("utf-8"), color=self.shiftColors[self.shiftLevel]))
 					else:
 						text.append(MultiContentEntryText(pos=(xData, self.padding[1]), size=(w, h), font=0, flags=alignH | alignV, text=key.encode("utf-8"), color=self.shiftColors[self.shiftLevel]))
 				highlight = self.keyHighlights.get(key.upper(), (None, None, None))  # Check if the cell needs to be highlighted.


### PR DESCRIPTION
* [VirtualKeyBoard.py] Update languages and translations

    The language changes are:
    -  Add a Hungarian layout to make adoption by OpenATV easier.
    -  Add and make "Latvian - QWERTY" the default keyboard for the "lv_LV" locale.

    The translation change removes the automatic translation of text buffer buttons. All text strings defined in the keymaps will be used EXACTLY as defined. If translation of the text is required then translation must be specifically requested. The documentation has been updated with this change.

    The translation change was made to address a concern that translation strings could not be automatically detected during the translation string harvest process.

* [VIRTUALKEYBOARD] Update documentation

    Update the VirtualKeyBoard documentation to match the latest changes to the code.
