### PR TITLE
[Directories.py] Revert "#" separator workaround

### DIFF
--- a/lib/python/Tools/Directories.py
+++ b/lib/python/Tools/Directories.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import os
-import re
 
 from enigma import eEnv, getDesktop
 from re import compile
@@ -89,11 +88,7 @@ def resolveFilename(scope, base="", path_prefix=None):
 			return None
 	# Remove any suffix data and restore it at the end.
 	suffix = None
-	# This is a hack to get around OpenPLi using "#" as suffix separator. "#" is 
-	# also a perfectly valid and common filename character. This hack should be 
-	# removed when OpenPLi switch to using the more common ":".
-	# data = base.split(":", 1)
-	data = re.split("[:#]", base, 1)
+	data = base.split(":", 1)
 	if len(data) > 1:
 		base = data[0]
 		suffix = data[1]


### PR DESCRIPTION
This patch resulted from an incorrect understanding of the actual problem.  The real issue was that some important images were specified to be in a shared location that is not in the normal search list.  I believe that the images do not exist in the nominated location.

The original issue can be corrected by placing the images at the specified location or else allowing the normal "Directories.py" logic to find the images in one of the standard locations.
