### PR TITLE
Add option "Complete disable PiP"

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -84,6 +84,7 @@
 		<item level="2" text="Show picons in display" description="Configure if service picons will be shown in display (when supported by the skin)." requires="HasFrontDisplayPicon">config.usage.show_picon_in_display</item>
 		<item level="2" text="Infobar frontend data source" description="Configure the source of the frontend data as shown on the infobars. 'Settings' is as stored on the settings. 'Tuner' is as reported by the tuner.">config.usage.infobar_frontend_source</item>
 		<item level="2" text="Show SNR percentage instead of dB value" description="By default, SNR will be shown in dB (when supported by the tuner). This setting forces SNR to be shown as a percentage instead.">config.usage.swap_snr_on_osd</item>
+		<item level="2" text="Complete disable PiP" description="Disable the use of PIP completely if your receiver supports it.">config.usage.pip_complete_disable</item>
 		<item level="2" text="Behavior of 0 key in PiP-mode" description="Configure the function of the '0' button do when PIP is active." requires="PIPAvailable">config.usage.pip_zero_button</item>
 		<item level="2" text="Close PiP on exit" description="When enabled the PiP can be closed by the exit button." requires="PIPAvailable">config.usage.pip_hideOnExit</item>
 		<item level="2" text="Remember last service in PiP" description="Configure if and how long the latest service in the PiP will be remembered." requires="PIPAvailable">config.usage.pip_last_service_timeout</item>

--- a/lib/python/Components/SystemInfo.py
+++ b/lib/python/Components/SystemInfo.py
@@ -7,6 +7,8 @@ import os
 SystemInfo = {}
 
 def getNumVideoDecoders():
+	if os.system("grep -q config.usage.pip_complete_disable=true /etc/enigma2/settings") == 0:
+		return 0
 	number_of_video_decoders = 0
 	while fileExists("/dev/dvb/adapter0/video%d" % (number_of_video_decoders), 'f'):
 		number_of_video_decoders += 1

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -99,6 +99,7 @@ def InitUsageConfig():
 	config.usage.output_12V = ConfigSelection(default = "do not change", choices = [
 		("do not change", _("Do not change")), ("off", _("Off")), ("on", _("On")) ])
 
+	config.usage.pip_complete_disable = ConfigYesNo(default=False)
 	config.usage.pip_zero_button = ConfigSelection(default = "standard", choices = [
 		("standard", _("Standard")), ("swap", _("Swap PiP and main picture")),
 		("swapstop", _("Move PiP to main picture")), ("stop", _("Stop PiP")) ])


### PR DESCRIPTION
Simple users, especially with children, the picture-in-picture function
is simply not needed.
When "Complete disable PiP" option is activated, the start buttons of
the PIP will be hidden after restarting the GUI.