### PR TITLE
Renamed ALL "upgrade" strings to "update"

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -37,7 +37,7 @@
 		<item level="2" text="Wake On LAN" description="When enabled the set top box is able to wakeup on LAN" requires="WakeOnLAN">config.usage.wakeOnLAN</item>
 		<item level="1" text="Startup to Standby" description="Startup the set top box in standby">config.usage.startup_to_standby</item>
 		<item level="2" text="Config resolution of pictures" description="configure in which resolution pictures are displayed with the picture viewer and movieplayer">config.usage.pic_resolution</item>
-		<item level="2" text="Load unlinked userbouquets" description="When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded">config.misc.load_unlinked_userbouquets</item>
+		<item level="2" text="Load unlinked userbouquets" description="When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated">config.misc.load_unlinked_userbouquets</item>
 		<item level="2" text="Ignore DVB-S namespace sub network" description="On valid ONIDs, ignore frequency sub network part">config.usage.subnetwork</item>
 		<item level="2" text="Ignore DVB-C namespace sub network" description="On valid ONIDs, ignore frequency sub network part">config.usage.subnetwork_cable</item>
 		<item level="2" text="Ignore DVB-T namespace sub network" description="On valid ONIDs, ignore frequency sub network part">config.usage.subnetwork_terrestrial</item>

--- a/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
@@ -143,7 +143,7 @@ class UpdatePluginMenu(Screen):
 			self.list.append(("backupfiles", _("Select backup files"),  _("Select files for backup.") + self.oktext + "\n\n" + self.infotext, None))
 			if config.usage.setup_level.index >= 2: # expert+
 				self.list.append(("ipkg-manager", _("Packet management"),  _("\nView, install and remove available or installed packages." ) + self.oktext, None))
-			self.list.append(("ipkg-source",_("Select upgrade source"), _("\nEdit the upgrade source address." ) + self.oktext, None))
+			self.list.append(("ipkg-source",_("Select update source"), _("\nEdit the update source address." ) + self.oktext, None))
 			for p in plugins.getPlugins(PluginDescriptor.WHERE_SOFTWAREMANAGER):
 				if "AdvancedSoftwareSupported" in p.__call__:
 					callFnc = p.__call__["AdvancedSoftwareSupported"](None)
@@ -390,7 +390,7 @@ class SoftwareManagerSetup(Screen, ConfigListScreen):
 
 	def selectionChanged(self):
 		if self["config"].getCurrent() == self.overwriteConfigfilesEntry:
-			self["introduction"].setText(_("Overwrite configuration files during software upgrade?"))
+			self["introduction"].setText(_("Overwrite configuration files during software update?"))
 		else:
 			self["introduction"].setText("")
 
@@ -1046,7 +1046,7 @@ class PluginManagerInfo(Screen):
 		elif action == 'remove':
 			return(( _('Removing'), info, removepng, divpng))
 		else:
-			return(( _('Upgrading'), info, upgradepng, divpng))
+			return(( _('Updating'), info, upgradepng, divpng))
 
 	def exit(self):
 		self.close()
@@ -1339,7 +1339,7 @@ class PluginDetails(Screen, PackageInfoHandler):
 
 class IPKGMenu(Screen):
 	skin = """
-		<screen name="IPKGMenu" position="center,center" size="560,400" title="Select upgrade source to edit." >
+		<screen name="IPKGMenu" position="center,center" size="560,400" title="Select update source to edit." >
 			<ePixmap pixmap="buttons/red.png" position="0,0" size="140,40" alphatest="on" />
 			<ePixmap pixmap="buttons/green.png" position="140,0" size="140,40" alphatest="on" />
 			<widget source="key_red" render="Label" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1" />
@@ -1380,7 +1380,7 @@ class IPKGMenu(Screen):
 		self.setWindowTitle()
 
 	def setWindowTitle(self):
-		self.setTitle(_("Select upgrade source to edit."))
+		self.setTitle(_("Select update source to edit."))
 
 	def fill_list(self):
 		flist = []
@@ -1410,7 +1410,7 @@ class IPKGMenu(Screen):
 
 class IPKGSource(Screen):
 	skin = """
-		<screen name="IPKGSource" position="center,center" size="560,80" title="Edit upgrade source url." >
+		<screen name="IPKGSource" position="center,center" size="560,80" title="Edit update source url." >
 			<ePixmap pixmap="buttons/red.png" position="0,0" size="140,40" alphatest="on" />
 			<ePixmap pixmap="buttons/green.png" position="140,0" size="140,40" alphatest="on" />
 			<widget source="key_red" render="Label" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1" />
@@ -1476,7 +1476,7 @@ class IPKGSource(Screen):
 		self["text"].right()
 
 	def setWindowTitle(self):
-		self.setTitle(_("Edit upgrade source url."))
+		self.setTitle(_("Edit update source url."))
 
 	def go(self):
 		text = self["text"].getText()
@@ -1665,7 +1665,7 @@ class PacketManager(Screen, NumericalTextInput):
 			elif status == 'upgradeable':
 				self.cmdList.append((IpkgComponent.CMD_INSTALL, { "package": package }))
 				if len(self.cmdList):
-					self.session.openWithCallback(self.runUpgrade, MessageBox, _("Do you want to upgrade the package:\n") + package + "\n" + self.oktext)
+					self.session.openWithCallback(self.runUpgrade, MessageBox, _("Do you want to update the package:\n") + package + "\n" + self.oktext)
 			elif status == "installable":
 				self.cmdList.append((IpkgComponent.CMD_INSTALL, { "package": package }))
 				if len(self.cmdList):

--- a/lib/python/Screens/About.py
+++ b/lib/python/Screens/About.py
@@ -29,7 +29,7 @@ class About(Screen):
 		AboutText += _("CPU: ") + cpu + "\n"
 		AboutText += _("Image: ") + about.getImageTypeString() + "\n"
 		AboutText += _("Build date: ") + about.getBuildDateString() + "\n"
-		AboutText += _("Last upgrade: ") + about.getUpdateDateString() + "\n"
+		AboutText += _("Last update: ") + about.getUpdateDateString() + "\n"
 
 		# [WanWizard] Removed until we find a reliable way to determine the installation date
 		# AboutText += _("Installed: ") + about.getFlashDateString() + "\n"

--- a/lib/python/Screens/Ipkg.py
+++ b/lib/python/Screens/Ipkg.py
@@ -55,7 +55,7 @@ class Ipkg(Screen):
 			self.slider.setValue(len(self.cmdList))
 
 			self.package.setText("")
-			self.status.setText(ngettext("Done - Installed, upgraded or removed %d package (%s)", "Done - Installed, upgraded or removed %d packages (%s)", self.packages) % (self.packages, ngettext("with %d error", "with %d errors", self.error) % self.error))
+			self.status.setText(ngettext("Done - Installed, updated or removed %d package (%s)", "Done - Installed, updated or removed %d packages (%s)", self.packages) % (self.packages, ngettext("with %d error", "with %d errors", self.error) % self.error))
 			return False
 		else:
 			cmd = self.cmdList[self.runningCmd]
@@ -85,7 +85,7 @@ class Ipkg(Screen):
 			if param in self.sliderPackages:
 				self.slider.setValue(self.sliderPackages[param])
 			self.package.setText(param)
-			self.status.setText(_("Upgrading"))
+			self.status.setText(_("Updating"))
 			if not param in self.processed_packages:
 				self.processed_packages.append(param)
 				self.packages += 1

--- a/lib/python/Screens/SoftwareUpdate.py
+++ b/lib/python/Screens/SoftwareUpdate.py
@@ -135,7 +135,7 @@ class UpdatePlugin(Screen, ProtectedScreen):
 			if param in self.sliderPackages:
 				self.slider.setValue(self.sliderPackages[param])
 			self.package.setText(param)
-			self.status.setText(_("Upgrading") + ": %s/%s" % (self.packages, self.total_packages))
+			self.status.setText(_("Updating") + ": %s/%s" % (self.packages, self.total_packages))
 			if not param in self.processed_packages:
 				self.processed_packages.append(param)
 				self.packages += 1
@@ -185,12 +185,12 @@ class UpdatePlugin(Screen, ProtectedScreen):
 						choices = [(_("Update and reboot (recommended)"), "cold"),
 						(_("Update and ask to reboot"), "hot")]
 					choices.append((_("Update channel list only"), "channels"))
-					choices.append((_("Show packages to be upgraded"), "showlist"))
+					choices.append((_("Show packages to be updated"), "showlist"))
 				else:
 					message = _("No updates available")
 					choices = []
 				if fileExists("/home/root/ipkgupgrade.log"):
-					choices.append((_("Show latest upgrade log"), "log"))
+					choices.append((_("Show latest update log"), "log"))
 				choices.append((_("Show latest commits"), "commits"))
 				choices.append((_("Cancel"), ""))
 				self.session.openWithCallback(self.startActualUpgrade, ChoiceBox, title=message, list=choices, windowTitle=self.title)
@@ -252,7 +252,7 @@ class UpdatePlugin(Screen, ProtectedScreen):
 			self.session.openWithCallback(boundFunction(self.ipkgCallback, IpkgComponent.EVENT_DONE, None), TextBox, text, _("Packages to update"), True)
 		elif answer[1] == "log":
 			text = open("/home/root/ipkgupgrade.log", "r").read()
-			self.session.openWithCallback(boundFunction(self.ipkgCallback, IpkgComponent.EVENT_DONE, None), TextBox, text, _("Latest upgrade log"), True)
+			self.session.openWithCallback(boundFunction(self.ipkgCallback, IpkgComponent.EVENT_DONE, None), TextBox, text, _("Latest update log"), True)
 		else:
 			self.ipkg.startCmd(IpkgComponent.CMD_UPGRADE, args = {'test_only': False})
 

--- a/lib/python/Screens/Standby.py
+++ b/lib/python/Screens/Standby.py
@@ -214,10 +214,10 @@ class QuitMainloopScreen(Screen):
 			QUIT_SHUTDOWN: _("Your receiver is shutting down"),
 			QUIT_REBOOT: _("Your receiver is rebooting"),
 			QUIT_RESTART: _("The user interface of your receiver is restarting"),
-			QUIT_UPGRADE_FP: _("Your frontprocessor will be upgraded\nPlease wait until your receiver reboots\nThis may take a few minutes"),
+			QUIT_UPGRADE_FP: _("Your frontprocessor will be updated\nPlease wait until your receiver reboots\nThis may take a few minutes"),
 			QUIT_ERROR_RESTART: _("The user interface of your receiver is restarting\ndue to an error in mytest.py"),
 			QUIT_DEBUG_RESTART: _("The user interface of your receiver is restarting in debug mode"),
-			QUIT_UPGRADE_PROGRAM: _("Unattended upgrade in progress\nPlease wait until your receiver reboots\nThis may take a few minutes")
+			QUIT_UPGRADE_PROGRAM: _("Unattended update in progress\nPlease wait until your receiver reboots\nThis may take a few minutes")
 		}.get(retvalue)
 		self["text"] = Label(text)
 
@@ -254,9 +254,9 @@ class TryQuitMainloop(MessageBox):
 				QUIT_SHUTDOWN: _("Really shutdown now?"),
 				QUIT_REBOOT: _("Really reboot now?"),
 				QUIT_RESTART: _("Really restart now?"),
-				QUIT_UPGRADE_FP: _("Really upgrade the frontprocessor and reboot now?"),
+				QUIT_UPGRADE_FP: _("Really update the frontprocessor and reboot now?"),
 				QUIT_DEBUG_RESTART: _("Really restart in debug mode now?"),
-				QUIT_UPGRADE_PROGRAM: _("Really upgrade your settop box and reboot now?")
+				QUIT_UPGRADE_PROGRAM: _("Really update your settop box and reboot now?")
 			}.get(retvalue, None)
 			if text:
 				MessageBox.__init__(self, session, "%s\n%s" % (reason, text), type=MessageBox.TYPE_YESNO, timeout=timeout, default=default_yes)

--- a/po/ar.po
+++ b/po/ar.po
@@ -47,7 +47,7 @@ msgstr ""
 #
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "تحرير عنوان مصدر الترقية."
@@ -3122,7 +3122,7 @@ msgstr "هل تريد تحديث جهاز الاستقبال إلى %s؟"
 msgid "Do you want to update your receiver?"
 msgstr "هل تريد تحديث جهاز الاستقبال؟"
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "هل تريد ترقية الحزمة: \n"
 
 msgid "Dolby"
@@ -3153,8 +3153,8 @@ msgid "Done"
 msgstr ""
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] ""
 msgstr[1] "تم - تثبيت ، تحديث أو حذف %d الرزم والاخطاء%d "
 msgstr[2] "تم - تثبيت ، تحديث أو حذف %d الرزم والاخطاء%d "
@@ -3275,7 +3275,7 @@ msgid "Edit title"
 msgstr "تحرير العنوان"
 
 #
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "تحرير عنوان مصدر الترقية."
 
 msgid "Education/Science/..."
@@ -4917,14 +4917,14 @@ msgstr "الإعدادت السابقة"
 msgid "Last speed"
 msgstr "السرعة السابقة"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "الترقية السابقة: "
 
 msgid "Latest Commits"
 msgstr ""
 
 #, fuzzy
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "أختيار مصدر الترقيه المراد تحريره"
 
 #
@@ -6069,7 +6069,7 @@ msgstr ""
 msgid "Overscan wizard"
 msgstr "معالج overscan"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "الكتابة على الإعدادات أثناء ترقية النظام؟"
 
 msgid "Overwrite configuration files?"
@@ -6920,10 +6920,10 @@ msgstr "هل تريد فعلا الاغلاق الان ؟"
 msgid "Really store at index %2d for current position?"
 msgstr ""
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr ""
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr ""
 
 msgid "Reboot"
@@ -7909,10 +7909,10 @@ msgid "Select the virtual keyboard shifted character set for the next character 
 msgstr ""
 
 #, fuzzy
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "أختيار مصدر الترقيه المراد تحريره"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "أختيار مصدر الترقيه المراد تحريره"
 
 #
@@ -8333,7 +8333,7 @@ msgstr "شاهد شريط المعلومات عند الانتقال للأما�
 msgid "Show latest commits"
 msgstr ""
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr ""
 
 msgid "Show menu or plugin numbers"
@@ -8370,7 +8370,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr ""
 
 msgid "Show picons in channel selection list"
@@ -10074,7 +10074,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -10195,7 +10195,7 @@ msgid "Updating software catalog"
 msgstr "جارى تحديث فهرس النظام"
 
 #
-msgid "Upgrading"
+msgid "Updating"
 msgstr "جارى الترقيه"
 
 msgid "Upper case"
@@ -10684,7 +10684,7 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr "أي نوع من بحث القنوات تريد؟"
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "عند تمكينه. enigma2 ستقوم بتحميل userbouquets غير مرتبطة. وهذا يعني أنه لا يزال سيتم تحميل userbouquets التي تتوفر ، ولكن لم يتم تضمينها في bouquets.tv أو ملفات bouquets.radio. يتيح لك هذا على سبيل المثال الاحتفاظ بباقة المستخدم الخاصة بك بينما تتم ترقية الإعدادات المثبتة"
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -11114,7 +11114,7 @@ msgid "Your current collection will get lost!"
 msgstr "ستفقد المجموعة الحالية !"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -43,7 +43,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Редакция на адреса за ъпгрейд."
@@ -2961,7 +2961,7 @@ msgstr "Искате ли да актуализирате вашия прием�
 msgid "Do you want to update your receiver?"
 msgstr "Искате ли да актуализирате вашия приемник?"
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Искате ли да ъпгрейднете този пакет:\n"
 
 msgid "Dolby"
@@ -2992,8 +2992,8 @@ msgid "Done"
 msgstr ""
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Изпълнено - Инсталиран, обновен или изтрит %d пакет (%s)"
 msgstr[1] "Изпълнено - Инсталирани, обновени или изтрити %d пакета (%s)"
 
@@ -3097,7 +3097,7 @@ msgstr "Редактиране на таймер"
 msgid "Edit title"
 msgstr "Редакт.заглавие"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Редакция на адреса за актуализации(url)."
 
 msgid "Education/Science/..."
@@ -4676,13 +4676,13 @@ msgstr "Последни настройки"
 msgid "Last speed"
 msgstr "Последна скорост"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Последна актуализация: "
 
 msgid "Latest Commits"
 msgstr "Последни Изменения"
 
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Лог на последната актуализация"
 
 msgid "Latitude"
@@ -5707,7 +5707,7 @@ msgstr "Общ прогрес:"
 msgid "Overscan wizard"
 msgstr "Помощник за Свръхсканиране"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Презаписване на конфигурационните файлове по време на актуализация?"
 
 msgid "Overwrite configuration files?"
@@ -6507,10 +6507,10 @@ msgstr "Да изключа ли приемника?"
 msgid "Really store at index %2d for current position?"
 msgstr "Да съхраня ли с номер %2d текущата позиция?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Да обновя ли фронтпроцесора и да рестартирам сега?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Да обновя ли Вашия приемник и да рестартирам сега?"
 
 msgid "Reboot"
@@ -7428,10 +7428,10 @@ msgstr ""
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr ""
 
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Избор на източника за обновяване"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Редактиране на източника за обновяване."
 
 msgid "Select video input with up/down buttons"
@@ -7827,7 +7827,7 @@ msgstr "Показвай инфо-лентата при прескачане н�
 msgid "Show latest commits"
 msgstr "Покажи последните изменения"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Покажи последния лог от обновяването"
 
 #, fuzzy
@@ -7861,7 +7861,7 @@ msgstr "Покажи известие когато импортирането н
 msgid "Show notification when import channels was successful"
 msgstr "Покажи известие когато импортирането на канали завърши успешно"
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Покажи пакетите, които ще бъдат обновени"
 
 msgid "Show picons in channel selection list"
@@ -9433,7 +9433,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9551,7 +9551,7 @@ msgstr "Няма наличен фийд за актуализации."
 msgid "Updating software catalog"
 msgstr "Актуализирам софтуер каталога"
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Ъпгрейдвам"
 
 msgid "Upper case"
@@ -10015,7 +10015,7 @@ msgstr "Западна Сахара"
 msgid "What type of service scan do you want?"
 msgstr "Какъв тип на търсене искате да изберете?"
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Ако е включено, при старт на енигма2 ще бъдат заредени достъпни букети, които на са включени в списъка bouquets.tv или bouquets.radio. Това Ви позволява например да запазите Вашите букети при актуализация на настройките"
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10436,7 +10436,7 @@ msgid "Your current collection will get lost!"
 msgstr "Вашата текуща колекция ще бъде изтрита!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -44,7 +44,7 @@ msgstr ""
 #
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 
 msgid ""
@@ -3282,7 +3282,7 @@ msgid "Do you want to update your receiver?"
 msgstr ""
 
 #
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr ""
 
 msgid "Dolby"
@@ -3315,8 +3315,8 @@ msgstr ""
 
 #
 #, fuzzy, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Fet. %d paquets instal·lats o actualitzats"
 msgstr[1] "Fet. %d paquets instal·lats o actualitzats"
 
@@ -3443,7 +3443,7 @@ msgid "Edit title"
 msgstr ""
 
 #
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr ""
 
 msgid "Education/Science/..."
@@ -5174,7 +5174,7 @@ msgstr ""
 msgid "Last speed"
 msgstr ""
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr ""
 
 msgid "Latest Commits"
@@ -5182,7 +5182,7 @@ msgstr ""
 
 #
 #, fuzzy
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Seleccionar una pel·lícula"
 
 #
@@ -6375,7 +6375,7 @@ msgstr ""
 msgid "Overscan wizard"
 msgstr ""
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr ""
 
 #
@@ -7309,10 +7309,10 @@ msgstr ""
 msgid "Really store at index %2d for current position?"
 msgstr ""
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr ""
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr ""
 
 msgid "Reboot"
@@ -8380,11 +8380,11 @@ msgstr ""
 
 #
 #, fuzzy
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Seleccionar una pel·lícula"
 
 #
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr ""
 
 #
@@ -8826,7 +8826,7 @@ msgstr "Mostrar la barra anant endavant/enrere"
 msgid "Show latest commits"
 msgstr ""
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr ""
 
 msgid "Show menu or plugin numbers"
@@ -8859,7 +8859,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr ""
 
 msgid "Show picons in channel selection list"
@@ -10589,7 +10589,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -10715,7 +10715,7 @@ msgid "Updating software catalog"
 msgstr ""
 
 #
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Actualitzant"
 
 msgid "Upper case"
