### PR TITLE
Fix ChoiceList alignment in mixed lists like the "ChannelContextMenu" screen

### DIFF
--- a/lib/python/Components/ChoiceList.py
+++ b/lib/python/Components/ChoiceList.py
@@ -13,7 +13,9 @@ def ChoiceEntryComponent(key = None, text = ["--"]):
 		if key:
 			x, y, w, h = skin.parameters.get("ChoicelistName",(45, 0, 800, 25))
 			res.append((eListboxPythonMultiContent.TYPE_TEXT, x, y, w, h, 0, RT_HALIGN_LEFT, text[0]))
-			if key == "expandable":
+			if key == "dummy":
+				png = None
+			elif key == "expandable":
 				png = LoadPixmap(resolveFilename(SCOPE_CURRENT_SKIN, "icons/expandable.png"))
 			elif key == "expanded":
 				png = LoadPixmap(resolveFilename(SCOPE_CURRENT_SKIN, "icons/expanded.png"))

--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -106,7 +106,10 @@ EDIT_ALTERNATIVES = 2
 
 def append_when_current_valid(current, menu, args, level=0, key=""):
 	if current and current.valid() and level <= config.usage.setup_level.index:
-		menu.append(ChoiceEntryComponent(key, args))
+		if key:
+			menu.append(ChoiceEntryComponent(key, args))
+		else:
+			menu.append(ChoiceEntryComponent("dummy", args))
 
 def removed_userbouquets_available():
 	for file in os.listdir("/etc/enigma2/"):
@@ -245,7 +248,7 @@ class ChannelContextMenu(Screen):
 							append_when_current_valid(current, menu, (_("add bouquet to parental protection"), boundFunction(self.addParentalProtection, current)), level=0)
 						else:
 							append_when_current_valid(current, menu, (_("remove bouquet from parental protection"), boundFunction(self.removeParentalProtection, current)), level=0)
-					menu.append(ChoiceEntryComponent(text=(_("add bouquet"), self.showBouquetInputBox)))
+					menu.append(ChoiceEntryComponent("dummy", (_("add bouquet"), self.showBouquetInputBox)))
 					append_when_current_valid(current, menu, (_("rename entry"), self.renameEntry), level=0, key="2")
 					append_when_current_valid(current, menu, (_("remove entry"), self.removeEntry), level=0, key="8")
 					self.removeFunction = self.removeBouquet
@@ -260,7 +263,7 @@ class ChannelContextMenu(Screen):
 					append_when_current_valid(current, menu, (_("enable move mode"), self.toggleMoveMode), level=0, key="6")
 				if not csel.entry_marked and not inBouquetRootList and current_root and not (current_root.flags & eServiceReference.isGroup):
 					if current.type != -1:
-						menu.append(ChoiceEntryComponent(text=(_("add marker"), self.showMarkerInputBox)))
+						menu.append(ChoiceEntryComponent("dummy", (_("add marker"), self.showMarkerInputBox)))
 					if not csel.movemode:
 						if haveBouquets:
 							append_when_current_valid(current, menu, (_("enable bouquet edit"), self.bouquetMarkStart), level=0)


### PR DESCRIPTION
After my previous change https://github.com/OpenPLi/enigma2/commit/5456c1daccb6c47f07e84215da589472970f332d (that allows a different position for choicelists without icons - see PR https://github.com/OpenPLi/enigma2/pull/2278), there is an issue with choicelists where some of the entries have icons and some don't, like in the ChannelContextMenu screen. In such choicelists, the alignment of the list entries is not proper.

This change-set, allows entries of such mixed choicelists to be created with space on the left (when "dummy" key is used), as if all entries had icons, so the choicelist is properly aligned.

See pictures before (pic. 1) versus after (pic. 2) this fix:

![1_0_1_28_2_212C_1860000_0_0_0_20190920205420](https://user-images.githubusercontent.com/1540233/65348551-23257b80-dbea-11e9-83f0-a12f26c1b954.jpg)
![1_0_1_28_2_212C_1860000_0_0_0_20190920203318](https://user-images.githubusercontent.com/1540233/65348558-27ea2f80-dbea-11e9-88cc-4682c8a874ba.jpg)
