### PR TITLE
config.py: Ignore case sensitive when checking for answers, this adds…

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -367,7 +367,7 @@ class ConfigSelection(ConfigElement):
 		from config import config
 		from skin import switchPixmap
 		if self.graphic and config.usage.boolean_graphic.value and switchPixmap.get("menu_on", False) and switchPixmap.get("menu_off", False):
-			boolvalue = self._descr in (_('True'),_('Yes'),_('Enabled'),_('On')) or (False if self._descr in (_('False'),_('No'),_("Disable"),_('Disabled'),_('Off'), _("None")) else None)
+			boolvalue = self._descr.lower() in ('true','yes','enable','enabled','on') or (False if self._descr.lower() in ('false','no','disable','disabled','off','none') else None)
 			if boolvalue is not None:
 				return ('pixmap', switchPixmap["menu_on" if boolvalue else "menu_off"])
 		return ("text", self._descr)


### PR DESCRIPTION
… lower case versions of the keywords used for displaying the graphical sliders in ConfigSelection. These are found in various plugins, etc.

Also adds enable to complement disable, Thanks to Huevos