@@ -11226,7 +11226,7 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -11663,7 +11663,7 @@ msgid "Your current collection will get lost!"
 msgstr ""
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -47,7 +47,7 @@ msgstr ""
 #
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Upravit adresy aktualizačních zdrojů."
@@ -3383,7 +3383,7 @@ msgid "Do you want to update your receiver?"
 msgstr "Chcete zaktualizovat Váš přijímač?"
 
 #
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Chcete aktualizovat balíček:\n"
 
 msgid "Dolby"
@@ -3416,8 +3416,8 @@ msgstr "Dokončeno"
 
 #
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Dokončeno - instalován, aktualizován nebo odstraněn %d balíček (%s)"
 msgstr[1] "Dokončeno - instalovány, aktualizovány nebo odstraněny %d balíčky (%s)"
 msgstr[2] "Dokončeno - instalováno, aktualizováno nebo odstraněno %d balíčků (%s)"
@@ -3543,7 +3543,7 @@ msgid "Edit title"
 msgstr "Upravit titul"
 
 #
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Upravit url zdroje aktualizací."
 
 msgid "Education/Science/..."
@@ -5297,14 +5297,14 @@ msgstr "Poslední konfigurace"
 msgid "Last speed"
 msgstr "Poslední rychlost"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Poslední aktualizace: "
 
 #
 msgid "Latest Commits"
 msgstr "Poslední změny"
 
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Log poslední aktualizace"
 
 #
@@ -6489,7 +6489,7 @@ msgstr "Celkový průběh:"
 msgid "Overscan wizard"
 msgstr "Overscan průvodce"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Přepsat konfigurační soubory při aktualizaci software ?"
 
 msgid "Overwrite configuration files?"
@@ -7435,10 +7435,10 @@ msgstr "Opravdu nyní vypnout?"
 msgid "Really store at index %2d for current position?"
 msgstr "Opravdu uložit současnou pozici pod index %2d?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Skutečně aktualizovat frontprocesor a restartovat?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Skutečně aktualizovat přijímač a restartovat"
 
 msgid "Reboot"
@@ -8485,11 +8485,11 @@ msgid "Select the virtual keyboard shifted character set for the next character 
 msgstr "Shift pro následující znak"
 
 #
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Vyberte zdroje pro aktualizaci"
 
 #
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Výběr zdroje pro aktualizaci k úpravě."
 
 #
@@ -8929,7 +8929,7 @@ msgstr "Zobrazit infobar při přeskočení dopředu/zpět"
 msgid "Show latest commits"
 msgstr "Zobrazit poslední změny"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Zobrazit log poslední aktualizace"
 
 msgid "Show menu or plugin numbers"
@@ -8963,7 +8963,7 @@ msgstr "Zobrazit zprávu při neúspěšném importu"
 msgid "Show notification when import channels was successful"
 msgstr "Zobrazit zprávu při úspěšném importu"
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Zobrazit aktualizované balíčky"
 
 #
@@ -10741,7 +10741,7 @@ msgstr "Nelze nastavit požadované adresáře na médiu (např. na USB nebo HDD
 #
 #
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -10868,7 +10868,7 @@ msgid "Updating software catalog"
 msgstr "Aktualizace katalogu programů"
 
 #
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Aktualizace"
 
 msgid "Upper case"
@@ -11397,7 +11397,7 @@ msgstr "Západní Sahara"
 msgid "What type of service scan do you want?"
 msgstr "Jaký typ vyhledání programů chcete?"
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Enigma2 bude načítat odstraněné uživatelské přehledy. To znamená, že uživatelské přehledy, které jsou k dispozici, ale nejsou zahrnuty v bouquets.tv nebo bouquets.radio, budou načteny. To například umožňuje zachovat vlastní uživatelské přehledy, zatímco instalovaná nastavení jsou aktualizována."
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -11861,7 +11861,7 @@ msgid "Your current collection will get lost!"
 msgstr "Vaše současná kompilace bude ztracena!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/da.po
+++ b/po/da.po
@@ -48,7 +48,7 @@ msgstr ""
 #
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Rediger kildeadressen til opgradering."
@@ -3338,7 +3338,7 @@ msgid "Do you want to update your receiver?"
 msgstr "Vil du opdatere din receiver?"
 
 #
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Vil du opgradere pakken:\n"
 
 msgid "Dolby"
@@ -3371,8 +3371,8 @@ msgstr ""
 
 #
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Færdig - Installeret, opgraderet eller fjernet %d pakken (%s)"
 msgstr[1] "Færdig - Installeret, opgraderet eller fjernet %d pakkerne (%s)"
 
@@ -3500,7 +3500,7 @@ msgid "Edit title"
 msgstr "Rediger titel"
 
 #
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Rediger url for opgraderingskilde."
 
 msgid "Education/Science/..."
@@ -5244,14 +5244,14 @@ msgstr "Seneste opsætning"
 msgid "Last speed"
 msgstr "Sidste hastighed"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Seneste opdatering"
 
 msgid "Latest Commits"
 msgstr "Seneste commit"
 
 #, fuzzy
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Vis seneste opgraderingslog"
 
 #
@@ -6439,7 +6439,7 @@ msgstr "Overordnet fremskridt:"
 msgid "Overscan wizard"
 msgstr "Overscan guide"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Overskriv konfigurationsfilerne under softwareopdateringen?"
 
 msgid "Overwrite configuration files?"
@@ -7379,10 +7379,10 @@ msgstr "Virkelig slukke nu?"
 msgid "Really store at index %2d for current position?"
 msgstr "Ønsker du virkelig at gemme indeks %2d på nuværende position?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Opdater frontprocessor og genstart nu?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Opdater boksen og genstart nu?"
 
 #
@@ -8437,11 +8437,11 @@ msgid "Select the virtual keyboard shifted character set for the next character 
 msgstr ""
 
 #
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Vælg opgraderingskilde"
 
 #
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Vælg opgraderingskilde til redigering."
 
 #
@@ -8880,7 +8880,7 @@ msgstr "Vis infobjælke ved skip fremspoling/tilbagespoling"
 msgid "Show latest commits"
 msgstr "Vis seneste commits"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Vis seneste opgraderingslog"
 
 #, fuzzy
@@ -8915,7 +8915,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Vis pakker der skal opgraderes"
 
 msgid "Show picons in channel selection list"
@@ -10709,7 +10709,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -10840,7 +10840,7 @@ msgid "Updating software catalog"
 msgstr "Opdaterer softwarekatalog"
 
 #
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Opdaterer"
 
 msgid "Upper case"
@@ -11372,7 +11372,7 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Når aktiveret vil enigma2 indlæse ikke sammenkædet brugerbouquets. Dette betyder at brugerbouquets der er tilgængelig, men ikke inkluderet i bouquets.tv eller bouquets.radio filer, vil stadig blive indlæst. Dette tillader dig f.eks. til at beholde dine egn brugerbouquet imens installerede indstillinger bliver opgraderet"
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -11825,7 +11825,7 @@ msgid "Your current collection will get lost!"
 msgstr "Din nuværende samling vil forsvinde!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -44,10 +44,10 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
-"Upgrade-Quell-Adresse bearbeiten."
+"Update-Quell-Adresse bearbeiten."
 
 msgid ""
 "\n"
@@ -2954,7 +2954,7 @@ msgstr "Wollen Sie Ihren Receiver auf %s aktualisieren?"
 msgid "Do you want to update your receiver?"
 msgstr "Wollen Sie Ihren Receiver aktualisieren?"
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Wollen Sie das Paket aktualisieren:\n"
 
 msgid "Dolby"
@@ -2985,8 +2985,8 @@ msgid "Done"
 msgstr "ausgeführt"
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Abgeschlossen - %d Paket installiert, aktualisiert oder entfernt (%s)"
 msgstr[1] "Abgeschlossen - %d Pakete installiert, aktualisiert oder entfernt (%s)"
 
@@ -3088,7 +3088,7 @@ msgstr "Timer editieren"
 msgid "Edit title"
 msgstr "Titel ändern"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Update Quell-URL bearbeiten."
 
 msgid "Education/Science/..."
@@ -4645,14 +4645,14 @@ msgstr "Letzte Konfiguration"
 msgid "Last speed"
 msgstr "Letzte Geschwindigkeit"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Letztes Update: "
 
 msgid "Latest Commits"
 msgstr "Letzte Änderungen"
 
-msgid "Latest upgrade log"
-msgstr "Letztes Upgrade-Protokoll"
+msgid "Latest update log"
+msgstr "Letztes Update-Protokoll"
 
 msgid "Latitude"
 msgstr "Breitengrad"
@@ -5667,7 +5667,7 @@ msgstr "Gesamtfortschritt: "
 msgid "Overscan wizard"
 msgstr "Overscan Assistent"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Konfigurationsdateien beim Software-Update überschreiben?"
 
 msgid "Overwrite configuration files?"
@@ -6459,10 +6459,10 @@ msgstr "Wollen Sie trotzdem ausschalten?"
 msgid "Really store at index %2d for current position?"
 msgstr "Wirklich bei Index% 2d für die aktuelle Position speichern?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Wollen Sie den Frontprozessor wirklich aktualisieren und anschließend neu starten?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Wollen Sie Ihren Receiver wirklich aktualisieren und anschließend neu starten?"
 
 msgid "Reboot"
@@ -7368,10 +7368,10 @@ msgstr "Wählen Sie den Zeichensatz für die Shift Tastatur aus"
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr "Shift nur für das nächste Zeichen benutzen"
 
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Wählen Sie eine Update-Quelle"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Wählen Sie eine Update-Quelle zum Bearbeiten."
 
 msgid "Select video input with up/down buttons"
@@ -7758,7 +7758,7 @@ msgstr "Infoleiste beim Spulen anzeigen"
 msgid "Show latest commits"
 msgstr "Letzte Änderungen anzeigen"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Protokoll der letzten Aktualisierung anzeigen"
 
 msgid "Show menu or plugin numbers"
@@ -7791,7 +7791,7 @@ msgstr "Benachrichtigung anzeigen, wenn Importkanäle nicht erfolgreich waren"
 msgid "Show notification when import channels was successful"
 msgstr "Benachrichtigung anzeigen, wenn Importkanäle erfolgreich waren"
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Zu aktualisierende Pakete"
 
 msgid "Show picons in channel selection list"
@@ -9359,7 +9359,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr "Es konnten nicht die benötigten Verzeichnisse auf dem Medium erstellt werden - Bitte überprüfen sie das Medium und versuchen sie es nochmal!"
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9472,7 +9472,7 @@ msgstr "Update-Feed nicht verfügbar."
 msgid "Updating software catalog"
 msgstr "Softwarekatalog wird aktualisiert."
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Aktualisiere"
 
 msgid "Upper case"
@@ -9931,7 +9931,7 @@ msgstr "Westsahara"
 msgid "What type of service scan do you want?"
 msgstr "Welche Art von Service-Scan wollen Sie durchführen?"
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Wenn Sie diese Option aktivieren, werden alle vorhandenen Kanallisten geladen, auch wenn diese nicht in der bouquets.tv oder bouquets.radio verlinkt sind. Dies erlaubt Ihnen z.B. Ihre eigenen Kanallisten zu erhalten, wenn eine Aktualisierung von installierten Kanallisten erfolgt."
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10366,7 +10366,7 @@ msgid "Your current collection will get lost!"
 msgstr "Ihre aktuelle Zusammenstellung geht dabei verloren!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -44,10 +44,10 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
-" Επεξεργασία διεύθυνσης πηγής αναβαθμίσεων."
+"Επεξεργασία διεύθυνσης πηγής ενημερώσεων."
 
 msgid ""
 "\n"
@@ -2948,8 +2948,8 @@ msgstr "Θέλετε να γίνει ενημέρωση του δέκτη σας
 msgid "Do you want to update your receiver?"
 msgstr "Θέλετε να γίνει ενημέρωση του δέκτη σας;"
 
-msgid "Do you want to upgrade the package:\n"
-msgstr "Θέλετε να αναβαθμίσετε το πακέτο:\n"
+msgid "Do you want to update the package:\n"
+msgstr "Θέλετε να ενημερώσετε το πακέτο:\n"
 
 msgid "Dolby"
 msgstr "Dolby"
@@ -2979,10 +2979,10 @@ msgid "Done"
 msgstr "Ολοκληρώθηκε"
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
-msgstr[0] "Τέλος - Εγκαταστάθηκε, αναβαθμίστηκε ή αφαιρέθηκε %d πακέτο (%s)"
-msgstr[1] "Τέλος - Εγκαταστάθηκαν, αναβαθμίστηκαν ή αφαιρέθηκαν %d πακέτα (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
+msgstr[0] "Τέλος - Εγκαταστάθηκε, ενημερώθηκε ή αφαιρέθηκε %d πακέτο (%s)"
+msgstr[1] "Τέλος - Εγκαταστάθηκαν, ενημερώθηκαν ή αφαιρέθηκαν %d πακέτα (%s)"
 
 msgid "Download plugins"
 msgstr "Λήψη προσθέτων"
@@ -3082,8 +3082,8 @@ msgstr "Επεξεργασία χρονοδιακόπτη"
 msgid "Edit title"
 msgstr "Επεξεργασία τίτλου"
 
-msgid "Edit upgrade source url."
-msgstr "Επιλέξτε πηγή αναβάθμισης για επεξεργασία."
+msgid "Edit update source url."
+msgstr "Επιλέξτε πηγή ενημέρωσης για επεξεργασία."
 
 msgid "Education/Science/..."
 msgstr "Εκπαίδευση/Επιστήμη/..."
@@ -4634,14 +4634,14 @@ msgstr "Τελευταία ρύθμιση"
 msgid "Last speed"
 msgstr "Τελευταία ταχύτητα"
 
-msgid "Last upgrade: "
-msgstr "Τελευταία αναβάθμιση: "
+msgid "Last update: "
+msgstr "Τελευταία ενημέρωση: "
 
 msgid "Latest Commits"
 msgstr "Τελευταίες αλλαγές"
 
-msgid "Latest upgrade log"
-msgstr "Kαταγραφής τελευταίας αναβάθμισης"
+msgid "Latest update log"
+msgstr "Kαταγραφής τελευταίας ενημέρωσης"
 
 msgid "Latitude"
 msgstr "Γεωγραφικό πλάτος"
@@ -5654,8 +5654,8 @@ msgstr "Συνολική πρόοδος:"
 msgid "Overscan wizard"
 msgstr "Οδηγός υπερσάρωσης"
 
-msgid "Overwrite configuration files during software upgrade?"
-msgstr "Να αντικατασταθούν τα αρχεία ρυθμίσεων κατά την αναβάθμιση λογισμικού;"
+msgid "Overwrite configuration files during software update?"
+msgstr "Να αντικατασταθούν τα αρχεία ρυθμίσεων κατά την ενημέρωση λογισμικού;"
 
 msgid "Overwrite configuration files?"
 msgstr "Αντικατάσταση αρχείων ρυθμίσεων;"
@@ -6031,7 +6031,7 @@ msgid "Please wait (downloading channel list)"
 msgstr "Παρακαλώ περιμένετε (λήψη λίστας καναλιών)"
 
 msgid "Please wait (updating packages)"
-msgstr "Παρακαλώ περιμένετε (αναβάθμιση πακέτων)"
+msgstr "Παρακαλώ περιμένετε (γίνεται ενημέρωση πακέτων)"
 
 msgid "Please wait for activation of your network configuration..."
 msgstr "Παρακαλώ περιμένετε, ενεργοποίηση ρύθμισης δικτύου..."
@@ -6445,11 +6445,11 @@ msgstr "Τερματισμός τώρα;"
 msgid "Really store at index %2d for current position?"
 msgstr "Να γίνει αποθήκευση στη θέση μνήμης %2d για την τρέχουσα θέση;"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
-msgstr "Να γίνει σίγουρα αναβάθμιση του μετωπιαίου επεξεργαστή και επανεκκίνηση;"
+msgid "Really update the frontprocessor and reboot now?"
+msgstr "Να γίνει σίγουρα ενημέρωση του μετωπιαίου επεξεργαστή και επανεκκίνηση;"
 
-msgid "Really upgrade your settop box and reboot now?"
-msgstr "Να γίνει σίγουρα αναβάθμιση του δέκτη και επανεκκίνηση;"
+msgid "Really update your settop box and reboot now?"
+msgstr "Να γίνει σίγουρα ενημέρωση του δέκτη και επανεκκίνηση;"
 
 msgid "Reboot"
 msgstr "Επανεκκίνηση"
@@ -7351,11 +7351,11 @@ msgstr "Επιλογή του σετ χαρακτήρων με shift"
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr "Επιλογή του σετ χαρακτήρων με shift του εικονικού πληκτρολογίου μόνο για τον επόμενο χαρακτήρα"
 
-msgid "Select upgrade source"
-msgstr "Επιλογή πηγής αναβαθμίσεων"
+msgid "Select update source"
+msgstr "Επιλογή πηγής ενημερώσεων"
 
-msgid "Select upgrade source to edit."
-msgstr "Επιλογή πηγής αναβάθμισης για επεξεργασία."
+msgid "Select update source to edit."
+msgstr "Επιλογή πηγής ενημέρωσης για επεξεργασία."
 
 msgid "Select video input with up/down buttons"
 msgstr "Επιλογή εισόδου εικόνας με τα πλήκτρα πάνω/κάτω"
@@ -7741,8 +7741,8 @@ msgstr "Εμφάνιση της μπάρας πληροφοριών κατά τ�
 msgid "Show latest commits"
 msgstr "Εμφάνιση τελευταίων αλλαγών"
 
-msgid "Show latest upgrade log"
-msgstr "Εμφάνιση καταγραφής τελευταίας αναβάθμισης"
+msgid "Show latest update log"
+msgstr "Εμφάνιση καταγραφής τελευταίας ενημέρωσης"
 
 msgid "Show menu or plugin numbers"
 msgstr "Εμφάνιση αριθμών μενού ή προσθέτων"
@@ -7774,8 +7774,8 @@ msgstr "Εμφάνιση ειδοποίησης μετά από αποτυχία
 msgid "Show notification when import channels was successful"
 msgstr "Εμφάνιση ειδοποίησης μετά από επιτυχή εισαγωγή καναλιών"
 
-msgid "Show packages to be upgraded"
-msgstr "Εμφάνιση πακέτων προς αναβάθμιση"
+msgid "Show packages to be updated"
+msgstr "Εμφάνιση πακέτων προς ενημέρωση"
 
 msgid "Show picons in channel selection list"
 msgstr "Εμφάνιση λογότυπων (picons) στη λίστα επιλογής καναλιών"
@@ -8093,7 +8093,7 @@ msgid "Sound carrier"
 msgstr "Φέρουσα ήχου"
 
 msgid "Source request"
-msgstr "Επιλογή πηγής αναβάθμισης"
+msgstr "Επιλογή πηγής ενημέρωσης"
 
 msgid "South"
 msgstr "Νότια"
@@ -9336,11 +9336,11 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr "Αδυναμία δημιουργίας των απαιτούμενων φακέλων στο μέσο (π.χ. USB στικ ή σκληρός δίσκος) - Παρακαλώ ελέγξτε το μέσο και προσπαθήστε ξανά!"
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
-"Εκτελείται αναβάθμιση\n"
+"Εκτελείται ενημέρωση\n"
 "Παρακαλώ περιμένετε μέχρι την επανεκκίνηση του δέκτη\n"
 "Αυτό μπορεί να διαρκέσει μερικά λεπτά"
 
@@ -9449,8 +9449,8 @@ msgstr "Η πηγή ενημερώσεων δεν είναι διαθέσιμη.
 msgid "Updating software catalog"
 msgstr "Ενημέρωση καταλόγου λογισμικού"
 
-msgid "Upgrading"
-msgstr "Εκτελείται αναβάθμιση"
+msgid "Updating"
+msgstr "Εκτελείται ενημέρωση"
 
 msgid "Upper case"
 msgstr "Κεφαλαία"
