### PR TITLE
Make CA PMT handling more compatible to EN 50221 standard

### DIFF
--- a/lib/dvb/cahandler.cpp
+++ b/lib/dvb/cahandler.cpp
@@ -589,8 +589,8 @@ int eDVBCAService::buildCAPMT(eTable<ProgramMapSection> *ptr)
 	build_hash |= (demux_mask & 0xff);
 	build_hash <<= 8;
 	build_hash |= (pmt_version & 0xff);
-	build_hash <<= 16;
-	build_hash |= (m_service_type_mask & 0xffff);
+	//build_hash <<= 16;
+	//build_hash |= (m_service_type_mask & 0xffff); // don't include in build_hash
 
 	bool scrambled = false;
 	for (std::vector<ProgramMapSection*>::const_iterator pmt = ptr->getSections().begin();
@@ -762,8 +762,8 @@ int eDVBCAService::buildCAPMT(ePtr<eDVBService> &dvbservice)
 	build_hash |= (demux_mask & 0xff);
 	build_hash <<= 8;
 	build_hash |= (pmt_version & 0xff);
-	build_hash <<= 16;
-	build_hash |= (m_service_type_mask & 0xffff);
+	//build_hash <<= 16;
+	//build_hash |= (m_service_type_mask & 0xffff); // don't include in build_hash
 
 	int pos = 0;
 	int programInfoLength = 0;

--- a/lib/dvb/cahandler.cpp
+++ b/lib/dvb/cahandler.cpp
@@ -308,7 +308,7 @@ int eDVBCAHandler::registerService(const eServiceReferenceDVB &ref, int adapter,
 	return 0;
 }
 
-int eDVBCAHandler::unregisterService(const eServiceReferenceDVB &ref, int adapter, int demux_nums[2], eTable<ProgramMapSection> *ptr)
+int eDVBCAHandler::unregisterService(const eServiceReferenceDVB &ref, int adapter, int demux_nums[2], int servicetype, eTable<ProgramMapSection> *ptr)
 {
 	CAServiceMap::iterator it = services.find(ref);
 	if (it == services.end())
@@ -319,6 +319,8 @@ int eDVBCAHandler::unregisterService(const eServiceReferenceDVB &ref, int adapte
 	else
 	{
 		eDVBCAService *caservice = it->second;
+		caservice->removeServiceType(servicetype);
+
 		int loops = demux_nums[0] != demux_nums[1] ? 2 : 1;
 		for (int i = 0; i < loops; ++i)
 		{
@@ -537,6 +539,11 @@ void eDVBCAService::setAdapter(uint8_t value)
 void eDVBCAService::addServiceType(int type)
 {
 	m_service_type_mask |= (1 << type);
+}
+
+void eDVBCAService::removeServiceType(int type)
+{
+	m_service_type_mask ^= (1 << type);
 }
 
 void eDVBCAService::connectionLost()

--- a/lib/dvb/cahandler.h
+++ b/lib/dvb/cahandler.h
@@ -122,6 +122,7 @@ public:
 	uint8_t getAdapter();
 	void setAdapter(uint8_t value);
 	void addServiceType(int type);
+	void removeServiceType(int type);
 	void sendCAPMT();
 	int writeCAPMTObject(eSocket *socket, int list_management = -1);
 	int buildCAPMT(eTable<ProgramMapSection> *ptr);
@@ -175,7 +176,7 @@ public:
 	~eDVBCAHandler();
 
 	int registerService(const eServiceReferenceDVB &service, int adapter, int demux_nums[2], int servicetype, eDVBCAService *&caservice);
-	int unregisterService(const eServiceReferenceDVB &service , int adapter, int demux_nums[2], eTable<ProgramMapSection> *ptr);
+	int unregisterService(const eServiceReferenceDVB &service, int adapter, int demux_nums[2], int servicetype, eTable<ProgramMapSection> *ptr);
 	void handlePMT(const eServiceReferenceDVB &service, ePtr<eTable<ProgramMapSection> > &ptr);
 	void handlePMT(const eServiceReferenceDVB &service, ePtr<eDVBService> &dvbservice);
 	void connectionLost(ePMTClient *client);

--- a/lib/dvb/cahandler.h
+++ b/lib/dvb/cahandler.h
@@ -175,6 +175,7 @@ public:
 #ifndef SWIG
 	~eDVBCAHandler();
 
+	int getNumberOfCAServices();
 	int registerService(const eServiceReferenceDVB &service, int adapter, int demux_nums[2], int servicetype, eDVBCAService *&caservice);
 	int unregisterService(const eServiceReferenceDVB &service, int adapter, int demux_nums[2], int servicetype, eTable<ProgramMapSection> *ptr);
 	void handlePMT(const eServiceReferenceDVB &service, ePtr<eTable<ProgramMapSection> > &ptr);

--- a/lib/dvb/pmt.cpp
+++ b/lib/dvb/pmt.cpp
@@ -1016,7 +1016,7 @@ void eDVBServicePMTHandler::free()
 			demuxes[1]=demuxes[0];
 		ePtr<eTable<ProgramMapSection> > ptr;
 		m_PMT.getCurrent(ptr);
-		eDVBCAHandler::getInstance()->unregisterService(m_reference, adapterid, demuxes, ptr);
+		eDVBCAHandler::getInstance()->unregisterService(m_reference, adapterid, demuxes, (int)m_service_type, ptr);
 		m_ca_servicePtr = 0;
 	}
 


### PR DESCRIPTION
The CA PMT handler currently supports two modes. An older one where enigma2 is the client and the softcam is the server, and a newer one that enigma2 is the server and the softcam is the client, [with many advantages](https://mediawiki.openpli.org/caPMT).

The newer CA PMT interface is based on the [EN 50221](https://www.dvb.org/resources/public/standards/En50221.V1.pdf) standard, but it's far from complete (feature wise). In addition, there are some basic differences in regard to when the CA PMT server is supposed to send CA PMT objects and what CA PMT list commands should be sent each time.

According to p.31 of the EN 50221 document linked above, it is explained when and what CA PMT commands should be sent in different scenarios. The same is also explained in p.20 of the [implementation guidelines of the CA PMT interface](https://www.dvb.org/resources/public/standards/R206-001.V1.pdf), while in p. 43 this is also demonstrated in a graphical way.

According to the specs, enigma2 should send a CA PMT command when the user selects another channel (zap) or when some parameters in the PMT of the current channel are changed (indicated by the PMT version_number and current_next_indicator changes), or when a channel is completely removed from the list of active services.

This means that a change in the service type of the current channel (e.g. when the user adds a recording to a channel he's already watching) should not trigger a CA PMT command. Until now enigma2 used to send a CA PMT "UPDATE" command when adding a recording while watching the channel, and used to send a new list of CA PMT objects when removing a service type (e.g. when stopping a recording while watching the channel). This is not done anymore.

In addition, when there is one or more open channels (e.g. one or more live tv channels, one live tv and a recording of a different channel, etc.) and one more channel is selected by the user, the CA PMT server should not send a new list of CA PMT objects. Instead, it should send an "ADD" CA PMT command with just the new channel. This would result in all previously selected channels to remain as they are (active). This is also fixed now.

To summarize, this patch changes the cahandler so it behaves more closely to the standard by sending less CA PMT commands (only when necessary) and also the correct ones.