### PR TITLE
[ServiceInfo.py] Fix crash in ecm pid info

### DIFF
--- a/lib/python/Screens/ServiceInfo.py
+++ b/lib/python/Screens/ServiceInfo.py
@@ -386,7 +386,7 @@ class ServiceInfo(Screen):
 						extra_info = "extra data=%s" % caid[2]
 				from Tools.GetEcmInfo import GetEcmInfo
 				ecmdata = GetEcmInfo().getEcmData()
-				formatstring = "ECMPid %04X (%d) %04X-%s %s (%s)" % _("used") if caid[0] == int(ecmdata[1], 16) and (caid[1] == int(ecmdata[3], 16) or str(int(ecmdata[2], 16)) in provid) else "ECMPid %04X (%d) %04X-%s %s"
+				formatstring = "ECMPid %04X (%d) %04X-%s %s " + _("(used)") if caid[0] == int(ecmdata[1], 16) and (caid[1] == int(ecmdata[3], 16) or str(int(ecmdata[2], 16)) in provid) else "ECMPid %04X (%d) %04X-%s %s"
 				tlist.append(ServiceInfoListEntry(formatstring % (caid[1], caid[1], caid[0], CaIdDescription, extra_info)))
 			if not tlist:
 				tlist.append(ServiceInfoListEntry(_("No ECMPids available (FTA Service)")))


### PR DESCRIPTION
The "used" string is meant to replace the last %s, but instead it replaces the first %04X and causes a crash. The bug was introduced in commit https://github.com/OpenPLi/enigma2/commit/7b5907cc9eb5dff63bebe9f8e81e55f760e5cc7a


Reported by @68foxboris 11 days ago...

```
Traceback (most recent call last):
File "/usr/lib/enigma2/python/Components/ActionMap.py", line 57, in action
File "/usr/lib/enigma2/python/Screens/ServiceInfo.py", line 389, in ShowECMInformation
TypeError: %X format: a number is required, not str
```