@@ -9907,8 +9907,8 @@ msgstr "Δυτική Σαχάρα"
 msgid "What type of service scan do you want?"
 msgstr "Ποιον τύπο ανίχνευσης επιθυμείτε;"
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
-msgstr "Όταν είναι ενεργό, το enigma2 θα φορτώνει τα ασύνδετα μπουκέτα χρήστη. Αυτό σημαίνει ότι τα μπουκέτα που είναι διαθέσιμα, αλλά δεν συμπεριλαμβάνονται στα αρχεία bouquets.tv ή bouquets.radio, θα φορτώνονται επίσης. Αυτό σας επιτρέπει για παράδειγμα να διατηρείτε το δικό σας μπουκέτον χρήστη όταν τα εγκατεστημένα θα αναβαθμίζονται"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
+msgstr "Όταν είναι ενεργό, το enigma2 θα φορτώνει τα ασύνδετα μπουκέτα χρήστη. Αυτό σημαίνει ότι τα μπουκέτα που είναι διαθέσιμα, αλλά δεν συμπεριλαμβάνονται στα αρχεία bouquets.tv ή bouquets.radio, θα φορτώνονται επίσης. Αυτό σας επιτρέπει για παράδειγμα να διατηρείτε το δικό σας μπουκέτον χρήστη όταν τα εγκατεστημένα θα ενημερώνονται"
 
 msgid "When enabled the PiP can be closed by the exit button."
 msgstr "Όταν είναι ενεργό, το PiP μπορεί να τερματιστεί με το πλήκτρο εξόδου."
@@ -10338,11 +10338,11 @@ msgid "Your current collection will get lost!"
 msgstr "Η τρέχουσα συλλογή σας θα χαθεί!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
-"Θα γίνει αναβάθμιση του μετωπαίου επεξεργαστή\n"
+"Θα γίνει ενημέρωση του μετωπαίου επεξεργαστή\n"
 "Παρακαλώ περιμένετε μέχρι την επανεκκίνηση του δέκτη σας\n"
 "Αυτό μπορεί να διαρκέσει μερικά λεπτά"
 

--- a/po/en.po
+++ b/po/en.po
@@ -41,10 +41,10 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 
 msgid ""
 "\n"
@@ -2972,8 +2972,8 @@ msgstr "Do you want to update your receiver to %s?"
 msgid "Do you want to update your receiver?"
 msgstr "Do you want to update your receiver?"
 
-msgid "Do you want to upgrade the package:\n"
-msgstr "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
+msgstr "Do you want to update the package:\n"
 
 msgid "Dolby"
 msgstr ""
@@ -3003,10 +3003,10 @@ msgid "Done"
 msgstr ""
 
 #, fuzzy, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
-msgstr[0] "Done - Installed, upgraded or removed %d packages with %d errors"
-msgstr[1] "Done - Installed, upgraded or removed %d packages with %d errors"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
+msgstr[0] "Done - Installed, updated or removed %d packages with %d errors"
+msgstr[1] "Done - Installed, updated or removed %d packages with %d errors"
 
 msgid "Download plugins"
 msgstr "Download plugins"
@@ -3111,8 +3111,8 @@ msgstr ""
 msgid "Edit title"
 msgstr "Edit title"
 
-msgid "Edit upgrade source url."
-msgstr "Edit upgrade source url."
+msgid "Edit update source url."
+msgstr "Edit update source url."
 
 msgid "Education/Science/..."
 msgstr "Education/Science/..."
@@ -4669,15 +4669,15 @@ msgstr "Last config"
 msgid "Last speed"
 msgstr "Last speed"
 
-msgid "Last upgrade: "
-msgstr "Last upgrade: "
+msgid "Last update: "
+msgstr "Last update: "
 
 msgid "Latest Commits"
 msgstr ""
 
 #, fuzzy
-msgid "Latest upgrade log"
-msgstr "Last upgrade: "
+msgid "Latest update log"
+msgstr "Last update: "
 
 msgid "Latitude"
 msgstr "Latitude"
@@ -5714,8 +5714,8 @@ msgstr ""
 msgid "Overscan wizard"
 msgstr ""
 
-msgid "Overwrite configuration files during software upgrade?"
-msgstr "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
+msgstr "Overwrite configuration files during software update?"
 
 msgid "Overwrite configuration files?"
 msgstr "Overwrite configuration files?"
@@ -6520,11 +6520,11 @@ msgstr "Really shutdown now?"
 msgid "Really store at index %2d for current position?"
 msgstr ""
 
-msgid "Really upgrade the frontprocessor and reboot now?"
-msgstr "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
+msgstr "Really update the frontprocessor and reboot now?"
 
-msgid "Really upgrade your settop box and reboot now?"
-msgstr "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
+msgstr "Really update your settop box and reboot now?"
 
 msgid "Reboot"
 msgstr "Reboot"
@@ -7448,11 +7448,11 @@ msgstr ""
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr ""
 
-msgid "Select upgrade source"
-msgstr "Select upgrade source"
+msgid "Select update source"
+msgstr "Select update source"
 
-msgid "Select upgrade source to edit."
-msgstr "Select upgrade source to edit."
+msgid "Select update source to edit."
+msgstr "Select update source to edit."
 
 msgid "Select video input with up/down buttons"
 msgstr "Select video input with up/down buttons"
@@ -7847,7 +7847,7 @@ msgstr "Show infobar on skip forward/backward"
 msgid "Show latest commits"
 msgstr ""
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr ""
 
 msgid "Show menu or plugin numbers"
@@ -7880,7 +7880,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr ""
 
 msgid "Show picons in channel selection list"
@@ -9451,11 +9451,11 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 
@@ -9567,8 +9567,8 @@ msgstr "Updatefeed not available."
 msgid "Updating software catalog"
 msgstr "Updating software catalog"
 
-msgid "Upgrading"
-msgstr "Upgrading"
+msgid "Updating"
+msgstr "Updating"
 
 msgid "Upper case"
 msgstr ""
@@ -10030,7 +10030,7 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10455,11 +10455,11 @@ msgid "Your current collection will get lost!"
 msgstr "Your current collection will get lost!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 

--- a/po/es.po
+++ b/po/es.po
@@ -49,7 +49,7 @@ msgstr ""
 #
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Editar la dirección fuente de actualización."
@@ -3282,7 +3282,7 @@ msgid "Do you want to update your receiver?"
 msgstr "¿Desea actualizar su receptor?"
 
 #
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Quiere actualizar el paquete:\n"
 
 msgid "Dolby"
@@ -3315,8 +3315,8 @@ msgstr "Hecho"
 
 #
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Hecho - Instalado, actualizado o eliminados %d paquetes con %s errores"
 msgstr[1] "Hecho - Instalado, actualizado o eliminados %d paquetes con %s errores"
 
@@ -3437,7 +3437,7 @@ msgid "Edit title"
 msgstr "Editar título"
 
 #
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Editar url de fuente de actualización."
 
 msgid "Education/Science/..."
@@ -5144,13 +5144,13 @@ msgstr "Última config:"
 msgid "Last speed"
 msgstr "Última velocidad"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Última actualización:"
 
 msgid "Latest Commits"
 msgstr "Últimos compromisos"
 
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Último registro de actualización"
 
 #
@@ -6307,7 +6307,7 @@ msgstr "Progreso general:"
 msgid "Overscan wizard"
 msgstr "Overscan wizard"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "¿Sobreescribir los ficheros de configuración durante la actualización del software?"
 
 msgid "Overwrite configuration files?"
@@ -7221,10 +7221,10 @@ msgstr "¿Quiere apagar ahora?"
 msgid "Really store at index %2d for current position?"
 msgstr "Realmente almacenar en el índice% 2d para la posición actual?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Realmente actualizar el frontprocessor y reiniciar ahora?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Realmente actualizar su caja settop y reiniciar ahora?"
 
 #
@@ -8236,11 +8236,11 @@ msgid "Select the virtual keyboard shifted character set for the next character 
 msgstr "Seleccione el teclado virtual cambiado el conjunto de caracteres"
 
 #
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Seleccionar fuente de actualización"
 
 #
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Seleccione fuente de actualización a editar."
 
 #
@@ -8666,7 +8666,7 @@ msgstr "Mostrar la infobar al pasar adelante/atras"
 msgid "Show latest commits"
 msgstr "Mostrar los últimos compromisos"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Mostrar el último registro de actualización"
 
 msgid "Show menu or plugin numbers"
@@ -8701,7 +8701,7 @@ msgstr "Mostrar notificación cuando los canales de importación no tuvieron éx
 msgid "Show notification when import channels was successful"
 msgstr "Mostrar notificación cuando los canales de importación tuvieron éxito"
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Mostrar los paquetes que se van a actualizar"
 
 msgid "Show picons in channel selection list"
@@ -10449,7 +10449,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr "No se pueden crear los directorios necesarios en el medio (por ejemplo, una memoria USB o un disco duro). ¡Verifique los medios y vuelva a intentarlo!"
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -10571,7 +10571,7 @@ msgid "Updating software catalog"
 msgstr "Actualizando el catálogo de software"
 
 #
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Actualizando"
 
 msgid "Upper case"
@@ -11094,7 +11094,7 @@ msgstr "Sahara Occidental"
 msgid "What type of service scan do you want?"
 msgstr "¿Qué tipo de escaneo de servicio quieres?"
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Cuando está habilitado, enigma2 cargará los usuarios desvinculados. Esto significa que los userbouquets que están disponibles, pero que no están incluidos en los archivos bouquets.tv o bouquets.radio, seguirán cargándose. Esto le permite, por ejemplo, mantener su propio ramo de usuario mientras se instalan los ajustes instalados"
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -11547,7 +11547,7 @@ msgid "Your current collection will get lost!"
 msgstr "¡Su colección actual se perdió!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/et.po
+++ b/po/et.po
@@ -44,7 +44,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Muuda uuenduste allika aadressi."
@@ -2956,7 +2956,7 @@ msgstr "Kas soovid uuendada vastuvõtja tarkvara %s?"
 msgid "Do you want to update your receiver?"
 msgstr "Kas soovid uuendada vastuvõtja tarkvara?"
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Kas soovid parendada paketti:\n"
 
 msgid "Dolby"
@@ -2987,8 +2987,8 @@ msgid "Done"
 msgstr ""
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Valmis - paigaldatud, täiendatud või eemaldatud %d pakett (%s)"
 msgstr[1] "Valmis - paigaldatud, täiendatud või eemaldatud %d paketti (%s)"
 
@@ -3091,7 +3091,7 @@ msgstr "Muuda taimerit"
 msgid "Edit title"
 msgstr "Muuda pealkirja"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Muuda uuenduste allika url."
 
 msgid "Education/Science/..."
@@ -4647,13 +4647,13 @@ msgstr "Viimane seadistus"
 msgid "Last speed"
 msgstr "Eelmine kiirus"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Uuendatud: "
 
 msgid "Latest Commits"
 msgstr "Viimased kanded"
 
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Viimase uuenduse logi"
 
 msgid "Latitude"
@@ -5676,7 +5676,7 @@ msgstr "Üldine edenemine:"
 msgid "Overscan wizard"
 msgstr "Üleskaneerimise abiline"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Kas tarkvara uuendamisel kirjutada üle konfiguratsioonifailid?"
 
 msgid "Overwrite configuration files?"
@@ -6475,10 +6475,10 @@ msgstr "Lülitame välja?"
 msgid "Really store at index %2d for current position?"
 msgstr "Kas salvestada indeks %2d  selle asukoha jaoks?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Uuendad esiprotsessori ja taaskäivitad vastuvõtja?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Kas uuendad ja taaskäivitad vastuvõtja?"
 
 msgid "Reboot"
@@ -7394,10 +7394,10 @@ msgstr ""
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr ""
 
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Vali uuenduste allikas"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Vali uuenduste allikas muutmiseks."
 
 msgid "Select video input with up/down buttons"
@@ -7787,7 +7787,7 @@ msgstr "Näita kerimisel inforiba"
 msgid "Show latest commits"
 msgstr "Näita viimaseid kandeid"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Näita viimast uuenduslogi"
 
 #, fuzzy
@@ -7821,7 +7821,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Näita pakette mida peaks uuendama"
 
 msgid "Show picons in channel selection list"
@@ -9409,7 +9409,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9526,7 +9526,7 @@ msgstr "Uuenduslink pole saadaval."
 msgid "Updating software catalog"
 msgstr "Uuendan tarkvara kataloogi"
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Uuendan"
 
 msgid "Upper case"
@@ -9988,7 +9988,7 @@ msgstr "Lääne-Sahara"
 msgid "What type of service scan do you want?"
 msgstr "Mis tüüpi teenuse otsingut soovid?"
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Määrates 'jah', laeb enigma2 ka sidumata lemmiknimekirjad. See tähendab, et lemmiknimekirjad, mis on olemas, aga puuduvad bouquets.tv või bouquets.radio failides, laetakse ikkagi. Nii on võimalik oma lemmiknimekirjad säilitada ka paigaldatud kanalinimekirjade uuendamisel."
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10425,7 +10425,7 @@ msgid "Your current collection will get lost!"
 msgstr "Praegune valik kustutatakse!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -44,7 +44,7 @@ msgstr ""
 #
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "ویرایش آدرس منبع به روز رسانی"
@@ -3016,7 +3016,7 @@ msgstr "آیا میخواهید ایمیج را در %s دانلود کنید ؟
 msgid "Do you want to update your receiver?"
 msgstr ""
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "آیا میخواهید بسته به روز رسانی شود:\n"
 
 msgid "Dolby"
@@ -3047,8 +3047,8 @@ msgid "Done"
 msgstr ""
 
 #, fuzzy, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "انجام شد ، تعداد %d بسته با %d خطا نصب ، به روز رسانی و یا حذف شد"
 
 #, fuzzy
@@ -3156,7 +3156,7 @@ msgid "Edit title"
 msgstr "ویرایش عنوان"
 
 #
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "ویرایش منبع به روز رسانی"
 
 msgid "Education/Science/..."
@@ -4747,13 +4747,13 @@ msgstr "آخرین پیکربندی"
 msgid "Last speed"
 msgstr "آخرین سرعت"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "آخرین به روز رسانی: "
 
 msgid "Latest Commits"
 msgstr "جدیدترین فعالیت"
 
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "جدیدترین گزارش روز رسانی"
 
 msgid "Latitude"
@@ -5811,7 +5811,7 @@ msgstr ""
 msgid "Overscan wizard"
 msgstr ""
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "بازنویسی فایل های پیکربندی هنگام به روز رسانی نرم افزار ؟"
 
 #, fuzzy
@@ -6630,10 +6630,10 @@ msgstr "خاموش کردن هم اکنون؟"
 msgid "Really store at index %2d for current position?"
 msgstr ""
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "پردازنده جلو به روز رسانی و هم اکنون راه اندازی مجدد شود ؟"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "دستگاه شما به روز رسانی و هم اکنون راه اندازی مجدد شود ؟"
 
 msgid "Reboot"
@@ -7580,10 +7580,10 @@ msgid "Select the virtual keyboard shifted character set for the next character 
 msgstr ""
 
 #, fuzzy
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "انتخاب منبع به روز رسانی برای ویرایش"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "انتخاب منبع به روز رسانی برای ویرایش"
 
 msgid "Select video input with up/down buttons"
@@ -7996,7 +7996,7 @@ msgstr ""
 msgid "Show latest commits"
 msgstr ""
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr ""
 
 #, fuzzy
@@ -8031,7 +8031,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr ""
 
 msgid "Show picons in channel selection list"
@@ -9598,7 +9598,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9708,7 +9708,7 @@ msgstr ""
 msgid "Updating software catalog"
 msgstr ""
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr ""
 
 msgid "Upper case"
@@ -10148,7 +10148,7 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10563,7 +10563,7 @@ msgid "Your current collection will get lost!"
 msgstr ""
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -46,7 +46,7 @@ msgstr ""
 #
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Muokkaa päivityksen lähdeosoitetta."
@@ -3248,7 +3248,7 @@ msgid "Do you want to update your receiver?"
 msgstr "Haluatko päivittää vastaanottimesi?"
 
 #
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Haluatko päivittää ohjelmapaketin:\n"
 
 msgid "Dolby"
@@ -3283,8 +3283,8 @@ msgstr ""
 
 #
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Valmis - asennettu, päivitetty tai poistettu %d ohjelmapaketti (%s)"
 msgstr[1] "Valmis - asennettu, päivitetty tai poistettu %d ohjelmapakettia (%s)"
 
@@ -3407,7 +3407,7 @@ msgid "Edit title"
 msgstr "Editoi"
 
 #
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Muokkaa päivitys-URL:ia."
 
 msgid "Education/Science/..."
@@ -5106,13 +5106,13 @@ msgstr "Aikais.arvot"
 msgid "Last speed"
 msgstr "Aikaisempi nopeus"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Viimeisin päivitys:"
 
 msgid "Latest Commits"
 msgstr "Viim. muutokset"
 
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Viimeisin päivityslokitiedosto"
 
 #
@@ -6294,7 +6294,7 @@ msgstr ""
 msgid "Overscan wizard"
 msgstr "Overscan avustin"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Korvaa asetustiedostot ohjelmistopäivityksen aikana?"
 
 msgid "Overwrite configuration files?"
@@ -7221,10 +7221,10 @@ msgstr "Haluatko silti sammuttaa?"
 msgid "Really store at index %2d for current position?"
 msgstr "Haluatko tallentaa muistipaikkaan %2d nykyisen suuntauksen?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Päivitetäänkö etuprosessori nyt ja käynnistetään uudelleen?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Päivitetäänkö vastaanotin nyt ja käynnistetään uudelleen?"
 
 #
@@ -8251,11 +8251,11 @@ msgid "Select the virtual keyboard shifted character set for the next character 
 msgstr ""
 
 #
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Valitse päivityksen lähde"
 
 #
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Valitse muokattava päivityslähde."
 
 #
@@ -8686,7 +8686,7 @@ msgstr "Näytä tietopalkki kelauksien/hyppyjen aikana"
 msgid "Show latest commits"
 msgstr "Näytä viimeisimmät muutokset"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Näytä viimeisin päivityslokitiedosto"
 
 msgid "Show menu or plugin numbers"
@@ -8720,7 +8720,7 @@ msgstr "Näytä ilmoitus kun tuonti epäonnistui"
 msgid "Show notification when import channels was successful"
 msgstr "Näytä ilmoitus kun tuonti onnistui"
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Näytä päivitettävät ohjelmistopaketit"
 
 msgid "Show picons in channel selection list"
@@ -10479,7 +10479,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr "Hakemistojen luonti epäonnistui. Varmista tallennusmedian toimivuus ja kokeile uudestaan!"
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -10602,7 +10602,7 @@ msgid "Updating software catalog"
 msgstr "Päivitetään ohjelmistoluetteloa"
 
 #
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Päivitetään"
 
 msgid "Upper case"
@@ -11123,7 +11123,7 @@ msgstr "Western Sahara"
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Kun päällä, suosikkilistat jotka ovat saatavilla ladataan vaikka ne eivät olisi bouquets.tv tai bouquets.radio tiedostoissa. Tämä antaa sinun pitää omat suosikkilistasi samalla kun asennettuja päivitetään."
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -11570,7 +11570,7 @@ msgid "Your current collection will get lost!"
 msgstr "Nykyinen kokoelma häviää!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -43,7 +43,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Éditer l'adresse d'origine de la mise à jour."
@@ -2952,7 +2952,7 @@ msgstr "Voulez-vous mettre à jour votre récepteur vers %s?"
 msgid "Do you want to update your receiver?"
 msgstr "Voulez-vous mettre à jour votre récepteur?"
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Voulez-vous mettre à jour le paquet:\n"
 
 msgid "Dolby"
@@ -2983,8 +2983,8 @@ msgid "Done"
 msgstr "Terminé"
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Terminé - %d paquet (sur %s) installé, mis à jour ou retiré"
 msgstr[1] "Terminé - %d paquets (sur %s) installés, mis à jour ou retirés "
 
@@ -3086,7 +3086,7 @@ msgstr "Éditer programmation"
 msgid "Edit title"
 msgstr "Éditer titre"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Éditer url source mise à jour."
 
 msgid "Education/Science/..."
@@ -4636,13 +4636,13 @@ msgstr "Dernière config"
 msgid "Last speed"
 msgstr "Dernière vitesse"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Dernière mise à jour: "
 
 msgid "Latest Commits"
 msgstr "Derniers changements"
 
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Log de la dernière mise à jour"
 
 msgid "Latitude"
@@ -5656,7 +5656,7 @@ msgstr "Aperçu de la progression:"
 msgid "Overscan wizard"
 msgstr "Assistant Overscan"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Ecraser fichiers configuration pendant mise à jour logicielle?"
 
 msgid "Overwrite configuration files?"
