### PR TITLE
config: add lower case to "show on/off button in multiple selections"

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -367,7 +367,7 @@ class ConfigSelection(ConfigElement):
 		from config import config
 		from skin import switchPixmap
 		if self.graphic and config.usage.boolean_graphic.value and switchPixmap.get("menu_on", False) and switchPixmap.get("menu_off", False):
-			boolvalue = self._descr in (_('True'),_('Yes'),_('Enabled'),_('On')) or (False if self._descr in (_('False'),_('No'),_("Disable"),_('Disabled'),_('Off'), _("None")) else None)
+			boolvalue = self._descr in (_('True'),_('true'),_('Yes'),_('yes'),_('Enable'),_('enable'),_('Enabled'),_('enabled'),_('On'),_('on')) or (False if self._descr in (_('False'),_('false'),_('No'),_('no'),_("Disable"),_('disable'),_('Disabled'),_('disabled'),_('Off'),_('off'),_('None'),_('none')) else None)
 			if boolvalue is not None:
 				return ('pixmap', switchPixmap["menu_on" if boolvalue else "menu_off"])
 		return ("text", self._descr)


### PR DESCRIPTION
This adds lower case versions of the keywords used for displaying the graphical sliders in ConfigSelection. These are found in various plugins, etc.

Also adds "Enable" to complement "Disable".