### PR TITLE
[ServiceInfo] Do not embed color in python code

### DIFF
--- a/lib/python/Screens/ServiceInfo.py
+++ b/lib/python/Screens/ServiceInfo.py
@@ -386,8 +386,7 @@ class ServiceInfo(Screen):
 						extra_info = "extra data=%s" % caid[2]
 				from Tools.GetEcmInfo import GetEcmInfo
 				ecmdata = GetEcmInfo().getEcmData()
-				color = "\c00??;?00" if caid[0] == int(ecmdata[1], 16) and (caid[1] == int(ecmdata[3], 16) or str(int(ecmdata[2], 16)) in provid) else ""
-				tlist.append(ServiceInfoListEntry("%sECMPid %04X (%d) %04X-%s %s" % (color, caid[1], caid[1], caid[0], CaIdDescription, extra_info)))
+				tlist.append(ServiceInfoListEntry("ECMPid %04X (%d) %04X-%s %s" % (caid[1], caid[1], caid[0], CaIdDescription, extra_info)))
 			if not tlist:
 				tlist.append(ServiceInfoListEntry(_("No ECMPids available (FTA Service)")))
 			self["infolist"].l.setList(tlist)


### PR DESCRIPTION
In service info, when pressing the green button, the ecm info is showing in yellow/orange color. This is because the color in embedded in the python code. So, instead of setting a color in the code, we should allow skins to determine what color to use.

After this change, skins will continue to work perfectly fine and the ecm info will be displayed in whatever color is already selected for the service info screen.