@@ -6447,10 +6447,10 @@ msgstr "Voulez-vous vraiment éteindre maintenant?"
 msgid "Really store at index %2d for current position?"
 msgstr "Vraiment sauvegarder la position actuelle à l’index %2d?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Voulez-vous vraiment mettre à jour le frontprocessor et redémarrer maintenant?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Voulez-vous vraiment mettre à jour votre décodeur et redémarrer maintenant?"
 
 msgid "Reboot"
@@ -7353,10 +7353,10 @@ msgstr "Sélectionnez le jeu de caractères décalé du clavier virtuel"
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr "Sélectionnez le clavier virtuel décalé pour le caractère suivant uniquement"
 
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Sélectionnez la source de mise à jour"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Sélectionnez la source de mise à niveau pour éditer."
 
 msgid "Select video input with up/down buttons"
@@ -7743,7 +7743,7 @@ msgstr "Afficher barre d'infos sur saut avant/arrière"
 msgid "Show latest commits"
 msgstr "Afficher les derniers changements"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Afficher le log de la dernière mise à jour"
 
 msgid "Show menu or plugin numbers"
@@ -7776,7 +7776,7 @@ msgstr "Afficher une notification lorsque l’import des chaînes n’a pas réu
 msgid "Show notification when import channels was successful"
 msgstr "Afficher une notification lorsque l’import des chaînes a réussi"
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Afficher les paquets à mettre à jour"
 
 msgid "Show picons in channel selection list"
@@ -9349,7 +9349,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr "Impossible de créer les répertoires requis sur le support (par ex. clé USB ou disque dur)-Veuillez vérifier les médias et réessayez!"
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9462,7 +9462,7 @@ msgstr "MAJ feed non disponible."
 msgid "Updating software catalog"
 msgstr "Mise à jour du catalogue logiciel"
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Mise à jour en cours"
 
 msgid "Upper case"
@@ -9920,7 +9920,7 @@ msgstr "Sahara Occidental"
 msgid "What type of service scan do you want?"
 msgstr "Quel type de recherche de service voulez-vous?"
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Lorsqu'elle est activée, enigma2 chargera les userbouquets non liés. Cela signifie que les userbouquets qui sont disponibles, mais pas repris dans les fichiers bouquets.tv ou bouquets.radio, seront chargés."
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10351,7 +10351,7 @@ msgid "Your current collection will get lost!"
 msgstr "Votre collection actuelle sera perdue!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/fy.po
+++ b/po/fy.po
@@ -45,7 +45,7 @@ msgstr ""
 #
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 
 msgid ""
@@ -3341,7 +3341,7 @@ msgid "Do you want to update your receiver?"
 msgstr ""
 
 #
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr ""
 
 msgid "Dolby"
@@ -3374,8 +3374,8 @@ msgstr ""
 
 #
 #, fuzzy, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Dien - %d paket(ten) ynstalllearre of bywurke"
 msgstr[1] "Dien - %d paket(ten) ynstalllearre of bywurke"
 
@@ -3506,7 +3506,7 @@ msgid "Edit title"
 msgstr "Bewukje titel"
 
 #
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr ""
 
 msgid "Education/Science/..."
@@ -5268,7 +5268,7 @@ msgstr ""
 msgid "Last speed"
 msgstr "Lêste faasje"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr ""
 
 msgid "Latest Commits"
@@ -5276,7 +5276,7 @@ msgstr ""
 
 #
 #, fuzzy
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Kies fideo moadus"
 
 #
@@ -6483,7 +6483,7 @@ msgstr ""
 msgid "Overscan wizard"
 msgstr ""
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr ""
 
 #
@@ -7432,10 +7432,10 @@ msgstr "Wier no kompleet útskeakelje ?"
 msgid "Really store at index %2d for current position?"
 msgstr ""
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr ""
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr ""
 
 #
@@ -8516,11 +8516,11 @@ msgstr ""
 
 #
 #, fuzzy
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Kies fideo moadus"
 
 #
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr ""
 
 #
@@ -8977,7 +8977,7 @@ msgstr "Ynfobalke sjen by rap foarút / efterút"
 msgid "Show latest commits"
 msgstr ""
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr ""
 
 msgid "Show menu or plugin numbers"
@@ -9012,7 +9012,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr ""
 
 msgid "Show picons in channel selection list"
@@ -10798,7 +10798,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -10924,7 +10924,7 @@ msgid "Updating software catalog"
 msgstr ""
 
 #
-msgid "Upgrading"
+msgid "Updating"
 msgstr "An it bywurkjen"
 
 msgid "Upper case"
@@ -11462,7 +11462,7 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -11907,7 +11907,7 @@ msgid "Your current collection will get lost!"
 msgstr ""
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -48,7 +48,7 @@ msgstr ""
 #
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "ערוך את כתובת מקור העדכון"
@@ -3152,7 +3152,7 @@ msgstr "? האם ברצונך לשחזר את ההגדרות"
 msgid "Do you want to update your receiver?"
 msgstr ""
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "?האם ברצונך לשדרג את החבילה\n"
 
 msgid "Dolby"
@@ -3183,8 +3183,8 @@ msgid "Done"
 msgstr ""
 
 #, fuzzy, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "תקלות %d חבילות עם %d בוצע - הותקנו, עודכנו או הוסרו"
 msgstr[1] "תקלות %d חבילות עם %d בוצע - הותקנו, עודכנו או הוסרו"
 
@@ -3304,8 +3304,8 @@ msgid "Edit title"
 msgstr "ערוך כותרת"
 
 #
-msgid "Edit upgrade source url."
-msgstr "Edit upgrade source url."
+msgid "Edit update source url."
+msgstr "Edit update source url."
 
 msgid "Education/Science/..."
 msgstr ""
@@ -4974,15 +4974,15 @@ msgstr "הגדרה קודמת"
 msgid "Last speed"
 msgstr "מהירות קודמת"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr ""
 
 msgid "Latest Commits"
 msgstr ""
 
 #, fuzzy
-msgid "Latest upgrade log"
-msgstr "Select upgrade source to edit."
+msgid "Latest update log"
+msgstr "Select update source to edit."
 
 #
 msgid "Latitude"
@@ -6131,7 +6131,7 @@ msgstr ""
 msgid "Overscan wizard"
 msgstr ""
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr ""
 
 #, fuzzy
@@ -7000,10 +7000,10 @@ msgstr "?לבצע כיבוי עכשיו"
 msgid "Really store at index %2d for current position?"
 msgstr ""
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr ""
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr ""
 
 msgid "Reboot"
@@ -8005,11 +8005,11 @@ msgid "Select the virtual keyboard shifted character set for the next character 
 msgstr ""
 
 #, fuzzy
-msgid "Select upgrade source"
-msgstr "Select upgrade source to edit."
+msgid "Select update source"
+msgstr "Select update source to edit."
 
-msgid "Select upgrade source to edit."
-msgstr "Select upgrade source to edit."
+msgid "Select update source to edit."
+msgstr "Select update source to edit."
 
 #
 msgid "Select video input with up/down buttons"
@@ -8441,7 +8441,7 @@ msgstr "Show infobar on skip forward/backward"
 msgid "Show latest commits"
 msgstr ""
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr ""
 
 msgid "Show menu or plugin numbers"
@@ -8478,7 +8478,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr ""
 
 msgid "Show picons in channel selection list"
@@ -10200,7 +10200,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -10320,7 +10320,7 @@ msgid "Updating software catalog"
 msgstr "מעדכן קטלוג תוכנה"
 
 #
-msgid "Upgrading"
+msgid "Updating"
 msgstr "משדרג"
 
 msgid "Upper case"
@@ -10820,7 +10820,7 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -11247,7 +11247,7 @@ msgid "Your current collection will get lost!"
 msgstr "Your current collection will get lost!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -43,7 +43,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Uredite adresu za nadogradnje."
@@ -2964,7 +2964,7 @@ msgstr "Želite li ažurirati svoj prijemnik na %s?"
 msgid "Do you want to update your receiver?"
 msgstr "Želite li ažurirati svoj prijemnik?"
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Želite li nadograditi paket:\n"
 
 msgid "Dolby"
@@ -2997,8 +2997,8 @@ msgid "Done"
 msgstr "Gotovo"
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Gotovo - Instaliran, ažuriran ili uklonjen  %d paket (%s)"
 msgstr[1] "Gotovo - Instalirane, ažurirane ili uklonjene  %d pakete (%s)"
 msgstr[2] "Gotovo - Instalirani, ažurirani ili uklonjeni  %d paketi (%s)"
@@ -3101,7 +3101,7 @@ msgstr "Uredite tajmer"
 msgid "Edit title"
 msgstr "Uredite titlove"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Uredite url izvornog ažuriranja."
 
 msgid "Education/Science/..."
@@ -4655,13 +4655,13 @@ msgstr "Zadnja konfiguracija"
 msgid "Last speed"
 msgstr "Zadnja brzina"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Zadnja nadogradnja: "
 
 msgid "Latest Commits"
 msgstr "Najnovije objave"
 
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Zadnjii dnevnik nadogradnje"
 
 msgid "Latitude"
@@ -5676,7 +5676,7 @@ msgstr "Opći napredak:"
 msgid "Overscan wizard"
 msgstr "Vodič za postavljanje skaliranja"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Prebrisati konfiguracijske datoteke tijekom ažuriranja softvera?"
 
 msgid "Overwrite configuration files?"
@@ -6467,10 +6467,10 @@ msgstr "Dali stvarno želite sada isključiti?"
 msgid "Really store at index %2d for current position?"
 msgstr "Dali stvarno želite pohraniti u indeksu %2d za trenutnu poziciju?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Dali stvarno želite nadograditi frontprocessor i ponovno pokrenuti sustav?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Dali stvarno želite nadograditi svoj STB i ponovno pokrenuti sustav?"
 
 msgid "Reboot"
@@ -7376,10 +7376,10 @@ msgstr "Odaberite skup znakova pomaknutih virtualnom tipkovnicom"
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr "Odaberite skup znakova virtualne tipkovnice pomaknut samo za sljedeći znak"
 
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Odaberite izvor ažuriranja"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Odaberite izvor ažuriranja za uređivanje."
 
 msgid "Select video input with up/down buttons"
@@ -7766,7 +7766,7 @@ msgstr "Prikažite info traku pri preskakanju naprijed/natrag"
 msgid "Show latest commits"
 msgstr "Prikažite najnovije objave"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Prikažite posljednji log ažuriranja"
 
 msgid "Show menu or plugin numbers"
@@ -7799,7 +7799,7 @@ msgstr "Prikažite obavijest kada uvoz kanala nije uspio"
 msgid "Show notification when import channels was successful"
 msgstr "Prikažite obavijest kada je uvoz kanala uspio"
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Prikažite pakete koje treba nadograditi"
 
 msgid "Show picons in channel selection list"
@@ -9359,7 +9359,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr "Nije moguće kreirati potrebne direktorije na mediju (npr. USB stick ili HDD) - Provjerite medije i pokušajte ponovo!"
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9473,7 +9473,7 @@ msgstr "Ažuriranje feeda nije dostupno."
 msgid "Updating software catalog"
 msgstr "Ažuriranje kataloga softvera"
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Ažuriranje"
 
 msgid "Upper case"
@@ -9932,7 +9932,7 @@ msgstr "Zapadna Sahara"
 msgid "What type of service scan do you want?"
 msgstr "Koju vrstu skeniranja usluga želite?"
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Kada je omogućeno enigma2 učitat će nepovezane korisničke pakete. To znači da će korisnički paketi koji su dostupni, ali nisu uključeni u bouquets.tv ili bouquets.radio datoteke, i dalje biti učitani. To vam omogućuje, primjerice, da zadržite vlastiti korisnički paket dok su instalirane postavke nadograđene."
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10363,7 +10363,7 @@ msgid "Your current collection will get lost!"
 msgstr "Vaša trenutna kolekcija će se izgubiti!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -43,7 +43,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "A szoftver-frissítési forrás címének módosítása."
@@ -2950,7 +2950,7 @@ msgstr "Szeretné frissíteni a készülék szoftverét %s-re?"
 msgid "Do you want to update your receiver?"
 msgstr "Szeretné frissíteni a készülék szoftverét?"
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Biztos benne, hogy frissíteni szeretné ezt a csomagot:\n"
 
 msgid "Dolby"
@@ -2981,8 +2981,8 @@ msgid "Done"
 msgstr "Kész"
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "%d szoftvercsomag telepítése, frissítése vagy eltávolítása elkészült (%s)"
 msgstr[1] "%d szoftvercsomag telepítése, frissítése vagy eltávolítása elkészült (%s)"
 
@@ -3084,7 +3084,7 @@ msgstr "Időzítő módosítása"
 msgid "Edit title"
 msgstr "Cím módosítása"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "A frissítési forrás URL-jének szerkesztése."
 
 msgid "Education/Science/..."
@@ -4634,13 +4634,13 @@ msgstr "Utolsó konfiguráció"
 msgid "Last speed"
 msgstr "Utolsó sebesség"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Utolsó frissítés: "
 
 msgid "Latest Commits"
 msgstr "Utolsó módosítások"
 
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Utolsó frissítés jegyzéke"
 
 msgid "Latitude"
@@ -5656,7 +5656,7 @@ msgstr "Összes folyamat:"
 msgid "Overscan wizard"
 msgstr "Képernyőbeállító"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Konfigurációs fájlok felülírása szoftverfrissítése alkalmával?"
 
 msgid "Overwrite configuration files?"
@@ -6447,10 +6447,10 @@ msgstr "Biztos lekapcsoljam most?"
 msgid "Really store at index %2d for current position?"
 msgstr "Valóban tárolja a jelenlegi pozíciót a %d indexben?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Biztos benne, hogy frissíteni szeretné a frontprocesszort, majd újraindítani a készüléket?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Indulhat a frissítés, majd újraindítás?"
 
 msgid "Reboot"
@@ -7351,10 +7351,10 @@ msgstr "Váltás a virtuális billentyűzeten a 'shift' karakterkiosztásra"
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr "Váltás a virtuális billentyűzeten a 'shift' karakterkiosztásra csak a következő karakterre vonatkozóan"
 
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Válasszon szerkesztendő frissítési forrást"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Válasszon szerkesztendő frissítési forrást."
 
 msgid "Select video input with up/down buttons"
@@ -7742,7 +7742,7 @@ msgstr "Információs sáv megjelenítése Előre/Hátra ugrás esetén"
 msgid "Show latest commits"
 msgstr "Legutóbbi módosítások mutatása"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Utolsó frissítési naplófájl"
 
 msgid "Show menu or plugin numbers"
@@ -7775,7 +7775,7 @@ msgstr "Figyelmeztetés mutatása, ha a csatornák importálása sikertelen volt
 msgid "Show notification when import channels was successful"
 msgstr "Figyelmeztetés mutatása, ha a csatornák importálása sikeres volt"
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Frissítendő csomagok mutatása"
 
 msgid "Show picons in channel selection list"
@@ -9341,7 +9341,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr "Néhány könyvtárlétrehozása a médián (pl. USB meghajtó) nem sikerült. Ellenőrizze a médiát, majd próbálja újra!"
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9454,7 +9454,7 @@ msgstr "Frissítő szerver nem elérhető."
 msgid "Updating software catalog"
 msgstr "Szoftver-katalógus frissítése"
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Frissítés"
 
 msgid "Upper case"
@@ -9908,7 +9908,7 @@ msgstr "Nyugat-Szahara"
 msgid "What type of service scan do you want?"
 msgstr "Milyen típusú szolgáltatást szeretne keresni?"
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Ha engedélyezi, a leválasztott listák is betöltődnek. Ez azt jelenti, hogy az olyan felhasználói listák is betöltődnek, amelyek léteznek, de nincsnek benne a bouquets.tv vagy bouquets.radio fájlban. Ez lehetőséget ad arra, hogy a saját listáit megtartsa, ha a csatornák frissülnek."
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10342,7 +10342,7 @@ msgid "Your current collection will get lost!"
 msgstr "Az aktuális kapcsolata meg fog szűnni!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -43,7 +43,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Ubah alamat sumber peningkatan."
@@ -3002,7 +3002,7 @@ msgstr "Anda ingin memperbarui rx anda ke %s?"
 msgid "Do you want to update your receiver?"
 msgstr "Anda ingin memperbarui rx anda?"
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Anda ingin menaiktingkatkan paket:\n"
 
 msgid "Dolby"
@@ -3033,8 +3033,8 @@ msgid "Done"
 msgstr ""
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Selesai - Terpasang, dinaiktingkatkan atau dihapus %d paket (%s)"
 msgstr[1] "Selesai - Terpasang, dinaiktingkatkan atau dihapus %d paket (%s)"
 
@@ -3141,8 +3141,8 @@ msgstr "Ubah pewaktu"
 msgid "Edit title"
 msgstr "Ubah judul"
 
-msgid "Edit upgrade source url."
-msgstr "Ubah url sumber upgrade."
+msgid "Edit update source url."
+msgstr "Ubah url sumber update."
 
 msgid "Education/Science/..."
 msgstr "Edukasi/Sains/..."
@@ -4738,14 +4738,14 @@ msgstr "Pengaturan terakhir"
 msgid "Last speed"
 msgstr "Kecepatan terakhir"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Peningkatan terakhir: "
 
 msgid "Latest Commits"
 msgstr "Pengerjaan Terbaru"
 
 #, fuzzy
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Log peningkatan terbaru: "
 
 msgid "Latitude"
@@ -5786,8 +5786,8 @@ msgstr "Kemajuan keseluruhan"
 msgid "Overscan wizard"
 msgstr "Wizard overscan"
 
-msgid "Overwrite configuration files during software upgrade?"
-msgstr "Timpa file konfigurasi saat upgrade perangkat lunak?"
+msgid "Overwrite configuration files during software update?"
+msgstr "Timpa file konfigurasi saat update perangkat lunak?"
 
 msgid "Overwrite configuration files?"
 msgstr "Timpa file konfigurasi?"
@@ -6594,10 +6594,10 @@ msgstr "Yakin ingin mematikan rx sekarang?"
 msgid "Really store at index %2d for current position?"
 msgstr "Yakin menyimpan pada indeks %2d untuk posisi sekarang?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Yakin meningkatkan frontprosessor dan reboot sekarang?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Yakin meningkatkan Rx anda dan reboot sekarang?"
 
 msgid "Reboot"
@@ -7526,11 +7526,11 @@ msgstr "Pilih set karakter geser pada papankunci virtual"
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr "Pilih set karakter geser pada papankunci virtual"
 
-msgid "Select upgrade source"
-msgstr "Pilih sumber upgrade"
+msgid "Select update source"
+msgstr "Pilih sumber update"
 
-msgid "Select upgrade source to edit."
-msgstr "Pilih sumber upgrade untuk diubah."
+msgid "Select update source to edit."
+msgstr "Pilih sumber update untuk diubah."
 
 msgid "Select video input with up/down buttons"
 msgstr "Pilih input video dengan tombol up/down"
@@ -7925,7 +7925,7 @@ msgstr "Tampilkan infobar pada lewati ke depan/ke belakang "
 msgid "Show latest commits"
 msgstr "Tampilkan pengerjaan terbaru"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Tampilkan log peningkatan terbaru"
 
 msgid "Show menu or plugin numbers"
@@ -7958,7 +7958,7 @@ msgstr "Tampilkan pemberitahuan saat impor kanal tidak berhasil"
 msgid "Show notification when import channels was successful"
 msgstr "Tampilkan pemberitahuan saat impor kanal berhasil"
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Tampilkan paket-paket untuk ditingkatkan"
 
 msgid "Show picons in channel selection list"
@@ -9552,7 +9552,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr "Tidak bisa menyetel direktori yang diperlukan pada media (misalnya USB flashdisk) - Mohon periksa media lau coba lagi!"
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9671,7 +9671,7 @@ msgstr "Umpan pembaruan tidak tersedia."
 msgid "Updating software catalog"
 msgstr "Memperbarui katalog perangkat lunak"
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Meningkatkan"
 
 msgid "Upper case"
@@ -10137,7 +10137,7 @@ msgstr "Sahara Barat"
 msgid "What type of service scan do you want?"
 msgstr "Jenis pelacakan layanan apa yg anda inginkan?"
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Ketika diaktifkan enigma2 akan memuat buket pengguna yg tak terhubung. Ini berarti bahwa buket pengguna yg tersedia, tapi tidak disertakan dalam file bouquets.tv atau bouquets.radio, akan tetap dimuat. Ini memungkinkan anda misalnya untuk menyimpan buket pengguna anda sendiri sementara pengaturan yg terpasang sedang ditingkatkan"
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10578,7 +10578,7 @@ msgid "Your current collection will get lost!"
 msgstr "Koleksi anda saat ini akan hilang!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/is.po
