### PR TITLE
[TimeDateInput.py] Use of proper names for colored buttons

### DIFF
--- a/data/skin_default.xml
+++ b/data/skin_default.xml
@@ -1217,10 +1217,10 @@ self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth)/2, orgpos.y() + (or
 	</screen>
 	<!-- Time & date input -->
 	<screen name="TimeDateInput" position="center,center" size="400,200" title="Date/time input">
-		<widget name="cancel" pixmap="buttons/red.png" position="10,0" size="140,40" alphatest="on"/>
-		<widget name="ok" pixmap="buttons/green.png" position="250,0" size="140,40" alphatest="on"/>
-		<widget name="canceltext" position="10,0" zPosition="1" size="140,40" font="Regular;19" halign="center" valign="center" transparent="1"/>
-		<widget name="oktext" position="250,0" zPosition="1" size="140,40" font="Regular;19" halign="center" valign="center" transparent="1"/>
+		<ePixmap pixmap="buttons/red.png" position="10,0" size="140,40" alphatest="on"/>
+		<ePixmap pixmap="buttons/green.png" position="250,0" size="140,40" alphatest="on"/>
+		<widget source="key_red" render="Label" position="10,0" zPosition="1" size="140,40" font="Regular;19" halign="center" valign="center" transparent="1"/>
+		<widget source="key_green" render="Label" position="250,0" zPosition="1" size="140,40" font="Regular;19" halign="center" valign="center" transparent="1"/>
 		<widget name="config" position="10,40" size="380,150"/>
 	</screen>
 	<!-- Timer edit -->

--- a/lib/python/Screens/TimeDateInput.py
+++ b/lib/python/Screens/TimeDateInput.py
@@ -2,8 +2,7 @@ from Screen import Screen
 from Components.config import ConfigClock, ConfigDateTime, getConfigListEntry
 from Components.ActionMap import NumberActionMap
 from Components.ConfigList import ConfigListScreen
-from Components.Label import Label
-from Components.Pixmap import Pixmap
+from Components.Sources.StaticText import StaticText
 import time
 import datetime
 
@@ -11,17 +10,17 @@ class TimeDateInput(Screen, ConfigListScreen):
 	def __init__(self, session, config_time=None, config_date=None):
 		Screen.__init__(self, session)
 		self.setTitle(_("Date/time input"))
-		self["oktext"] = Label(_("OK"))
-		self["canceltext"] = Label(_("Cancel"))
-		self["ok"] = Pixmap()
-		self["cancel"] = Pixmap()
+		self["key_red"] = StaticText(_("Cancel"))
+		self["key_green"] = StaticText(_("OK"))
 
 		self.createConfig(config_date, config_time)
 
-		self["actions"] = NumberActionMap(["SetupActions"],
+		self["actions"] = NumberActionMap(["SetupActions", "OkCancelActions", "ColorActions"],
 		{
-			"ok": self.keySelect,
+			"ok": self.keyGo,
+			"green": self.keyGo,
 			"save": self.keyGo,
+			"red": self.keyCancel,
 			"cancel": self.keyCancel,
 		}, -2)
 
@@ -61,9 +60,6 @@ class TimeDateInput(Screen, ConfigListScreen):
 		if sel and sel[1] == self.timeinput_time:
 			self.timeinput_time.increment()
 			self["config"].invalidateCurrent()
-
-	def keySelect(self):
-		self.keyGo()
 
 	def getTimestamp(self, date, mytime):
 		d = time.localtime(date)


### PR DESCRIPTION
Colored buttons should be named "key_red" and "key_green" and use StaticText.
Default skin is updated to reflect the changes.
Modern third-party skins using automatic buttons should not have any problems with this change.

In addition, the use of the "TimeDateInput" class is pretty limited (it is used in only 2 or 3 cases) throughout the code of enigma2, so it won't be a disaster for old and unsupported skins.