### PR TITLE
Fix multiboot selection when using non-PLi images

### DIFF
--- a/lib/python/Screens/FlashImage.py
+++ b/lib/python/Screens/FlashImage.py
@@ -482,6 +482,8 @@ class MultibootSelection(SelectImage):
 				shutil.copyfile("/tmp/startupmount/STARTUP_LINUX_%s_BOXMODE_12" % slot, "/tmp/startupmount/STARTUP")
 		elif os.path.isfile("/tmp/startupmount/STARTUP_LINUX_4"):
 			shutil.copyfile("/tmp/startupmount/STARTUP_LINUX_%s" % slot, "/tmp/startupmount/STARTUP")
+		elif os.path.isfile("/tmp/startupmount/STARTUP_4"):
+			shutil.copyfile("/tmp/startupmount/STARTUP_%s" % slot, "/tmp/startupmount/STARTUP")
 		else:
 			if slot < 12:
 				startupFileContents = "boot emmcflash0.kernel%s 'root=/dev/mmcblk0p%s rw rootwait %s_4.boxmode=1'\n" % (slot, slot * 2 + 1, model)


### PR DESCRIPTION
OE-A images use different STARTUP filenames.
STARTUP_X is e.g. used for hd51, h7,...

STARTUP_LINUX_X is still necessary as h9combo uses it.