### PR TITLE
Fix entry alignment in the MovieContextMenu list

### DIFF
--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -104,12 +104,9 @@ OFF = 0
 EDIT_BOUQUET = 1
 EDIT_ALTERNATIVES = 2
 
-def append_when_current_valid(current, menu, args, level=0, key=""):
+def append_when_current_valid(current, menu, args, level=0, key="dummy"):
 	if current and current.valid() and level <= config.usage.setup_level.index:
-		if key:
-			menu.append(ChoiceEntryComponent(key, args))
-		else:
-			menu.append(ChoiceEntryComponent("dummy", args))
+		menu.append(ChoiceEntryComponent(key, args))
 
 def removed_userbouquets_available():
 	for file in os.listdir("/etc/enigma2/"):

--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -388,7 +388,7 @@ class MovieContextMenu(Screen, ProtectedScreen):
 				"8": boundFunction(self.close, csel.do_delete),
 			})
 
-		def append_to_menu(menu, args, key=""):
+		def append_to_menu(menu, args, key="dummy"):
 			menu.append(ChoiceEntryComponent(key, args))
 
 		menu = []


### PR DESCRIPTION
This is similar to the ChannelContextMenu fix in PR https://github.com/OpenPLi/enigma2/pull/2279, but this time for the MovieContextMenu (displayed with PVR->MENU).

Also I made a slightly cleaner fix for the ChannelContextMenu.