+++ b/po/is.po
@@ -44,7 +44,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Breyta veffangi uppfærslu uppruna."
@@ -3215,7 +3215,7 @@ msgid "Do you want to update your receiver?"
 msgstr ""
 
 #
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Viltu uppfæra pakkann:\n"
 
 msgid "Dolby"
@@ -3248,8 +3248,8 @@ msgstr ""
 
 #
 #, fuzzy, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Búin, setti inn, uppfærði eða tót út %d pakka með %d villum"
 msgstr[1] "Búin, setti inn, uppfærði eða tót út %d pakka með %d villum"
 
@@ -3372,7 +3372,7 @@ msgstr ""
 msgid "Edit title"
 msgstr "Breyta titili"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Breyta uppfærslu uppruna slóð."
 
 msgid "Education/Science/..."
@@ -5115,7 +5115,7 @@ msgstr "Síðasta stilling"
 msgid "Last speed"
 msgstr "Síðasti hraði"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr ""
 
 msgid "Latest Commits"
@@ -5123,7 +5123,7 @@ msgstr ""
 
 #
 #, fuzzy
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Veldu upphafs slóð til að breyta."
 
 #
@@ -6332,7 +6332,7 @@ msgstr ""
 msgid "Overscan wizard"
 msgstr ""
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Skrifa yfir stillinga skrár við hugbúnaðar uppfærslu?"
 
 #, fuzzy
@@ -7274,10 +7274,10 @@ msgstr "Viltu örugglega slökkva núna?"
 msgid "Really store at index %2d for current position?"
 msgstr ""
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr ""
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr ""
 
 #
@@ -8341,11 +8341,11 @@ msgstr ""
 
 #
 #, fuzzy
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Veldu upphafs slóð til að breyta."
 
 #
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Veldu upphafs slóð til að breyta."
 
 #
@@ -8801,7 +8801,7 @@ msgstr "Sýna upplýsingaborða við stökk fram eða aftur"
 msgid "Show latest commits"
 msgstr ""
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr ""
 
 msgid "Show menu or plugin numbers"
@@ -8837,7 +8837,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr ""
 
 msgid "Show picons in channel selection list"
@@ -10636,7 +10636,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -10755,7 +10755,7 @@ msgid "Updating software catalog"
 msgstr "Uppfæri efnisyfirlit hugbúnaðar"
 
 #
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Uppfæri"
 
 msgid "Upper case"
@@ -11290,7 +11290,7 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -11732,7 +11732,7 @@ msgid "Your current collection will get lost!"
 msgstr "Núverandi safn þitt mun glatast!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -50,7 +50,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Modificare l'indirizzo dell'origine degli aggiornamenti."
@@ -2966,7 +2966,7 @@ msgstr "Aggiornare il ricevitore a %s?"
 msgid "Do you want to update your receiver?"
 msgstr "Aggiornare il ricevitore?"
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Aggiornare il pacchetto:\n"
 
 msgid "Dolby"
@@ -2997,8 +2997,8 @@ msgid "Done"
 msgstr ""
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Completato. Installato, aggiornato o rimosso %d pacchetto (%s)"
 msgstr[1] "Completato. Installati, aggiornati o rimossi %d pacchetti (%s)"
 
@@ -3101,7 +3101,7 @@ msgstr "Modificare il timer"
 msgid "Edit title"
 msgstr "Modificare il titolo"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Modificare l'URL di origine degli aggiornamenti."
 
 msgid "Education/Science/..."
@@ -4668,13 +4668,13 @@ msgstr "Ultima configurazione"
 msgid "Last speed"
 msgstr "Ultima velocità"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Ultimo aggiornamento: "
 
 msgid "Latest Commits"
 msgstr "Ultime modifiche"
 
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Ultimo registro di aggiornamento"
 
 msgid "Latitude"
@@ -5699,7 +5699,7 @@ msgstr "Avanzamento complessivo:"
 msgid "Overscan wizard"
 msgstr "Regolazione overscan"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Sovrascrivere i file di configurazione a seguito di un aggiornamento software?"
 
 msgid "Overwrite configuration files?"
@@ -6499,10 +6499,10 @@ msgstr "Spegnere adesso?"
 msgid "Really store at index %2d for current position?"
 msgstr "Registrare la posizione attuale all'indice %2d?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Aggiornare adesso il frontprocessor e riavviare?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Aggiornare adesso il ricevitore e riavviare?"
 
 msgid "Reboot"
@@ -7418,10 +7418,10 @@ msgstr ""
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr ""
 
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Selezionare l'origine degli aggiornamenti"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Selezionare l'origine degli aggiornamenti da modificare."
 
 msgid "Select video input with up/down buttons"
@@ -7814,7 +7814,7 @@ msgstr "Mostrare l'infobar sul salto in avanti o indietro"
 msgid "Show latest commits"
 msgstr "Mostrare le ultime modifiche"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Mostrare il registro dell'ultimo aggiornamento"
 
 #, fuzzy
@@ -7848,7 +7848,7 @@ msgstr "Mostrare una notifica quando i canali di importazione non sono stati com
 msgid "Show notification when import channels was successful"
 msgstr "Mostrare una notifica quando i canali di importazione sono stati completati"
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Mostrare i pacchetti da aggiornare"
 
 msgid "Show picons in channel selection list"
@@ -9444,7 +9444,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9562,7 +9562,7 @@ msgstr "Fonte degli aggiornamenti non disponibile."
 msgid "Updating software catalog"
 msgstr "Aggiornamento del catalogo software in corso..."
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Aggiornamento in corso..."
 
 msgid "Upper case"
@@ -10026,7 +10026,7 @@ msgstr "Sahara occidentale"
 msgid "What type of service scan do you want?"
 msgstr "Che tipo di scansione si desidera effettuare?"
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Se questa impostazione è attivata, Enigma2 caricherà anche tutti i bouquet disponibili ma non inclusi negli elenchi bouquet.tv o bouquet.radio. Questo consente ad esempio di conservare i propri bouquet personalizzati quando l'elenco canali viene aggiornato."
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10461,7 +10461,7 @@ msgid "Your current collection will get lost!"
 msgstr "La collezione attuale andrà perduta!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/ku.po
+++ b/po/ku.po
@@ -48,10 +48,10 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
-"Upgrate ra Eyaran Çékin"
+"Update ra Eyaran Çékin"
 
 msgid ""
 "\n"
@@ -2978,8 +2978,8 @@ msgstr "Do you want to update your receiver to %s?"
 msgid "Do you want to update your receiver?"
 msgstr "Do you want to update your receiver?"
 
-msgid "Do you want to upgrade the package:\n"
-msgstr "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
+msgstr "Do you want to update the package:\n"
 
 msgid "Dolby"
 msgstr ""
@@ -3009,10 +3009,10 @@ msgid "Done"
 msgstr ""
 
 #, fuzzy, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
-msgstr[0] "Done - Installed, upgraded or removed %d packages with %d errors"
-msgstr[1] "Done - Installed, upgraded or removed %d packages with %d errors"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
+msgstr[0] "Done - Installed, updated or removed %d packages with %d errors"
+msgstr[1] "Done - Installed, updated or removed %d packages with %d errors"
 
 msgid "Download plugins"
 msgstr "Dayni Girédayi"
@@ -3117,8 +3117,8 @@ msgstr ""
 msgid "Edit title"
 msgstr "Edit title"
 
-msgid "Edit upgrade source url."
-msgstr "Edit upgrade source url."
+msgid "Edit update source url."
+msgstr "Edit update source url."
 
 msgid "Education/Science/..."
 msgstr "Education/Science/..."
@@ -4673,15 +4673,15 @@ msgstr "Last config"
 msgid "Last speed"
 msgstr "Last speed"
 
-msgid "Last upgrade: "
-msgstr "Last upgrade: "
+msgid "Last update: "
+msgstr "Last update: "
 
 msgid "Latest Commits"
 msgstr ""
 
 #, fuzzy
-msgid "Latest upgrade log"
-msgstr "Last upgrade: "
+msgid "Latest update log"
+msgstr "Last update: "
 
 msgid "Latitude"
 msgstr "Latitude"
@@ -5718,8 +5718,8 @@ msgstr ""
 msgid "Overscan wizard"
 msgstr ""
 
-msgid "Overwrite configuration files during software upgrade?"
-msgstr "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
+msgstr "Overwrite configuration files during software update?"
 
 msgid "Overwrite configuration files?"
 msgstr "Overwrite configuration files?"
@@ -6524,11 +6524,11 @@ msgstr "Really shutdown now?"
 msgid "Really store at index %2d for current position?"
 msgstr ""
 
-msgid "Really upgrade the frontprocessor and reboot now?"
-msgstr "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
+msgstr "Really update the frontprocessor and reboot now?"
 
-msgid "Really upgrade your settop box and reboot now?"
-msgstr "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
+msgstr "Really update your settop box and reboot now?"
 
 msgid "Reboot"
 msgstr "Reboot"
@@ -7452,11 +7452,11 @@ msgstr ""
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr ""
 
-msgid "Select upgrade source"
-msgstr "Select upgrade source"
+msgid "Select update source"
+msgstr "Select update source"
 
-msgid "Select upgrade source to edit."
-msgstr "Select upgrade source to edit."
+msgid "Select update source to edit."
+msgstr "Select update source to edit."
 
 msgid "Select video input with up/down buttons"
 msgstr "Select video input with up/down buttons"
@@ -7851,7 +7851,7 @@ msgstr "Show infobar on skip forward/backward"
 msgid "Show latest commits"
 msgstr ""
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr ""
 
 msgid "Show menu or plugin numbers"
@@ -7884,7 +7884,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr ""
 
 msgid "Show picons in channel selection list"
@@ -9451,11 +9451,11 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 
@@ -9567,8 +9567,8 @@ msgstr "Updatefeed not available."
 msgid "Updating software catalog"
 msgstr "Updating software catalog"
 
-msgid "Upgrading"
-msgstr "Upgrading"
+msgid "Updating"
+msgstr "Updating"
 
 msgid "Upper case"
 msgstr ""
@@ -10030,7 +10030,7 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10455,11 +10455,11 @@ msgid "Your current collection will get lost!"
 msgstr "Your current collection will get lost!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -44,7 +44,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Redaguoti atnaujinimo šaltinių adresus."
@@ -2962,7 +2962,7 @@ msgstr "Ar norite atnaujinti įrangą į %s?"
 msgid "Do you want to update your receiver?"
 msgstr "Ar norite atnaujinti imtuvo įrangą?"
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Ar norite atnaujinti paketą:\n"
 
 msgid "Dolby"
@@ -2993,8 +2993,8 @@ msgid "Done"
 msgstr ""
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Baigta - įdiegtas, atnaujintas, ar pašalintas %d paketas (%s)"
 msgstr[1] "Baigta - įdiegti, atnaujinti ar pašalinti %d paketai (%s)"
 msgstr[2] "Baigta - įdiegta,atnaujinta ar pašalinta %d paketų (%s)"
@@ -3098,7 +3098,7 @@ msgstr "Redaguoti laikmatį"
 msgid "Edit title"
 msgstr "Redaguoti pavadinimą"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Redaguoti atnaujinimo šaltinio internetinį adresą."
 
 msgid "Education/Science/..."
@@ -4654,13 +4654,13 @@ msgstr "Paskutinė konfigūracija"
 msgid "Last speed"
 msgstr "Paskutinis greitis"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Paskutinis atnaujinimas: "
 
 msgid "Latest Commits"
 msgstr "Rodyti paskutinius veiksmus"
 
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Rodyti paskutinio atnaujinimo žurnalą"
 
 msgid "Latitude"
@@ -5684,7 +5684,7 @@ msgstr "Bendra eiga:"
 msgid "Overscan wizard"
 msgstr "Ekrano formato vedlys"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Ar atnaujinimo metu perrašyti konfigūracijos failus naujais?"
 
 msgid "Overwrite configuration files?"
@@ -6478,10 +6478,10 @@ msgstr "Tikrai išjungti dabar?"
 msgid "Really store at index %2d for current position?"
 msgstr "Tikrai šiai pozicijai išsaugoti ties %2d?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Tikrai atnaujinti priekinį procesorių ir paleisti iš naujo?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Tikrai atnaujinti jūsų priedėlį ir perkrauti dabar?"
 
 msgid "Reboot"
@@ -7390,10 +7390,10 @@ msgstr "Pasirinkite simbolių rinkinį su virtualia klaviatūra"
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr "Pasirinkite simbolių rinkinį su virtualia klaviatūra"
 
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Pasirinkite atnaujinimo šaltinį"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Pasirinkite atnaujinimo šaltinį redagavimui."
 
 msgid "Select video input with up/down buttons"
@@ -7782,7 +7782,7 @@ msgstr "Rodyti info juostą praleidžiant į priekį/atgal"
 msgid "Show latest commits"
 msgstr "Rodyti paskutinius veiksmus"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Rodyti paskutinio atnaujinimo žurnalą"
 
 msgid "Show menu or plugin numbers"
@@ -7815,7 +7815,7 @@ msgstr "Rodyti pranešimą, kai kanalų importas nepavyko"
 msgid "Show notification when import channels was successful"
 msgstr "Rodyti pranešimą, kai kanalų importas pavyko"
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Rodyti paketus, turinčius atnaujinimų"
 
 msgid "Show picons in channel selection list"
@@ -9382,7 +9382,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr "Neįmanoma nustatyti reikiamų katalogų laikmenose (pvz., USB atmintinėje) - Patikrinkite laikmeną ir bandykite dar kartą!"
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9496,7 +9496,7 @@ msgstr "Atnaujinimo šaltinis nepasiekiamas."
 msgid "Updating software catalog"
 msgstr "Atnaujinamas programinės įrangos katalogas"
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Atnaujinama"
 
 msgid "Upper case"
@@ -9955,7 +9955,7 @@ msgstr "Vakarinė Sahara"
 msgid "What type of service scan do you want?"
 msgstr "Kokio tipo kanalų nuskaitymo norite?"
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Kai čia įjungta enigma2 bus įkelti atsieti vartotojo paketai. Tai reiškia, kad vartotojo paketai, kurie yra prieinami, tačiau nėra įtraukti į paketai.tv ar paketai.radijas failus, vis tiek bus įkelti. Tai leidžia jums pvz. saugoti savo vartotojo paketus, o įdiegti nustatymai bus atnaujinti"
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10388,7 +10388,7 @@ msgid "Your current collection will get lost!"
 msgstr "Jūsų dabartinė kolekcija bus prarasta!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/lv.po
+++ b/po/lv.po
@@ -45,7 +45,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Rediģēt atjaunināšanas avota adresi."
@@ -2959,7 +2959,7 @@ msgstr "Vai vēlaties atjaunot uztvērēju uz %s?"
 msgid "Do you want to update your receiver?"
 msgstr "Vai vēlaties atjaunot uztvērēju?"
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Vai vēlaties atjaunināt pakotni:\n"
 
 msgid "Dolby"
@@ -2990,8 +2990,8 @@ msgid "Done"
 msgstr ""
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Pabeigts - instalēta, atjaunināta vai dzēsta %d pakotne (%s)"
 msgstr[1] "Pabeigts - instalētas, atjauninātas vai dzēstas %d pakotnes (%s)"
 msgstr[2] "Pabeigts - instalētas, atjauninātas vai dzēstas %d pakotnes (%s)"
@@ -3095,7 +3095,7 @@ msgstr "Rediģēt taimeri"
 msgid "Edit title"
 msgstr "Rediģēt nosaukumu"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Rediģēt atjaunināšanas avota adresi."
 
 msgid "Education/Science/..."
@@ -4651,13 +4651,13 @@ msgstr "Pēdējie iestatījumi"
 msgid "Last speed"
 msgstr "Pēdējais ātrums"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Pēdējā atjaunošana: "
 
 msgid "Latest Commits"
 msgstr "Izmaiņas"
 
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Pēdējās atjaunošanas žurnāls"
 
 msgid "Latitude"
@@ -5677,7 +5677,7 @@ msgstr "Izpilda:"
 msgid "Overscan wizard"
 msgstr "Attēla vednis"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Pārrakstīt konfigurācijas failus atjauninot programmatūru?"
 
 msgid "Overwrite configuration files?"
@@ -6470,10 +6470,10 @@ msgstr "Vai tiešām izslēgt?"
 msgid "Really store at index %2d for current position?"
 msgstr "Vai tiešām saglabāt numuru %2d pašreizējai pozīcijai?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Vai tiešām atjaunot frontprocesoru un pārstartēt tagad?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Vai tiešām atjaunot uztvērēju un pārstartēt tagad?"
 
 msgid "Reboot"
@@ -7381,10 +7381,10 @@ msgstr "Izvēlieties virtuālās tastatūras speciālo izkārtojumu"
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr "Izvēlieties virtuālās tastatūras speciālo izkārtojumu"
 
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Izvēlieties atjaunināšanas avotu"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Izvēlieties atjaunināšanas avotu lai rediģētu."
 
 msgid "Select video input with up/down buttons"
@@ -7771,7 +7771,7 @@ msgstr "Rādīt infojoslu pārlēciena turp/atpakaļ laikā"
 msgid "Show latest commits"
 msgstr "Parādīt jaunākās izmaiņas"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Rādīt pēdējās atjaunošanas žurnālu"
 
 msgid "Show menu or plugin numbers"
@@ -7804,7 +7804,7 @@ msgstr "Parādīt brīdinājumu kad imports nav izdevies"
 msgid "Show notification when import channels was successful"
 msgstr "Parādīt brīdinājumu kad imports ir izdevies"
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Parādīt paketes kuras tiks atjaunotas"
 
 msgid "Show picons in channel selection list"
@@ -9366,7 +9366,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr "Nevarēja izveidot nepieciešamās direktorijas datu nesējā (USB zibatmiņā vai HDD). Pārbaudiet datu nesēju un mēģiniet vēlreiz!"
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9480,7 +9480,7 @@ msgstr "Barotnes nav pieejamas."
 msgid "Updating software catalog"
 msgstr "Atjauno programmatūras katalogu"
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Atjauno"
 
 msgid "Upper case"
@@ -9939,7 +9939,7 @@ msgstr "Rietumsahāra"
 msgid "What type of service scan do you want?"
 msgstr "Kāda veida kanālu meklēšanu vēlaties veikt?"
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Ja ieslēgts, enigma ielādēs neiekļautās buķetes. Tas nozīmē ka buķetes tiek izmantotas, bet nav iekļautas bouquets.tv vai bouquets.radio failos. Tas atļauj saglabāt jūsu individuālās buķetes ja tiek atjaunoti uzstādījumi."
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10370,7 +10370,7 @@ msgid "Your current collection will get lost!"
 msgstr "Jūsu pašreizējā kolekcija zudīs!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -48,7 +48,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Rediger kildeadressen for oppdateringen."
@@ -3257,7 +3257,7 @@ msgid "Do you want to update your receiver?"
 msgstr "Oppdatere mottakeren?"
 
 #
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Oppdatere pakken:\n"
 
 msgid "Dolby"
@@ -3291,8 +3291,8 @@ msgstr "Utført"
 
 #
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Ferdig - Installert, oppdatert eller slettet %d pakke (%s)"
 msgstr[1] "Ferdig - Installert, oppdatert eller slettet %d pakker (%s)"
 
@@ -3407,7 +3407,7 @@ msgstr "Rediger timer"
 msgid "Edit title"
 msgstr "Rediger overskrift"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Rediger kilden til internettadresse."
 
 msgid "Education/Science/..."
@@ -5138,13 +5138,13 @@ msgstr "Siste innstilling"
 msgid "Last speed"
 msgstr "Siste hastighet"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Siste oppdatering: "
 
 msgid "Latest Commits"
 msgstr "Siste nytt"
 
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Siste oppdaterings logg"
 
 #
@@ -6290,7 +6290,7 @@ msgstr "Liten framdriftsbar:"
 msgid "Overscan wizard"
 msgstr "Veiviser for ekte bildestørrelse"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Overskrive konfigurerte filer under programvareoppdateringen?"
 
 #
@@ -7195,10 +7195,10 @@ msgstr "Slå av nå?"
 msgid "Really store at index %2d for current position?"
 msgstr "Lagre ved index %2d for denne posisjon?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Er du sikker på at du vil oppdatere frontprosessoren og starte på nytt?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Skal mottakeren oppdateres og starte på nytt nå?"
 
 msgid "Reboot"
