### PR TITLE
[ServiceInfo] Use text instead of color for indicating active ecm pids

### DIFF
--- a/lib/python/Screens/ServiceInfo.py
+++ b/lib/python/Screens/ServiceInfo.py
@@ -386,8 +386,8 @@ class ServiceInfo(Screen):
 						extra_info = "extra data=%s" % caid[2]
 				from Tools.GetEcmInfo import GetEcmInfo
 				ecmdata = GetEcmInfo().getEcmData()
-				color = "\c00??;?00" if caid[0] == int(ecmdata[1], 16) and (caid[1] == int(ecmdata[3], 16) or str(int(ecmdata[2], 16)) in provid) else ""
-				tlist.append(ServiceInfoListEntry("%sECMPid %04X (%d) %04X-%s %s" % (color, caid[1], caid[1], caid[0], CaIdDescription, extra_info)))
+				active = _("(currently active)") if caid[0] == int(ecmdata[1], 16) and (caid[1] == int(ecmdata[3], 16) or str(int(ecmdata[2], 16)) in provid) else ""
+				tlist.append(ServiceInfoListEntry("ECMPid %04X (%d) %04X-%s %s %s" % (caid[1], caid[1], caid[0], CaIdDescription, extra_info, active)))
 			if not tlist:
 				tlist.append(ServiceInfoListEntry(_("No ECMPids available (FTA Service)")))
 			self["infolist"].l.setList(tlist)


### PR DESCRIPTION
Embedding colors in python means that skins have no control on them.
This change adds a text string next to the active ecm pid, instead of using a different display color.

Skins need no changes as all.

This is how it will look like after this change:

![1_0_1_C1D_1E78_71_820000_0_0_0_20190910192138](https://user-images.githubusercontent.com/1540233/64632142-332aa780-d401-11e9-819f-1e3ec3e6ae16.jpg)
