### PR TITLE
NimManager.py: add new method "getNimListForSat".

### DIFF
--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -1070,6 +1070,9 @@ class NimManager:
 								list.append(user_sat)
 		return list
 
+	def getNimListForSat(self, orb_pos):
+		return [nim.slot for nim in self.nim_slots if nim.isCompatible("DVB-S") and not nim.isFBCLink() and orb_pos in [sat[0] for sat in self.getSatListForNim(nim.slot)]]
+
 	def getRotorSatListForNim(self, slotid):
 		list = []
 		if self.nim_slots[slotid].isCompatible("DVB-S"):


### PR DESCRIPTION
Returns a list of tuners available for the orbital position given as the argument.
e.g. find all the tuners that can tune Astra 1...
nimmanager.getNimListForSat(192)