### PR TITLE
scan.cpp: Sky UK EPG channel, switch "servicetype==1"

### DIFF
--- a/lib/dvb/scan.cpp
+++ b/lib/dvb/scan.cpp
@@ -1521,6 +1521,7 @@ RESULT eDVBScan::processSDT(eDVBNamespace dvbnamespace, const ServiceDescription
 					{
 					/* DISH/BEV servicetypes: */
 					case 128:
+					case 131: /*Sky UK OpenTV EPG channel */ 
 					case 133:
 					case 137:
 					case 144:


### PR DESCRIPTION
This channel must be zapped to start OpenTV download so must be shown in the channel list.

It can then be added in EPG Refresh plugin or used for a manual EPG download.