### PR TITLE
[Plugin] fix possible BSOD

### DIFF
--- a/lib/python/Plugins/Plugin.py
+++ b/lib/python/Plugins/Plugin.py
@@ -96,7 +96,7 @@ class PluginDescriptor:
 
 	@property
 	def icon(self):
-		if self.iconstr:
+		if self.iconstr and self.path:
 			from Tools.LoadPixmap import LoadPixmap
 			return LoadPixmap(os.path.join(self.path, self.iconstr))
 		else:


### PR DESCRIPTION
E.g. Enable/show epgrefresh in plugins without restart

(cherry picked from commit 5216f2141f2f786c6b12b0cdffb50c1f532a780f)

<  1194.274>   File "/usr/lib/enigma2/python/Components/ActionMap.py", line 71, in action
<  1194.274>   File "/usr/lib/enigma2/python/Components/ActionMap.py", line 51, in action
<  1194.274>   File "/usr/lib/enigma2/python/Screens/Menu.py", line 60, in okbuttonClick
<  1194.275>   File "/usr/lib/enigma2/python/Tools/BoundFunction.py", line 9, in __call__
<  1194.275>   File "/usr/lib/enigma2/python/Screens/Menu.py", line 74, in runScreen
<  1194.275>   File "/usr/lib/enigma2/python/Screens/Menu.py", line 80, in openDialog
<  1194.275>   File "/usr/lib/enigma2/python/mytest.py", line 320, in openWithCallback
<  1194.276>     dlg = self.open(screen, *arguments, **kwargs)
<  1194.276>   File "/usr/lib/enigma2/python/mytest.py", line 333, in open
<  1194.276>     self.execBegin()
<  1194.276>   File "/usr/lib/enigma2/python/mytest.py", line 248, in execBegin
<  1194.278>     c.execBegin()
<  1194.278>   File "/usr/lib/enigma2/python/Screens/Screen.py", line 98, in execBegin
<  1194.278>   File "/usr/lib/enigma2/python/Screens/PluginBrowser.py", line 231, in updateList
<  1194.278>   File "/usr/lib/enigma2/python/Screens/PluginBrowser.py", line 231, in <genexpr>
<  1194.278> TypeError: 'NoneType' object has no attribute '__getitem__'
<  1194.279> [ePyObject] (CallObject(<bound method NumberActionMap.action of <Components.ActionMap.NumberActionMap instance at 0xb1803c60>>,('OkCancelActions', 'ok')) failed)