### PR TITLE
[ServiceInfo] fix when not play service

### DIFF
--- a/lib/python/Screens/ServiceInfo.py
+++ b/lib/python/Screens/ServiceInfo.py
@@ -221,8 +221,8 @@ class ServiceInfo(Screen):
 
 	def getTrackList(self):
 		trackList = []
-		currentTrack = self.audio and self.audio.getCurrentTrack()
 		if self.numberofTracks:
+			currentTrack = self.audio.getCurrentTrack()
 			for i in range(0, self.numberofTracks):
 				audioDesc = self.audio.getTrackInfo(i).getDescription()
 				audioPID = self.audio.getTrackInfo(i).getPID()

--- a/lib/python/Screens/ServiceInfo.py
+++ b/lib/python/Screens/ServiceInfo.py
@@ -221,7 +221,7 @@ class ServiceInfo(Screen):
 
 	def getTrackList(self):
 		trackList = []
-		currentTrack = self.audio.getCurrentTrack()
+		currentTrack = self.audio and self.audio.getCurrentTrack()
 		if self.numberofTracks:
 			for i in range(0, self.numberofTracks):
 				audioDesc = self.audio.getTrackInfo(i).getDescription()


### PR DESCRIPTION
File "/usr/lib/enigma2/python/Screens/Screen.py", line 93, in execBegin

File "/usr/lib/enigma2/python/Screens/ServiceInfo.py", line 190, in
ShowServiceInformation
  File
"/usr/lib/enigma2/python/Screens/ServiceInfo.py", line 224, in
getTrackList
AttributeError: 'NoneType' object has no attribute
'getCurrentTrack'