### PR TITLE
[SatFinder] Fix "selecting wrong frontend" bug.

### DIFF
--- a/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
@@ -196,6 +196,7 @@ class Satfinder(ScanSetup, ServiceScan):
 						self.scan_sat.t2mi_plp_id.value = eDVBFrontendParametersSatellite.No_T2MI_PLP_Id
 						self.scan_sat.t2mi_pid.value = eDVBFrontendParametersSatellite.T2MI_Default_Pid
 			elif self.tuning_type.value == "predefined_transponder":
+				self.scan_nims.value = self.satfinder_scan_nims.value
 				self.updatePreDefTransponders()
 				self.preDefTransponderEntry = getConfigListEntry(_("Transponder"), self.preDefTransponders)
 				self.list.append(self.preDefTransponderEntry)


### PR DESCRIPTION
This bug affected "predefined" transponder list content. Only showed when there was a combination of DVB-S2 and DVB-S2X tuners.