@@ -8203,10 +8203,10 @@ msgstr "Velg virtuell tastaturs shift tegnsett"
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr "Velg det virtuelle tastaturs tegnoppsett bare for neste tegn"
 
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Velg oppdateringssted"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Rediger oppdateringssted."
 
 msgid "Select video input with up/down buttons"
@@ -8633,7 +8633,7 @@ msgstr "Vis infobar ved spoling framover/bakover"
 msgid "Show latest commits"
 msgstr "Vis siste nytt"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Vis siste oppdaterings logg"
 
 #
@@ -8669,7 +8669,7 @@ msgstr "Vis et varsel når import av kanaler mislyktes"
 msgid "Show notification when import channels was successful"
 msgstr "Vis et varsel når import av kanaler ble vellykket"
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Vis oppdateringer"
 
 msgid "Show picons in channel selection list"
@@ -10415,7 +10415,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr "Kan ikke opprette de nødvendige katalogene på mediet (for eksempel USB-pinne eller harddisk)-kontroller media og prøv igjen!"
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -10539,7 +10539,7 @@ msgid "Updating software catalog"
 msgstr "Oppdaterer programvarekatalog"
 
 #
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Oppdaterer"
 
 msgid "Upper case"
@@ -11041,7 +11041,7 @@ msgstr "Vest Sahara"
 msgid "What type of service scan do you want?"
 msgstr "Hvilken type kanalsøk vil du bruke?"
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Når dette er på, vil enigma2 laste kanallister som ikke er tilknyttet mottakeren. Dette kan være kanallister som er tilgjengelig, men ikke tilknyttet radio eller tv kanallistene for mottakeren. Dette tillater at du kan lagre for eksempel egne favorittlister mens oppgradering av innstillingene pågår"
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -11493,7 +11493,7 @@ msgid "Your current collection will get lost!"
 msgstr "Din nåværende samling vil gå tapt!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -43,10 +43,10 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
-"Wijzig het bronadres voor de upgrade."
+"Wijzig het bronadres voor de update."
 
 msgid ""
 "\n"
@@ -3136,7 +3136,7 @@ msgstr "Wilt u uw ontvanger updaten naar %s?"
 msgid "Do you want to update your receiver?"
 msgstr "Wilt u de ontvanger updaten?"
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Wilt u een dit pakket opwaarderen:\n"
 
 msgid "Dolby"
@@ -3167,8 +3167,8 @@ msgid "Done"
 msgstr "Gereed"
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Gereed - %d pakket geïnstalleerd, vervangen of verwijderd (%s)"
 msgstr[1] "Gereed - %d pakketten geïnstalleerd, vervangen of verwijderd (%s)"
 
@@ -3274,8 +3274,8 @@ msgstr "Wijzig timer"
 msgid "Edit title"
 msgstr "Wijzig titel"
 
-msgid "Edit upgrade source url."
-msgstr "Upgrade url bewerken."
+msgid "Edit update source url."
+msgstr "Update url bewerken."
 
 msgid "Education/Science/..."
 msgstr "Educatief/Wetenschappelijk /..."
@@ -4836,14 +4836,14 @@ msgstr "Laatste configuratie"
 msgid "Last speed"
 msgstr "Laatste snelheid"
 
-msgid "Last upgrade: "
-msgstr "Laatste upgrade: "
+msgid "Last update: "
+msgstr "Laatste update: "
 
 msgid "Latest Commits"
 msgstr "Laatste commits"
 
-msgid "Latest upgrade log"
-msgstr "Laatste upgrade log"
+msgid "Latest update log"
+msgstr "Laatste update log"
 
 msgid "Latitude"
 msgstr "Breedtegraad"
@@ -5863,7 +5863,7 @@ msgstr "Algemene voortgang:"
 msgid "Overscan wizard"
 msgstr "Overscan wizard"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Configuratie bestanden tijdens de software update overschrijven?"
 
 msgid "Overwrite configuration files?"
@@ -6679,10 +6679,10 @@ msgstr "Nu uitschakelen?"
 msgid "Really store at index %2d for current position?"
 msgstr "Index %2d voor huidige postitie opslaan?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Wilt u de frontprocessor nu echt updaten en herstarten?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Wilt u de ontvanger werkelijk updaten en herstarten?"
 
 msgid "Reboot"
@@ -7589,11 +7589,11 @@ msgstr "Kies de variabele tekenset op het virtuele toetsenbord"
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr "Kies enkel voor het volgende teken de variabele tekenset op het virtuele toetsenbord"
 
-msgid "Select upgrade source"
-msgstr "Kies de bron om te upgraden"
+msgid "Select update source"
+msgstr "Kies de bron om te updaten"
 
-msgid "Select upgrade source to edit."
-msgstr "Kies de te wijzigen upgradefeed."
+msgid "Select update source to edit."
+msgstr "Kies de te wijzigen updatefeed."
 
 msgid "Select video input with up/down buttons"
 msgstr "Selecteer video-ingang met de omhoog/omlaag toetsen"
@@ -7985,8 +7985,8 @@ msgstr "Informatiebalk zichtbaar na overslaan, vooruit/achteruit"
 msgid "Show latest commits"
 msgstr "Toon de laatste commits"
 
-msgid "Show latest upgrade log"
-msgstr "Toon het laatste upgrade log"
+msgid "Show latest update log"
+msgstr "Toon het laatste update log"
 
 msgid "Show menu or plugin numbers"
 msgstr "Toon telnummers in menu en plugins overzichten"
@@ -8018,8 +8018,8 @@ msgstr "Toon een melding indien de import is mislukt"
 msgid "Show notification when import channels was successful"
 msgstr "Toon een melding indien de import is gelukt"
 
-msgid "Show packages to be upgraded"
-msgstr "Toon de te upgraden pakketten"
+msgid "Show packages to be updated"
+msgstr "Toon de te updaten pakketten"
 
 msgid "Show picons in channel selection list"
 msgstr "Picons in kanalenlijst tonen"
@@ -9603,7 +9603,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr "Niet mogelijk om de benodigde map(pen) op het medium (b.v. USB stick of harde schijf) aan te maken. Controleer het medium en probeer het nogmaals."
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9716,7 +9716,7 @@ msgstr "Updatefeed niet beschikbaar."
 msgid "Updating software catalog"
 msgstr "Software catalogus wordt geüpdatet"
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Bezig met update"
 
 msgid "Upper case"
@@ -10191,7 +10191,7 @@ msgstr ""
 "\n"
 "Maak uw keuze en volg de aanwijzingen op het scherm. "
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Indien geactiveerd, dan zal Enigma de niet gelinkte zenderbouquetten laden. Dit houdt in, dat aanwezige gebruikerslijsten die niet aanwezig zijn in bouquets.tv of bouquets.radio alsnog geladen worden. Hiermee kunt u uw eigen wijzigingen in de zenderlijst behouden ondanks een mogelijke update van deze lijst. "
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10650,7 +10650,7 @@ msgid "Your current collection will get lost!"
 msgstr "Uw huidige collectie zal verloren gaan!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/nn.po
+++ b/po/nn.po
@@ -46,7 +46,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Endre oppdateringsadresse."
@@ -3239,7 +3239,7 @@ msgid "Do you want to update your receiver?"
 msgstr "Vil du oppdatere din mottaker?"
 
 #
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Vil du oppdatere pakken:\n"
 
 msgid "Dolby"
@@ -3271,8 +3271,8 @@ msgstr ""
 
 #
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Ferdig - Installert, oppdatert eller fjernet %d pakke (%s)"
 msgstr[1] "Ferdig - Installert, oppdatert eller fjernet %d pakker (%s)"
 
@@ -3393,7 +3393,7 @@ msgstr ""
 msgid "Edit title"
 msgstr "Endre navn"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Endre oppdateringens internettadresse."
 
 msgid "Education/Science/..."
@@ -5092,14 +5092,14 @@ msgstr "Siste innstilling"
 msgid "Last speed"
 msgstr "Siste hastighet"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Siste oppdatering:"
 
 msgid "Latest Commits"
 msgstr ""
 
 #, fuzzy
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Siste oppdatering:"
 
 #
@@ -6257,7 +6257,7 @@ msgstr ""
 msgid "Overscan wizard"
 msgstr ""
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Overskrive konfigurerte filer under programvareoppdateringen?"
 
 #
@@ -7146,10 +7146,10 @@ msgstr "Slå av nå?"
 msgid "Really store at index %2d for current position?"
 msgstr ""
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Vil du oppdatere frontprosessor og starte på nytt nå?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Vil du oppdatere mottakeren og starte på nytt nå?"
 
 msgid "Reboot"
@@ -8149,10 +8149,10 @@ msgstr ""
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr ""
 
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Velg oppdateringssted"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Velg og endre oppdateringssted."
 
 msgid "Select video input with up/down buttons"
@@ -8575,7 +8575,7 @@ msgstr "Vis informasjonslinje ved kanalhopp framover/bakover"
 msgid "Show latest commits"
 msgstr ""
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr ""
 
 msgid "Show menu or plugin numbers"
@@ -8608,7 +8608,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr ""
 
 msgid "Show picons in channel selection list"
@@ -10330,7 +10330,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -10456,7 +10456,7 @@ msgid "Updating software catalog"
 msgstr "Oppdaterer programvare katalog"
 
 #
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Oppdaterer"
 
 msgid "Upper case"
@@ -10958,7 +10958,7 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -11403,7 +11403,7 @@ msgid "Your current collection will get lost!"
 msgstr "Din nåværende samling vil gå tapt!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -43,7 +43,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Edytuj adres aktualizacji."
@@ -2964,7 +2964,7 @@ msgstr "Chcesz zaktualizować oprogramowanie odbiornika do %s?"
 msgid "Do you want to update your receiver?"
 msgstr "Chcesz zaktualizować oprogramowanie odbiornika?"
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Chcesz zaktualizować pakiet:\n"
 
 msgid "Dolby"
@@ -2995,8 +2995,8 @@ msgid "Done"
 msgstr "Gotowe"
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Gotowe - zainstalowano, zaktualizowano lub usunięto %d pakiet (%s)"
 msgstr[1] "Gotowe - zainstalowano, zaktualizowano lub usunięto %d pakiety (%s)"
 msgstr[2] "Gotowe - zainstalowano, zaktualizowano lub usunięto %d pakietów (%s)"
@@ -3099,7 +3099,7 @@ msgstr "Edytuj timer"
 msgid "Edit title"
 msgstr "Edytuj tytuł"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Edytuj adres aktualizacji"
 
 msgid "Education/Science/..."
@@ -4651,13 +4651,13 @@ msgstr "Ostatnie ustawienia"
 msgid "Last speed"
 msgstr "Ostatnia prędkość"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Ostatnia aktualizacja:"
 
 msgid "Latest Commits"
 msgstr "Ostatnie commit'y"
 
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Ostatni log aktualizacji"
 
 msgid "Latitude"
@@ -5672,7 +5672,7 @@ msgstr "Ogólny postęp:"
 msgid "Overscan wizard"
 msgstr "Test overscan"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Nadpisać pliki konfiguracyjne podczas aktualizacji?"
 
 msgid "Overwrite configuration files?"
@@ -6463,11 +6463,11 @@ msgstr "Wyłączyć teraz?"
 msgid "Really store at index %2d for current position?"
 msgstr "Przechowywać pod indeksem %2d dla aktualnej pozycji"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
-msgstr "Wykonać teraz upgrade frontprocesora i zrestartować STB?"
+msgid "Really update the frontprocessor and reboot now?"
+msgstr "Wykonać teraz update frontprocesora i zrestartować STB?"
 
-msgid "Really upgrade your settop box and reboot now?"
-msgstr "Wykonać upgrade odbiornika i zrestartować?"
+msgid "Really update your settop box and reboot now?"
+msgstr "Wykonać update odbiornika i zrestartować?"
 
 msgid "Reboot"
 msgstr ""
@@ -7372,10 +7372,10 @@ msgstr "Wybierz zestaw znaków klawiatury wirtualnej z 'SHIFT'"
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr "Wybierz alternatywny znak (z SHIFT) klawiatury wirtualnej tylko dla kolejnego znaku"
 
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Wybierz źródło aktualizacji"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Wybierz źródło aktualizacji do edycji"
 
 msgid "Select video input with up/down buttons"
@@ -7762,7 +7762,7 @@ msgstr "Pokaż pasek info przy przewijaniu przód/tył"
 msgid "Show latest commits"
 msgstr "Wyświetl ostatnie commity"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Ostatni log aktualizacji"
 
 msgid "Show menu or plugin numbers"
@@ -7795,7 +7795,7 @@ msgstr "Pokazuj informację gdy import kanałów się nie powiódł"
 msgid "Show notification when import channels was successful"
 msgstr "Pokazuj informację gdy import kanałów się powiódł"
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Pakiety do zaktualizowania"
 
 msgid "Show picons in channel selection list"
@@ -9358,7 +9358,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr "Nie można utworzyć wymaganych katalogów na nośniku (np. pamięć USB lub dysk twardy) - sprawdź nośnik i spróbuj ponownie!"
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9472,7 +9472,7 @@ msgstr "Aktualizacje nie dostępne."
 msgid "Updating software catalog"
 msgstr "Aktualizowanie katalogu oprogramowania"
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Aktualizowanie"
 
 msgid "Upper case"
@@ -9930,7 +9930,7 @@ msgstr "Sahara Zachodnia"
 msgid "What type of service scan do you want?"
 msgstr "Jaki typ skanowania kanałów wybierasz?"
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Gdy włączone, system będzie ładować także niepodlinkowane bukiety. To oznacza, że bukiety użytkownika nie uwzględnione w  plikach bouquets.tv lub bouquets.radio nadal będą dostępne. To pozwala np. zachować własne bukiety, gdy lista zainstalowana z feedu jest aktualizowana"
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10361,11 +10361,11 @@ msgid "Your current collection will get lost!"
 msgstr "Twoja obecna kolekcja zostanie utracona!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
-"Nastąpi upgrade frontprocesora\n"
+"Nastąpi update frontprocesora\n"
 "Czekaj aż odbiornik zrestartuje się\n"
 "To może potrwać kilka minut"
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -46,7 +46,7 @@ msgstr ""
 #
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Editar o endereço da fonte de actualização."
@@ -3388,7 +3388,7 @@ msgid "Do you want to update your receiver?"
 msgstr "Deseja actualizar o receptor?"
 
 #
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Deseja actualizar o pacote:\n"
 
 msgid "Dolby"
@@ -3421,8 +3421,8 @@ msgstr ""
 
 #
 #, fuzzy, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Concluído - Instalado, actualizado, ou removido %d pacote com %d erros"
 msgstr[1] "Concluído - Instalados, actualizados, ou removidos %d pacotes com %d erros"
 
@@ -3550,7 +3550,7 @@ msgid "Edit title"
 msgstr "Editar o título"
 
 #
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Editar o URL da fonte de actualização."
 
 msgid "Education/Science/..."
@@ -5313,14 +5313,14 @@ msgid "Last speed"
 msgstr "Última velocidade"
 
 #, fuzzy
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Última actualização: "
 
 msgid "Latest Commits"
 msgstr "Últimos commits"
 
 #, fuzzy
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Última actualização: "
 
 #
@@ -6540,7 +6540,7 @@ msgstr ""
 msgid "Overscan wizard"
 msgstr ""
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Substituir os ficheiros de configuração durante a actualização de software?"
 
 #, fuzzy
@@ -7507,10 +7507,10 @@ msgstr "Desligar agora?"
 msgid "Really store at index %2d for current position?"
 msgstr ""
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Actualizar o processador e reiniciar agora?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Actualizar o receptor e reiniciar agora?"
 
 #
@@ -8596,11 +8596,11 @@ msgstr ""
 
 #
 #, fuzzy
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Seleccionar fonte de actualizações"
 
 #
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Seleccionar fonte de actualizações para editar."
 
 #
@@ -9062,7 +9062,7 @@ msgstr "Mostrar barra informativa ao avançar/retroceder canal"
 msgid "Show latest commits"
 msgstr ""
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr ""
 
 msgid "Show menu or plugin numbers"
@@ -9098,7 +9098,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr ""
 
 msgid "Show picons in channel selection list"
@@ -10919,7 +10919,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -11048,7 +11048,7 @@ msgid "Updating software catalog"
 msgstr "A actualizar o catalogo de software"
 
 #
-msgid "Upgrading"
+msgid "Updating"
 msgstr "A actualizar"
 
 msgid "Upper case"
@@ -11601,7 +11601,7 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -12057,7 +12057,7 @@ msgid "Your current collection will get lost!"
 msgstr "A sua colecção actual irá perder-se!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -45,7 +45,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Editar o endereço do repositório de atualizações."
@@ -2973,7 +2973,7 @@ msgstr "Atualizar o receptor para %s?"
 msgid "Do you want to update your receiver?"
 msgstr "Deseja atualizar o receptor?"
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Deseja atualizar o pacote:\n"
 
 msgid "Dolby"
@@ -3004,8 +3004,8 @@ msgid "Done"
 msgstr ""
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Terminado - Instalado, atualizado ou removido %d pacote (%s)"
 msgstr[1] "Terminado - Instalados, atualizados ou removidos %d pacotes (%s)"
 
@@ -3112,7 +3112,7 @@ msgstr ""
 msgid "Edit title"
 msgstr "Editar título"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Editar URL da fonte de atualização."
 
 msgid "Education/Science/..."
@@ -4667,14 +4667,14 @@ msgstr "Última configuração"
 msgid "Last speed"
 msgstr "Última velocidade"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Última atualização:"
 
 msgid "Latest Commits"
 msgstr ""
 
 #, fuzzy
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Última atualização:"
 
 msgid "Latitude"
@@ -5711,7 +5711,7 @@ msgstr ""
 msgid "Overscan wizard"
 msgstr ""
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Substituir os arquivos de configuração durante a atualização de software?"
 
 msgid "Overwrite configuration files?"
@@ -6519,10 +6519,10 @@ msgstr "Desligar agora?"
 msgid "Really store at index %2d for current position?"
 msgstr ""
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Atualizar o processador e reiniciar agora?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Atualizar o receptor e reiniciar agora?"
 
 msgid "Reboot"
@@ -7446,10 +7446,10 @@ msgstr ""
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr ""
 
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Servidores de atualizações"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Selecione a fonte de atualizações para editar"
 
 msgid "Select video input with up/down buttons"
@@ -7845,7 +7845,7 @@ msgstr "Barra de informações ao avançar/retornar"
 msgid "Show latest commits"
 msgstr ""
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr ""
 
 msgid "Show menu or plugin numbers"
@@ -7878,7 +7878,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr ""
 
 msgid "Show picons in channel selection list"
@@ -9444,7 +9444,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9560,7 +9560,7 @@ msgstr "Servidor de atualizações não disponível."
 msgid "Updating software catalog"
 msgstr "Atualizando o catálogo de software..."
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Atualizando..."
 
 msgid "Upper case"
@@ -10025,7 +10025,7 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10451,7 +10451,7 @@ msgid "Your current collection will get lost!"
 msgstr "A coleção atual será descartada!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/ro.po
+++ b/po/ro.po
@@ -43,10 +43,10 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
-"Editati pe adresa de upgrade."
+"Editati pe adresa de update."
 
 msgid ""
 "\n"
@@ -3013,7 +3013,7 @@ msgstr "Doriti restaurarea setarilor dvs?"
 msgid "Do you want to update your receiver?"
 msgstr ""
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Doriti actualizarea pachetului:\n"
 
 msgid "Dolby"
@@ -3044,8 +3044,8 @@ msgid "Done"
 msgstr ""
 
 #, fuzzy, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "S-a finalizat instalarea, actualizarea sau stergerea a %d pachete cu %d erori"
 msgstr[1] "S-a finalizat instalarea, actualizarea sau stergerea a %d pachete cu %d erori"
 
@@ -3154,7 +3154,7 @@ msgstr ""
 msgid "Edit title"
 msgstr "Editare titlu"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr ""
 
 msgid "Education/Science/..."
@@ -4745,14 +4745,14 @@ msgstr ""
 msgid "Last speed"
 msgstr "Ultima viteza"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr ""
 
 msgid "Latest Commits"
 msgstr ""
 
 #, fuzzy
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Alege sursa de actualizare"
 
 msgid "Latitude"
@@ -5818,7 +5818,7 @@ msgstr ""
 msgid "Overscan wizard"
 msgstr ""
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr ""
 
 #, fuzzy
