### PR TITLE
[ChoiceList.py] Fix text position when no icon is used

### DIFF
--- a/lib/python/Components/ChoiceList.py
+++ b/lib/python/Components/ChoiceList.py
@@ -10,9 +10,9 @@ def ChoiceEntryComponent(key = None, text = ["--"]):
 		x, y, w, h = skin.parameters.get("ChoicelistDash",(0, 0, 800, 25))
 		res.append((eListboxPythonMultiContent.TYPE_TEXT, x, y, w, h, 0, RT_HALIGN_LEFT, "-"*200))
 	else:
-		x, y, w, h = skin.parameters.get("ChoicelistName",(45, 0, 800, 25))
-		res.append((eListboxPythonMultiContent.TYPE_TEXT, x, y, w, h, 0, RT_HALIGN_LEFT, text[0]))
 		if key:
+			x, y, w, h = skin.parameters.get("ChoicelistName",(45, 0, 800, 25))
+			res.append((eListboxPythonMultiContent.TYPE_TEXT, x, y, w, h, 0, RT_HALIGN_LEFT, text[0]))
 			if key == "expandable":
 				png = LoadPixmap(resolveFilename(SCOPE_CURRENT_SKIN, "icons/expandable.png"))
 			elif key == "expanded":
@@ -26,6 +26,9 @@ def ChoiceEntryComponent(key = None, text = ["--"]):
 			if png:
 				x, y, w, h = skin.parameters.get("ChoicelistIcon",(5, 0, 35, 25))
 				res.append((eListboxPythonMultiContent.TYPE_PIXMAP_ALPHABLEND, x, y, w, h, png))
+		else:
+			x, y, w, h = skin.parameters.get("ChoicelistNameSingle",(5, 0, 800, 25))
+			res.append((eListboxPythonMultiContent.TYPE_TEXT, x, y, w, h, 0, RT_HALIGN_LEFT, text[0]))
 	return res
 
 class ChoiceList(MenuList):

--- a/skin.py
+++ b/skin.py
@@ -499,6 +499,7 @@ def loadSingleSkinData(desktop, skin, path_prefix):
 					parameters["FileListMultiLock"] = (2,0,36,36)
 					parameters["ChoicelistDash"] = (0,3,1000,30)
 					parameters["ChoicelistName"] = (68,3,1000,30)
+					parameters["ChoicelistNameSingle"] = (7,3,1000,30)
 					parameters["ChoicelistIcon"] = (7,0,52,38)
 					parameters["PluginBrowserName"] = (180,8,38)
 					parameters["PluginBrowserDescr"] = (180,42,25)


### PR DESCRIPTION
In Choicelist, there is an option to create it with an icon on the left. This could be the "expandable", "expanded", "verticalline" or "key_%s" icon.
The position of the icon and the list text are controlled by the "ChoicelistIcon" and the "ChoicelistName" skin parameters. So far, so good.

A choicelist can also be created without any icon at all, when the "ChoiceEntryComponent" function is called with "key=None".
In this case, the list text is aligned more to the right, leaving space for the non present icon. This is not pretty.

This commit adds a new skin parameter called "ChoicelistNameSingle" to control the position of the list text when the list is created with "key=None".
It also restricts the effect of the existing "ChoicelistName" parameter to only when "key" is not "None".

Example of what this change does...

In the HotkeySetup screen, there is a choicelist created with no icon on the left, but there is space for it which cannot be controlled (pic. 1). With this commit, the space can be controlled, so we can position the text more to the left (pic. 2). This can be done with the new "ChoicelistNameSingle" skin parameter.

On the other hand when an icon in used in the choicelist (e.g. in the HotkeySetupSelect screen) there is no change and the icon and text are positioned like before (pic. 3).

![1_0_1_C1D_1E78_71_820000_0_0_0_20190919135642](https://user-images.githubusercontent.com/1540233/65240748-a2cc2100-daea-11e9-86ba-dc7d92116856.jpg)
![1_0_1_C1D_1E78_71_820000_0_0_0_20190919135003](https://user-images.githubusercontent.com/1540233/65240736-9cd64000-daea-11e9-9cde-b697a215203d.jpg)
![1_0_1_C1D_1E78_71_820000_0_0_0_20190919134906](https://user-images.githubusercontent.com/1540233/65240716-947e0500-daea-11e9-9ba2-fd177461169f.jpg)