@@ -6636,10 +6636,10 @@ msgstr "Inchideti acum?"
 msgid "Really store at index %2d for current position?"
 msgstr ""
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr ""
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr ""
 
 msgid "Reboot"
@@ -7590,10 +7590,10 @@ msgid "Select the virtual keyboard shifted character set for the next character 
 msgstr ""
 
 #, fuzzy
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Alege sursa de actualizare"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr ""
 
 msgid "Select video input with up/down buttons"
@@ -8004,7 +8004,7 @@ msgstr "Arata bara de informatii la saltul inainte/inapoi"
 msgid "Show latest commits"
 msgstr ""
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr ""
 
 msgid "Show menu or plugin numbers"
@@ -8038,7 +8038,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr ""
 
 msgid "Show picons in channel selection list"
@@ -9636,7 +9636,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9749,8 +9749,8 @@ msgstr ""
 msgid "Updating software catalog"
 msgstr ""
 
-msgid "Upgrading"
-msgstr "Upgradare"
+msgid "Updating"
+msgstr "Updatare"
 
 msgid "Upper case"
 msgstr ""
@@ -10221,7 +10221,7 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10641,7 +10641,7 @@ msgid "Your current collection will get lost!"
 msgstr ""
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -43,7 +43,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Редактировать адрес источника обновления."
@@ -2962,7 +2962,7 @@ msgstr "Вы хотите обновить Ваш ресивер от %s?"
 msgid "Do you want to update your receiver?"
 msgstr "Вы хотите обновить ваш ресивер?"
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Вы хотите обновить пакеты:\n"
 
 msgid "Dolby"
@@ -2993,8 +2993,8 @@ msgid "Done"
 msgstr "Готово"
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Выполнено - Установлен, обновлен или удален %d пакет (%s)"
 msgstr[1] "Выполнено - Установлено, обновлено или удалено %d пакета (%s)"
 msgstr[2] "Выполнено - Установлено, обновлено или удалено %d пакетов (%s)"
@@ -3097,7 +3097,7 @@ msgstr "Редактировать таймер"
 msgid "Edit title"
 msgstr "Редактировать название"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Редактировать URL-адрес источника обновления"
 
 msgid "Education/Science/..."
@@ -4649,13 +4649,13 @@ msgstr "Последнии настройки"
 msgid "Last speed"
 msgstr "Последняя скорость"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Последнее обновление: "
 
 msgid "Latest Commits"
 msgstr "Последние изменения"
 
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Показать последний лог обновления"
 
 msgid "Latitude"
@@ -5672,7 +5672,7 @@ msgstr "Общий прогресс:"
 msgid "Overscan wizard"
 msgstr "Мастер настройки переразвертки"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Переписывать файлы конфигурации во время обновления ПО?"
 
 msgid "Overwrite configuration files?"
@@ -6463,10 +6463,10 @@ msgstr "Действительно выполнить выключение се�
 msgid "Really store at index %2d for current position?"
 msgstr "Действительно сохранить номер %2d для текущей позиции?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Обновить фронтпроцессор и выполнить перезагрузку сейчас?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Действительно обновить Ваш ресивер и выполнить перезагрузку сейчас?"
 
 msgid "Reboot"
@@ -7374,10 +7374,10 @@ msgstr "Выберите набор символов с виртуальной �
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr "Выберите набор символов со сдвигом виртуальной клавиатуры только для следующего символа"
 
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Выбор источника обновления"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Выбор источника обновления для редактирования."
 
 msgid "Select video input with up/down buttons"
@@ -7764,7 +7764,7 @@ msgstr "Показать инфобар при перемотке вперед/�
 msgid "Show latest commits"
 msgstr "Показать последние изменения на гите"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Показать последний лог обновления"
 
 msgid "Show menu or plugin numbers"
@@ -7797,7 +7797,7 @@ msgstr "Показывать уведомление, когда импорт к�
 msgid "Show notification when import channels was successful"
 msgstr "Показывать уведомление, когда импорт каналов удался"
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Показать пакеты, которые будут обновлены"
 
 msgid "Show picons in channel selection list"
@@ -9355,7 +9355,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr "Невозможно создать необходимые каталоги на носителе (например, USB-накопитель или жесткий диск). Пожалуйста, проверьте носитель и попробуйте снова!"
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9469,7 +9469,7 @@ msgstr "Обновления с фида не доступны."
 msgid "Updating software catalog"
 msgstr "Обновление каталога ПО"
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Обновление"
 
 msgid "Upper case"
@@ -9927,7 +9927,7 @@ msgstr "Western Sahara"
 msgid "What type of service scan do you want?"
 msgstr "Какой тип сканирования Вы хотите выбрать?"
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Если это включено, то при старте энигма2 будут загружены доступные букеты, которые не включены в списки bouquets.tv или bouquets.radio."
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10358,7 +10358,7 @@ msgid "Your current collection will get lost!"
 msgstr "Ваша текущая коллекция будет утеряна!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/sk.po
+++ b/po/sk.po
@@ -44,7 +44,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Upraviť adresu zdroja aktualizácií."
@@ -2969,7 +2969,7 @@ msgstr "Chcete aktualizovať Váš prijímač na %s?"
 msgid "Do you want to update your receiver?"
 msgstr "Chcete aktualizovať Váš prijímač?"
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Chcete aktualizovať balíček:\n"
 
 msgid "Dolby"
@@ -3000,8 +3000,8 @@ msgid "Done"
 msgstr "Hotovo"
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Hotovo - Nainštalovaný, aktualizovaný alebo odstránený %d balíček (%s)"
 msgstr[1] "Hotovo - Nainštalové, aktualizované alebo odstránené %d balíčky (%s)"
 msgstr[2] "Hotovo - Nainštalovaných, aktualizovaných alebo odstránených %d balíčkov (%s)"
@@ -3105,7 +3105,7 @@ msgstr "Úpraviť časovač"
 msgid "Edit title"
 msgstr "Upraviť titul"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Upraviť URL zdroja aktualizácie."
 
 msgid "Education/Science/..."
@@ -4662,13 +4662,13 @@ msgstr "Posledné nastavenie"
 msgid "Last speed"
 msgstr "Posledná rýchlosť"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Posledná aktualizácia: "
 
 msgid "Latest Commits"
 msgstr "Posledné zmeny"
 
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Protokol poslednej aktualizácie"
 
 msgid "Latitude"
@@ -5683,7 +5683,7 @@ msgstr "Celkový priebeh:"
 msgid "Overscan wizard"
 msgstr "Nastavenie veľkosti obrazu (Overscan)"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Prepísať konfiguračné súbory pri aktualizácii softvéru?"
 
 msgid "Overwrite configuration files?"
@@ -6474,10 +6474,10 @@ msgstr "Naozaj teraz vypnúť?"
 msgid "Really store at index %2d for current position?"
 msgstr "Naozaj uložiť na indexe %2d pre aktuálnu pozíciu?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Naozaj aktualizovať frontprocessor a reštartovať prijímač?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Naozaj aktualizovať a reštartovať prijímač?"
 
 msgid "Reboot"
@@ -7381,10 +7381,10 @@ msgstr "Vyberte znakovú sadu virtuálnej klávesnice po stlačení klávesy Shi
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr "Vyberte znakovú sadu virtuálnej klávesnice po stlačení klávesy Shift iba pre ďalší znak"
 
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Zvoľte zdroj aktualizácie"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Zvoľte zdroj aktualizácie, ktorý chcete upraviť."
 
 msgid "Select video input with up/down buttons"
@@ -7771,7 +7771,7 @@ msgstr "Zobraziť infopanel pri skoku vpred/vzad"
 msgid "Show latest commits"
 msgstr "Zobraziť posledné zmeny"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Zobraziť protokol z poslednej aktualizácie"
 
 msgid "Show menu or plugin numbers"
@@ -7804,7 +7804,7 @@ msgstr "Zobraziť notifikáciu v prípade, keď nebol import staníc úspešne d
 msgid "Show notification when import channels was successful"
 msgstr "Zobraziť notifikáciu v prípade, keď bol import staníc úspešne dokončený"
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Zobraziť balíčky dostupnej aktualizácie"
 
 msgid "Show picons in channel selection list"
@@ -9368,7 +9368,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr "Nebolo možné vytvoriť požadované zložky na disku (napr. USB kľúč alebo pevný disk) - skontrolujte prosím médium a skúste to znovu!"
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9482,7 +9482,7 @@ msgstr "Zdroj aktualizácií nie je k dispozícií."
 msgid "Updating software catalog"
 msgstr "Aktualizácia katalógu softvéru"
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Aktualizujem"
 
 msgid "Upper case"
@@ -9939,7 +9939,7 @@ msgstr "Západná Sahara"
 msgid "What type of service scan do you want?"
 msgstr "Aký typ staníc chcete prehľadať?"
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Ak je povolené, enigma2 načíta neprepojené užívateľské prehľady. To znamená, že užívateľské prehľady, ktoré sú k dispozícii, ale nie sú zahrnuté v bouquets.tv alebo bouquets.radio súboroch sa aj napriek tomu načítajú. To Vám umožňuje napríklad zachovať Vaše vlastné užívateľské prehľady po inštalácii a inovácii nastavení."
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10370,7 +10370,7 @@ msgid "Your current collection will get lost!"
 msgstr "Vaša aktuálna zostava bude stratená!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -44,7 +44,7 @@ msgstr ""
 #
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Sprememba vira za nadgradnjo sprejemnika."
@@ -3397,7 +3397,7 @@ msgid "Do you want to update your receiver?"
 msgstr "Želite posodobiti vaš sprejemnik na zadnjo verzijo OpenPLi slike?"
 
 #
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Želite nadgraditi paket:\n"
 
 msgid "Dolby"
@@ -3430,8 +3430,8 @@ msgstr ""
 
 #
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Končano - nameščen, nadgrajen ali izbrisan je bil %d paket (%s)."
 msgstr[1] "Končano - nameščena, nadgrajena ali izbrisana sta bila %d paketa (%s)."
 msgstr[2] "Končano - nameščeni, nadgrajeni ali izbrisani so bili %d paketi (%s)."
@@ -3566,7 +3566,7 @@ msgid "Edit title"
 msgstr "Spremenite naslov"
 
 #
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Uredite povezavo vira za nadgradnjo."
 
 msgid "Education/Science/..."
@@ -5331,14 +5331,14 @@ msgstr "Prejšnje nastavitve"
 msgid "Last speed"
 msgstr "Zadnja hitrost"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Zadnja nadgradnja: "
 
 msgid "Latest Commits"
 msgstr "Zadnje spremembe"
 
 #, fuzzy
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Prikaz zadnjega dnevnika nadgradnje"
 
 #
@@ -6535,7 +6535,7 @@ msgstr ""
 msgid "Overscan wizard"
 msgstr ""
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Prepis nastavitvenih datotek pri nadgradnji programske opreme?"
 
 msgid "Overwrite configuration files?"
@@ -7490,10 +7490,10 @@ msgstr "Res želite izklopiti sprejemnik?"
 msgid "Really store at index %2d for current position?"
 msgstr ""
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Resnično želite nadgraditi frontprocessor in ponovno zagnati sprejemnik?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Res želite nadgraditi sprejemnik in ga ponovno zagnati?"
 
 #
@@ -8575,11 +8575,11 @@ msgid "Select the virtual keyboard shifted character set for the next character 
 msgstr ""
 
 #
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Izberite vir nadgradnje"
 
 #
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Izberite vir, ki ga boste urejali."
 
 #
@@ -9034,7 +9034,7 @@ msgstr "Prikaz info. vrstice med preskakovanjem naprej/nazaj"
 msgid "Show latest commits"
 msgstr "Prikaz zadnjih OpenPLi sprememb"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Prikaz zadnjega dnevnika nadgradnje"
 
 msgid "Show menu or plugin numbers"
@@ -9069,7 +9069,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Prikaz paketov, ki bodo nadgrajeni"
 
 msgid "Show picons in channel selection list"
@@ -10862,7 +10862,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -10992,7 +10992,7 @@ msgid "Updating software catalog"
 msgstr "Poteka posodabljanje kataloga programov ..."
 
 #
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Nadgrajujem"
 
 msgid "Upper case"
@@ -11527,7 +11527,7 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -11983,7 +11983,7 @@ msgid "Your current collection will get lost!"
 msgstr "Vašo trenutno zbirko boste izgubili!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -47,7 +47,7 @@ msgstr ""
 #
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Uredi poboljšanu izvornu adresu"
@@ -3409,7 +3409,7 @@ msgid "Do you want to update your receiver?"
 msgstr ""
 
 #
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Da li želite da nadogradite paket:\n"
 
 msgid "Dolby"
@@ -3442,8 +3442,8 @@ msgstr ""
 
 #
 #, fuzzy, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Učinjeno,instalisano,nadograđeno ili uklonjeno %d paketa sa %d grešaka"
 msgstr[1] "Učinjeno,instalisano,nadograđeno ili uklonjeno %d paketa sa %d grešaka"
 msgstr[2] "Učinjeno,instalisano,nadograđeno ili uklonjeno %d paketa sa %d grešaka"
@@ -3577,7 +3577,7 @@ msgid "Edit title"
 msgstr "Urediti naslov"
 
 #
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Uredi url izvora nadogradnje."
 
 msgid "Education/Science/..."
@@ -5352,7 +5352,7 @@ msgstr "Zadnji konfig"
 msgid "Last speed"
 msgstr "Poslednja brzina"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr ""
 
 msgid "Latest Commits"
@@ -5360,7 +5360,7 @@ msgstr ""
 
 #
 #, fuzzy
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Izaberi izvor nadodradnje za uređivanje."
 
 #
@@ -6586,7 +6586,7 @@ msgstr ""
 msgid "Overscan wizard"
 msgstr ""
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Prepiši konfiguracione datoteke za vreme nadograđivanja softvera?"
 
 #, fuzzy
@@ -7546,10 +7546,10 @@ msgstr "Stvarno ugasiti sada?"
 msgid "Really store at index %2d for current position?"
 msgstr ""
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr ""
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr ""
 
 #
@@ -8633,11 +8633,11 @@ msgstr ""
 
 #
 #, fuzzy
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Izaberi izvor nadodradnje za uređivanje."
 
 #
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Izaberi izvor nadodradnje za uređivanje."
 
 #
@@ -9100,7 +9100,7 @@ msgstr "Prikaži info traku na preskakanju napred/nazad"
 msgid "Show latest commits"
 msgstr ""
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr ""
 
 msgid "Show menu or plugin numbers"
@@ -9137,7 +9137,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr ""
 
 msgid "Show picons in channel selection list"
@@ -10951,7 +10951,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -11078,7 +11078,7 @@ msgid "Updating software catalog"
 msgstr "Ažuriranje kataloga softvera"
 
 #
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Nadograđujem"
 
 msgid "Upper case"
@@ -11617,7 +11617,7 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -12066,7 +12066,7 @@ msgid "Your current collection will get lost!"
 msgstr "Vaša aktuelna kolekcija će biti izgubljena!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -48,10 +48,10 @@ msgstr ""
 #
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
-"Ändra uppgraderingskällans adress."
+"Ändra uppdateringskällans adress."
 
 msgid ""
 "\n"
@@ -3330,8 +3330,8 @@ msgid "Do you want to update your receiver?"
 msgstr "Vill du uppdatera din mottagare?"
 
 #
-msgid "Do you want to upgrade the package:\n"
-msgstr "Vill du uppgradera paketet :\n"
+msgid "Do you want to update the package:\n"
+msgstr "Vill du uppdatera paketet :\n"
 
 msgid "Dolby"
 msgstr ""
@@ -3363,10 +3363,10 @@ msgstr ""
 
 #
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
-msgstr[0] "Klar - installerat, uppgraderat eller avinstallerat %d paket (%s)"
-msgstr[1] "Klar - installerat, uppgraderat eller avinstallerat %d paket (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
+msgstr[0] "Klar - installerat, uppdaterat eller avinstallerat %d paket (%s)"
+msgstr[1] "Klar - installerat, uppdaterat eller avinstallerat %d paket (%s)"
 
 #
 msgid "Download plugins"
@@ -3489,8 +3489,8 @@ msgstr "Ändra timer"
 msgid "Edit title"
 msgstr "Ändra titel"
 
-msgid "Edit upgrade source url."
-msgstr "Ändra uppgraderingskällans url."
+msgid "Edit update source url."
+msgstr "Ändra uppdateringskällans url."
 
 msgid "Education/Science/..."
 msgstr "Utbildning / Vetenskap / ..."
@@ -5225,14 +5225,14 @@ msgstr "Senaste konfiguration"
 msgid "Last speed"
 msgstr "Föregående hastighet"
 
-msgid "Last upgrade: "
-msgstr "Senaste uppgradering :"
+msgid "Last update: "
+msgstr "Senaste uppdatering :"
 
 msgid "Latest Commits"
 msgstr "Senaste commits"
 
 #, fuzzy
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Visa senaste uppdateringslogg"
 
 #
@@ -6409,8 +6409,8 @@ msgstr "Generellt framsteg :"
 msgid "Overscan wizard"
 msgstr "Överskanningsguide"
 
-msgid "Overwrite configuration files during software upgrade?"
-msgstr "Skriva över konfigurationsfilerna vid mjukvaruuppgradering?"
+msgid "Overwrite configuration files during software update?"
+msgstr "Skriva över konfigurationsfilerna vid mjukvaruuppdatering?"
 
 msgid "Overwrite configuration files?"
 msgstr "Skriva över konfigurationsfilerna ?"
@@ -7342,10 +7342,10 @@ msgstr "Verkligen stänga av nu?"
 msgid "Really store at index %2d for current position?"
 msgstr "Vill du verkligen spara vid index %2d för denna position?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
-msgstr "Vill du verkligen uppgradera frontprocessorn och starta om nu?"
+msgid "Really update the frontprocessor and reboot now?"
+msgstr "Vill du verkligen uppdatera frontprocessorn och starta om nu?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Vill du verkligen uppdatera din mottagare och starta om nu?"
 
 #
@@ -8397,12 +8397,12 @@ msgid "Select the virtual keyboard shifted character set for the next character 
 msgstr ""
 
 #
-msgid "Select upgrade source"
-msgstr "Ange uppgraderingskälla."
+msgid "Select update source"
+msgstr "Ange uppdateringskälla."
 
 #
-msgid "Select upgrade source to edit."
-msgstr "Ange uppgraderingskälla att ändra."
+msgid "Select update source to edit."
+msgstr "Ange uppdateringskälla att ändra."
 
 #
 msgid "Select video input with up/down buttons"
@@ -8838,7 +8838,7 @@ msgstr "Visa infobalk vid hopp framåt / bakåt"
 msgid "Show latest commits"
 msgstr "Visa senaste commits"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Visa senaste uppdateringslogg"
 
 #, fuzzy
@@ -8872,7 +8872,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Visa paket som skall uppdateras"
 
 msgid "Show picons in channel selection list"
@@ -10674,11 +10674,11 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
-"Obevakad uppgradering pågår!\n"
+"Obevakad uppdatering pågår!\n"
 "Vänta tills din mottagare startar om\n"
 "Detta kan ta några minuter!"
 
@@ -10805,8 +10805,8 @@ msgid "Updating software catalog"
 msgstr "Uppdaterar mjukvarukatalogen"
 
 #
-msgid "Upgrading"
-msgstr "Uppgradering"
+msgid "Updating"
+msgstr "uppdatering"
 
 msgid "Upper case"
 msgstr ""
@@ -11334,8 +11334,8 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
-msgstr "Vid aktiverad laddar enigma2 olänkade favoritlistor. Detta innebär att favoritlistor som är tillgängliga men som inte ingår i bouquet.tv eller bouquet.radio filer kommer fortfarande laddas. Detta gör att du till exempel kan behålla dina egna favoritlistor medan installerade inställningar uppgraderas."
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
+msgstr "Vid aktiverad laddar enigma2 olänkade favoritlistor. Detta innebär att favoritlistor som är tillgängliga men som inte ingår i bouquet.tv eller bouquet.radio filer kommer fortfarande laddas. Detta gör att du till exempel kan behålla dina egna favoritlistor medan installerade inställningar uppdateras."
 
 msgid "When enabled the PiP can be closed by the exit button."
 msgstr "Vid aktiverad kan BiB stängas med exitknappen."
@@ -11802,11 +11802,11 @@ msgid "Your current collection will get lost!"
 msgstr "Din nuvarande samling kommer försvinna!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
-"Din frontprocessor kommer att uppgraderas\n"
+"Din frontprocessor kommer att uppdateras\n"
 "Vänta tills din mottagare startat om\n"
 "Detta kan ta några minuter!"
 

--- a/po/th.po
+++ b/po/th.po
@@ -45,7 +45,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "แก้ไขที่อยู่เพื่อโหลดส่วนปรับปรุง"
@@ -3026,7 +3026,7 @@ msgstr "ท่านต้องการที่จะนำการตั้
 msgid "Do you want to update your receiver?"
 msgstr ""
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "ยืนยันจะปรับปรุงส่วนประกอบนี้:\n"
 
 msgid "Dolby"
@@ -3057,8 +3057,8 @@ msgid "Done"
 msgstr ""
 
 #, fuzzy, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "เสร็จแล้ว - ติดตั้งปรับปรุงหรือลบ %d รายการ พบข้อผิดพลาด %d รายการ"
 msgstr[1] "เสร็จแล้ว - ติดตั้งปรับปรุงหรือลบ %d รายการ พบข้อผิดพลาด %d รายการ"
 
@@ -3168,7 +3168,7 @@ msgstr ""
 msgid "Edit title"
 msgstr "แก้ไขชื่อเรื่อง"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "แก้ไข URL ของเซอร์พเวอร์เพื่อปรับปรุง"
 
 msgid "Education/Science/..."
@@ -4768,14 +4768,14 @@ msgstr "ค่าที่ตั้งล่าสุด"
 msgid "Last speed"
 msgstr "ความเร็วล่าสุด"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr ""
 
 msgid "Latest Commits"
 msgstr ""
 
 #, fuzzy
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "เลือกที่มาเพื่อปรับปรุง"
 
 msgid "Latitude"
@@ -5844,7 +5844,7 @@ msgstr ""
 msgid "Overscan wizard"
 msgstr ""
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr ""
 
 #, fuzzy
@@ -6672,10 +6672,10 @@ msgstr "ต้องการปิดเครื่องตอนนี้ห
 msgid "Really store at index %2d for current position?"
 msgstr ""
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr ""
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr ""
 
 msgid "Reboot"
@@ -7627,10 +7627,10 @@ msgid "Select the virtual keyboard shifted character set for the next character 
 msgstr ""
 
 #, fuzzy
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "เลือกที่มาเพื่อปรับปรุง"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "เลือกที่มาเพื่อปรับปรุง"
 
 msgid "Select video input with up/down buttons"
@@ -8042,7 +8042,7 @@ msgstr "แสดงแถบรายการเมื่อเลือกเ
 msgid "Show latest commits"
 msgstr ""
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr ""
 
 msgid "Show menu or plugin numbers"
@@ -8077,7 +8077,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr ""
 
 msgid "Show picons in channel selection list"
@@ -9681,7 +9681,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9794,7 +9794,7 @@ msgstr ""
 msgid "Updating software catalog"
 msgstr ""
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "กำลังอัพเกรด"
 
 msgid "Upper case"
@@ -10266,7 +10266,7 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10688,7 +10688,7 @@ msgid "Your current collection will get lost!"
 msgstr ""
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -47,7 +47,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Güncelleme sunucusu adresini düzenleyin."
@@ -2985,7 +2985,7 @@ msgstr "Alıcıyı %s 'ye güncellemek istiyor musunuz?"
 msgid "Do you want to update your receiver?"
 msgstr "Güncelleme yapılsın mı?"
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Seçilen paketi güncellemek istiyor musunuz?:\n"
 
 msgid "Dolby"
@@ -3016,8 +3016,8 @@ msgid "Done"
 msgstr ""
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Yüklenen, güncellenen veya silinen %d paket (%s)"
 
 msgid "Download plugins"
@@ -3123,7 +3123,7 @@ msgstr "Zamanlayıcıyı Düzenle"
 msgid "Edit title"
 msgstr "Başlığı düzenle"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Güncelleme sunucusu adresini düzenleyin."
 
 msgid "Education/Science/..."
@@ -4694,14 +4694,14 @@ msgstr "Son ayar"
 msgid "Last speed"
 msgstr "Son hız"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Son güncelleme: "
 
 msgid "Latest Commits"
 msgstr "Son Eklenen"
 
 #, fuzzy
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Son güncelleme günlüğünü göster"
 
 msgid "Latitude"
@@ -5739,7 +5739,7 @@ msgstr ""
 msgid "Overscan wizard"
 msgstr ""
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Yazılım yükseltme sırasında konfigürasyon dosyaları üzerine yazılsın mı?"
 
 msgid "Overwrite configuration files?"
@@ -6549,10 +6549,10 @@ msgstr "STB'ı şimdi kapatmak istiyor musunuz?"
 msgid "Really store at index %2d for current position?"
 msgstr "Mevcut pozisyona %2d endeks saklansın mı?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Şimdi ön işlemci güncellensin ve cihaz yeniden başlatılsın mı?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Uydu alıcınız güncellensin ve yeniden başlatılsın mı?"
 
 msgid "Reboot"
@@ -7477,10 +7477,10 @@ msgstr ""
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr ""
 
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Güncelleme kaynağı seçin"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Düzenlemek istediğiniz güncelleme kaynağını seçin."
 
 msgid "Select video input with up/down buttons"
@@ -7876,7 +7876,7 @@ msgstr "İleri/geri sardırmada bilgi çubuğunu göster"
 msgid "Show latest commits"
 msgstr "Son kayıtları göster."
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Son güncelleme günlüğünü göster"
 
 #, fuzzy
@@ -7910,7 +7910,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Güncellenebilir paketleri göster."
 
 msgid "Show picons in channel selection list"
@@ -9498,7 +9498,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9616,7 +9616,7 @@ msgstr "Güncelleme sunucusu kullanılamıyor."
 msgid "Updating software catalog"
 msgstr "Yazılım kataloğu güncelleniyor"
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Güncelleme"
 
 msgid "Upper case"
@@ -10079,7 +10079,7 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Ne zaman enigma2 etkin bağlantısız buket yükleyecektir. Bu, mevcut değil, fakat bouquets.tv ya bouquets.radio dosyaları dahil değildir userbouquets zaten yüklü olacağı anlamına gelir. Yüklü ayarlar yükseltilmiş ise bu kendi kullanıcı buket tutmak için örneğin yapmanızı sağlar"
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10505,7 +10505,7 @@ msgid "Your current collection will get lost!"
 msgstr "Geçerli seçimi kaybetmiş olacaksınız!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -43,7 +43,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Редагувати адресу джерела оновлення."
@@ -3011,7 +3011,7 @@ msgstr "Ви хочете оновити ваш ресивер від %s?"
 msgid "Do you want to update your receiver?"
 msgstr "Ви хочете оновити ваш ресивер?"
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Ви хочете оновити пакети:\n"
 
 msgid "Dolby"
@@ -3042,8 +3042,8 @@ msgid "Done"
 msgstr ""
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Виконано - Встановлено, оновлений або видалений %d пакет (%s)"
 msgstr[1] "Виконано - Встановлено, оновлено або видалено %d пакета (%s)"
 msgstr[2] "Виконано - Встановлено, оновлено або видалено %d пакетів (%s)"
@@ -3151,7 +3151,7 @@ msgstr "Редагувати таймер"
 msgid "Edit title"
 msgstr "Редагувати заголовок"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Редагувати URL-адресу джерела оновлення"
 
 msgid "Education/Science/..."
@@ -4737,14 +4737,14 @@ msgstr "Останні налаштування"
 msgid "Last speed"
 msgstr "Остання швидкість"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Останнє оновлення: "
 
 msgid "Latest Commits"
 msgstr "Зміни"
 
 #, fuzzy
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Показати останній журнал оновлення"
 
 msgid "Latitude"
@@ -5784,7 +5784,7 @@ msgstr "Загальний прогрес:"
 msgid "Overscan wizard"
 msgstr "Майстер налаштування екрану"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Перезаписати конф. файли під час оновлення П/З?"
 
 msgid "Overwrite configuration files?"
@@ -6595,10 +6595,10 @@ msgstr "Дійсно вимкнути зараз?"
 msgid "Really store at index %2d for current position?"
 msgstr "Дійсно зберігати в індексі% 2d для поточної позиції?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Оновити фронтпроцессор і перезавантажити зараз?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Оновити ваш ресивер і перезавантажити зараз?"
 
 msgid "Reboot"
@@ -7533,10 +7533,10 @@ msgstr ""
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr ""
 
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Вибір джерела оновлення"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Вибір джерела оновлення для редагування."
 
 msgid "Select video input with up/down buttons"
@@ -7932,7 +7932,7 @@ msgstr "Показати інфобар при перемотуванню впе
 msgid "Show latest commits"
 msgstr "Показати останні зміни"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Показати останній журнал оновлення"
 
 #, fuzzy
@@ -7966,7 +7966,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Показати пакети, які будуть оновлені"
 
 msgid "Show picons in channel selection list"
@@ -9580,7 +9580,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9700,7 +9700,7 @@ msgstr "Оновлення з фіду недоступні."
 msgid "Updating software catalog"
 msgstr "Оновлення каталогу софта"
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Оновлення"
 
 msgid "Upper case"
@@ -10168,7 +10168,7 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Якщо включено, то будуть загружатися невибрані букети користувача. Це означає, букети існують, но не були включені в файли bouquets.tv або bouquets.radio. Це дасть Вам застосувати свій власний букет в існуючий список букетів"
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10620,7 +10620,7 @@ msgid "Your current collection will get lost!"
 msgstr "Ваша поточна колекція буде загублена!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/vi.po
+++ b/po/vi.po
@@ -43,7 +43,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "Chỉnh sửa địa chỉ nguồn nâng cấp."
@@ -2950,7 +2950,7 @@ msgstr "Bạn có muốn cập nhật đầu thu của mình lên%s không?"
 msgid "Do you want to update your receiver?"
 msgstr "Bạn có muốn cập nhật đầu thu của bạn?"
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr "Bạn có muốn nâng cấp gói:\n"
 
 msgid "Dolby"
@@ -2981,8 +2981,8 @@ msgid "Done"
 msgstr "Làm xong"
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] "Xong - Đã cài đặt, nâng cấp hoặc gỡ bỏ gói%d (%s)"
 msgstr[1] "Xong - Đã cài đặt, nâng cấp hoặc gỡ bỏ gói%d (%s)"
 
@@ -3084,7 +3084,7 @@ msgstr "Chỉnh sửa bộ đếm thời gian"
 msgid "Edit title"
 msgstr "Chỉnh sửa tiêu đề"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "Chỉnh sửa url nguồn nâng cấp."
 
 msgid "Education/Science/..."
@@ -4637,13 +4637,13 @@ msgstr "Cấu hình cuối cùng"
 msgid "Last speed"
 msgstr "Tốc độ cuối"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr "Nâng cấp lần cuối: "
 
 msgid "Latest Commits"
 msgstr "Cam kết mới nhất"
 
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "Nhật ký nâng cấp mới nhất"
 
 msgid "Latitude"
@@ -5657,7 +5657,7 @@ msgstr "Tiến độ tổng thể:"
 msgid "Overscan wizard"
 msgstr "Overscan wizard"
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr "Ghi đè tập tin cấu hình trong quá trình nâng cấp phần mềm?"
 
 msgid "Overwrite configuration files?"
@@ -6448,10 +6448,10 @@ msgstr "Thực sự tắt máy bây giờ?"
 msgid "Really store at index %2d for current position?"
 msgstr "Thực sự lưu trữ ở chỉ số %2d cho vị trí hiện tại?"
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr "Thực sự nâng cấp bộ xử lý trước và khởi động lại bây giờ?"
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr "Thực sự nâng cấp hộp giải quyết của bạn và khởi động lại bây giờ?"
 
 msgid "Reboot"
@@ -7354,10 +7354,10 @@ msgstr "Chọn bộ ký tự dịch chuyển bàn phím ảo"
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr "Chọn bộ ký tự dịch chuyển bàn phím ảo cho chỉ ký tự tiếp theo"
 
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr "Chọn nguồn nâng cấp"
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "Chọn nguồn nâng cấp để chỉnh sửa."
 
 msgid "Select video input with up/down buttons"
@@ -7744,7 +7744,7 @@ msgstr "Hiển thị infobar khi bỏ qua tiến / lùi"
 msgid "Show latest commits"
 msgstr "Hiển thị các cam kết mới nhất"
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr "Hiển thị nhật ký nâng cấp mới nhất"
 
 msgid "Show menu or plugin numbers"
@@ -7777,7 +7777,7 @@ msgstr "Hiển thị thông báo khi các kênh nhập không thành công"
 msgid "Show notification when import channels was successful"
 msgstr "Hiển thị thông báo khi các kênh nhập khẩu thành công"
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr "Hiển thị các gói sẽ được nâng cấp"
 
 msgid "Show picons in channel selection list"
@@ -9337,7 +9337,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr "Không thể tạo các thư mục cần thiết trên phương tiện (ví dụ: thẻ nhớ USB hoặc Ổ cứng) - Vui lòng xác minh phương tiện và thử lại!"
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9450,7 +9450,7 @@ msgstr "Cập nhật nguồn cấp dữ liệu không có sẵn."
 msgid "Updating software catalog"
 msgstr "Cập nhật danh mục phần mềm"
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "Nâng cấp"
 
 msgid "Upper case"
@@ -9909,7 +9909,7 @@ msgstr "Phía tây Sahara"
 msgid "What type of service scan do you want?"
 msgstr "Bạn muốn loại dịch vụ quét nào?"
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Khi được bật enigma2 sẽ tải các tập tin người dùng không liên kết. Điều này có nghĩa là các userbouquets có sẵn, nhưng không được bao gồm trong các tập tin bouquets.tv hoặc bouquets.radio, vẫn sẽ được tải. Điều này cho phép bạn lấy ví dụ để giữ bó hoa người dùng của riêng bạn trong khi cài đặt được cài đặt được nâng cấp"
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10339,7 +10339,7 @@ msgid "Your current collection will get lost!"
 msgstr "Bộ sưu tập hiện tại của bạn sẽ bị mất!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -41,7 +41,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "编辑升级源地址。"
@@ -2937,7 +2937,7 @@ msgstr ""
 msgid "Do you want to update your receiver?"
 msgstr ""
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr " 是否升级软件包:\n"
 
 msgid "Dolby"
@@ -2968,8 +2968,8 @@ msgid "Done"
 msgstr ""
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Edit title"
 msgstr "修改标题"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "修改升级源地址."
 
 msgid "Education/Science/..."
@@ -4628,14 +4628,14 @@ msgstr "上次配置"
 msgid "Last speed"
 msgstr "上次速度"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr ""
 
 msgid "Latest Commits"
 msgstr ""
 
 #, fuzzy
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "上次升级:"
 
 msgid "Latitude"
@@ -5669,7 +5669,7 @@ msgstr ""
 msgid "Overscan wizard"
 msgstr ""
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr ""
 
 msgid "Overwrite configuration files?"
@@ -6472,10 +6472,10 @@ msgstr "立即关机?"
 msgid "Really store at index %2d for current position?"
 msgstr ""
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr ""
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr ""
 
 msgid "Reboot"
@@ -7398,10 +7398,10 @@ msgstr ""
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr ""
 
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr ""
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "选泽升级源进行编辑."
 
 msgid "Select video input with up/down buttons"
@@ -7794,7 +7794,7 @@ msgstr "快退 / 快进时显示信息条"
 msgid "Show latest commits"
 msgstr ""
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr ""
 
 msgid "Show menu or plugin numbers"
@@ -7827,7 +7827,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr ""
 
 msgid "Show picons in channel selection list"
@@ -9358,7 +9358,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9471,7 +9471,7 @@ msgstr "更新资源无效"
 msgid "Updating software catalog"
 msgstr ""
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "升级"
 
 msgid "Upper case"
@@ -9916,7 +9916,7 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10333,7 +10333,7 @@ msgid "Your current collection will get lost!"
 msgstr ""
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -38,7 +38,7 @@ msgstr ""
 
 msgid ""
 "\n"
-"Edit the upgrade source address."
+"Edit the update source address."
 msgstr ""
 "\n"
 "編輯升級源地址。"
@@ -2934,7 +2934,7 @@ msgstr ""
 msgid "Do you want to update your receiver?"
 msgstr ""
 
-msgid "Do you want to upgrade the package:\n"
+msgid "Do you want to update the package:\n"
 msgstr " 是否升級套裝軟體:\n"
 
 msgid "Dolby"
@@ -2966,8 +2966,8 @@ msgid "Done"
 msgstr ""
 
 #, python-format
-msgid "Done - Installed, upgraded or removed %d package (%s)"
-msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgid "Done - Installed, updated or removed %d package (%s)"
+msgid_plural "Done - Installed, updated or removed %d packages (%s)"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -3075,7 +3075,7 @@ msgstr ""
 msgid "Edit title"
 msgstr "修改標題"
 
-msgid "Edit upgrade source url."
+msgid "Edit update source url."
 msgstr "編輯升級源地址."
 
 msgid "Education/Science/..."
@@ -4623,14 +4623,14 @@ msgstr "最後一次正確配置"
 msgid "Last speed"
 msgstr "最快速度"
 
-msgid "Last upgrade: "
+msgid "Last update: "
 msgstr ""
 
 msgid "Latest Commits"
 msgstr ""
 
 #, fuzzy
-msgid "Latest upgrade log"
+msgid "Latest update log"
 msgstr "最後更新"
 
 msgid "Latitude"
@@ -5666,7 +5666,7 @@ msgstr ""
 msgid "Overscan wizard"
 msgstr ""
 
-msgid "Overwrite configuration files during software upgrade?"
+msgid "Overwrite configuration files during software update?"
 msgstr ""
 
 msgid "Overwrite configuration files?"
@@ -6470,10 +6470,10 @@ msgstr "立即關機?"
 msgid "Really store at index %2d for current position?"
 msgstr ""
 
-msgid "Really upgrade the frontprocessor and reboot now?"
+msgid "Really update the frontprocessor and reboot now?"
 msgstr ""
 
-msgid "Really upgrade your settop box and reboot now?"
+msgid "Really update your settop box and reboot now?"
 msgstr ""
 
 msgid "Reboot"
@@ -7397,10 +7397,10 @@ msgstr ""
 msgid "Select the virtual keyboard shifted character set for the next character only"
 msgstr ""
 
-msgid "Select upgrade source"
+msgid "Select update source"
 msgstr ""
 
-msgid "Select upgrade source to edit."
+msgid "Select update source to edit."
 msgstr "選擇並編輯升級來源"
 
 msgid "Select video input with up/down buttons"
@@ -7794,7 +7794,7 @@ msgstr "快退 / 快進時顯示資訊條"
 msgid "Show latest commits"
 msgstr ""
 
-msgid "Show latest upgrade log"
+msgid "Show latest update log"
 msgstr ""
 
 msgid "Show menu or plugin numbers"
@@ -7827,7 +7827,7 @@ msgstr ""
 msgid "Show notification when import channels was successful"
 msgstr ""
 
-msgid "Show packages to be upgraded"
+msgid "Show packages to be updated"
 msgstr ""
 
 msgid "Show picons in channel selection list"
@@ -9365,7 +9365,7 @@ msgid "Unable to create the required directories on the media (e.g. USB stick or
 msgstr ""
 
 msgid ""
-"Unattended upgrade in progress\n"
+"Unattended update in progress\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""
@@ -9481,7 +9481,7 @@ msgstr ""
 msgid "Updating software catalog"
 msgstr "更新軟體目錄"
 
-msgid "Upgrading"
+msgid "Updating"
 msgstr "升級"
 
 msgid "Upper case"
@@ -9921,7 +9921,7 @@ msgstr ""
 msgid "What type of service scan do you want?"
 msgstr ""
 
-msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
 msgid "When enabled the PiP can be closed by the exit button."
@@ -10337,7 +10337,7 @@ msgid "Your current collection will get lost!"
 msgstr "您當前的收集將丟失!"
 
 msgid ""
-"Your frontprocessor will be upgraded\n"
+"Your frontprocessor will be updated\n"
 "Please wait until your receiver reboots\n"
 "This may take a few minutes"
 msgstr ""


### PR DESCRIPTION
In general, "upgrade" is used for hardware, while "update" is used for software. E.g. when we put a new hard disk into a PC, we do a hardware upgrade, but when we install a newer version of a program, we do a software update.
In openpli, both words and their derivatives are used interchangeably while refering to software updates.

This commit converts all instances of "upgrade" and its derivatives to "update" and its corresponding derivatives and makes sure ALL translations will continue to work like before. For some languages, the translated strings are also updated.