### PR TITLE
Edit some strings to start with uppercase letter

### DIFF
--- a/lib/python/Screens/LocationBox.py
+++ b/lib/python/Screens/LocationBox.py
@@ -126,7 +126,7 @@ class LocationBox(Screen, NumericalTextInput, HelpableScreen):
 				"right": self.right,
 				"up": self.up,
 				"down": self.down,
-				"ok": (self.ok, _("select")),
+				"ok": (self.ok, _("Select")),
 				"back": (self.cancel, _("Cancel")),
 			}, -2)
 
@@ -140,13 +140,13 @@ class LocationBox(Screen, NumericalTextInput, HelpableScreen):
 
 		self["EPGSelectActions"] = LocationBoxActionMap(self, "EPGSelectActions",
 			{
-				"prevBouquet": (self.switchToBookList, _("switch to bookmarks")),
-				"nextBouquet": (self.switchToFileList, _("switch to filelist")),
+				"prevBouquet": (self.switchToBookList, _("Switch to bookmarks")),
+				"nextBouquet": (self.switchToFileList, _("Switch to filelist")),
 			}, -2)
 
 		self["MenuActions"] = LocationBoxActionMap(self, "MenuActions",
 			{
-				"menu": (self.showMenu, _("menu")),
+				"menu": (self.showMenu, _("Menu")),
 			}, -2)
 
 		# Actions used by quickselect
@@ -436,20 +436,20 @@ class LocationBox(Screen, NumericalTextInput, HelpableScreen):
 		if not self.userMode and self.realBookmarks:
 			if self.currList == "filelist":
 				menu = [
-					(_("switch to bookmarks"), self.switchToBookList),
-					(_("add bookmark"), self.addRemoveBookmark),
-					(_("update bookmarks"), self.updateBookmarks)
+					(_("Switch to bookmarks"), self.switchToBookList),
+					(_("Add bookmark"), self.addRemoveBookmark),
+					(_("Update bookmarks"), self.updateBookmarks)
 				]
 				if self.editDir:
 					menu.extend((
-						(_("create directory"), self.createDir),
-						(_("remove directory"), self.removeDir)
+						(_("Create directory"), self.createDir),
+						(_("Remove directory"), self.removeDir)
 					))
 			else:
 				menu = (
-					(_("switch to filelist"), self.switchToFileList),
-					(_("remove bookmark"), self.addRemoveBookmark),
-					(_("update bookmarks"), self.updateBookmarks)
+					(_("Switch to filelist"), self.switchToFileList),
+					(_("Remove bookmark"), self.addRemoveBookmark),
+					(_("Update bookmarks"), self.updateBookmarks)
 				)
 
 			self.session.openWithCallback(

--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -275,7 +275,7 @@ class MovieBrowserConfiguration(ConfigListScreen,Screen):
 			configList.append(getConfigListEntry(_(btn), userDefinedButtons[btn]))
 		ConfigListScreen.__init__(self, configList, session=session, on_change = self.changedEntry)
 		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("Ok"))
+		self["key_green"] = StaticText(_("OK"))
 		self["setupActions"] = ActionMap(["SetupActions", "ColorActions",  "MenuActions"],
 		{
 			"red": self.cancel,
@@ -419,11 +419,11 @@ class MovieContextMenu(Screen, ProtectedScreen):
 			append_to_menu(menu, (_("Remove bookmark"), csel.do_addbookmark))
 		else:
 			append_to_menu(menu, (_("Add bookmark"), csel.do_addbookmark))
-		append_to_menu(menu, (_("create directory"), csel.do_createdir), key="7")
+		append_to_menu(menu, (_("Create directory"), csel.do_createdir), key="7")
 		append_to_menu(menu, (_("Sort by") + "...", csel.selectSortby))
 		append_to_menu(menu, (_("On end of movie") + "...", csel.do_movieoff_menu))
 		append_to_menu(menu, (_("Network") + "...", csel.showNetworkSetup), key="yellow")
-		append_to_menu(menu, (_("Settings") + "...", csel.configure), key="menu")
+		append_to_menu(menu, (_("Settings"), csel.configure), key="menu")
 
 		self["menu"] = ChoiceList(menu)
 
@@ -619,7 +619,7 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 			}, prio = -2)
 
 		def getinitUserDefinedActionsDescription(key):
-			return _(userDefinedActions.get(eval("config.movielist.%s.value" % key), _("Not Defined")))
+			return _(userDefinedActions.get(eval("config.movielist.%s.value" % key), _("Not defined")))
 
 		self["InfobarActions"] = HelpableActionMap(self, "InfobarActions",
 			{

--- a/lib/python/Screens/ServiceInfo.py
+++ b/lib/python/Screens/ServiceInfo.py
@@ -228,7 +228,7 @@ class ServiceInfo(Screen):
 				audioPID = self.audio.getTrackInfo(i).getPID()
 				audioLang = self.audio.getTrackInfo(i).getLanguage()
 				if audioLang == "":
-					audioLang = "Not Defined"
+					audioLang = "Not defined"
 				if self.showAll or currentTrack == i:
 					trackList += [(_("Audio PID%s, codec & lang") % ((" %s") % (i + 1) if self.numberofTracks > 1 and self.showAll else ""), "%04X (%d) - %s - %s" % (to_unsigned(audioPID), audioPID, audioDesc, audioLang), TYPE_TEXT)]
 				if self.getServiceInfoValue(iServiceInformation.sAudioPID) == "N/A":

--- a/po/ar.po
+++ b/po/ar.po
@@ -5889,7 +5889,7 @@ msgstr "نرويجى"
 msgid "Norwegian"
 msgstr "نرويجى"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "غير محددة"
 
 #
@@ -11492,7 +11492,7 @@ msgstr ""
 msgid "copy to bouquets"
 msgstr "نسخ الى الباقات"
 
-msgid "create directory"
+msgid "Create directory"
 msgstr "إنشاء دليل"
 
 #
@@ -12082,7 +12082,7 @@ msgstr ""
 msgid "remove cable services"
 msgstr ""
 
-msgid "remove directory"
+msgid "Remove directory"
 msgstr "حذف الدليل"
 
 msgid "remove entry"
@@ -12319,10 +12319,10 @@ msgid "successful"
 msgstr ""
 
 #
-msgid "switch to bookmarks"
+msgid "Switch to bookmarks"
 msgstr "الانتقال الى المرجعيات"
 
-msgid "switch to filelist"
+msgid "Switch to filelist"
 msgstr "الانتقال الى قائمة الملفات"
 
 msgid "switch to the next angle"
@@ -12406,7 +12406,7 @@ msgstr "حتى وضع الاستعداد/إعادة التشغيل"
 
 #
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "بحث آلـى"
 
 msgid "used"

--- a/po/bg.po
+++ b/po/bg.po
@@ -5538,7 +5538,7 @@ msgstr "Нервегия"
 msgid "Norwegian"
 msgstr "Норвежки"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Не определен"
 
 #, fuzzy
@@ -10803,8 +10803,8 @@ msgstr "готвене"
 msgid "copy to bouquets"
 msgstr "копиране в букет"
 
-msgid "create directory"
-msgstr "създай директория"
+msgid "Create directory"
+msgstr "Създай директория"
 
 msgid "daily"
 msgstr "дневно"
@@ -11364,8 +11364,8 @@ msgstr "премахни букет от родителския контрол"
 msgid "remove cable services"
 msgstr "премахни кабелни канали"
 
-msgid "remove directory"
-msgstr "премахни директория"
+msgid "Remove directory"
+msgstr "Премахни директория"
 
 msgid "remove entry"
 msgstr "премахни"
@@ -11593,11 +11593,11 @@ msgstr "отмяна на канала като стартиращ при зар
 msgid "successful"
 msgstr "успешно"
 
-msgid "switch to bookmarks"
-msgstr "превкл. към отметки"
+msgid "Switch to bookmarks"
+msgstr "Превкл. към отметки"
 
-msgid "switch to filelist"
-msgstr "превкл. на файллист"
+msgid "Switch to filelist"
+msgstr "Превкл. на файллист"
 
 msgid "switch to the next angle"
 msgstr "превкл. на следващ ъгъл"
@@ -11675,7 +11675,7 @@ msgid "until standby/restart"
 msgstr "до режим готовност/рестарт"
 
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Автоматично Търсене"
 
 msgid "used"

--- a/po/ca.po
+++ b/po/ca.po
@@ -6187,7 +6187,7 @@ msgstr "Noruec"
 msgid "Norwegian"
 msgstr "Noruec"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr ""
 
 #
@@ -12054,7 +12054,7 @@ msgid "copy to bouquets"
 msgstr "copiar a les llistes"
 
 #
-msgid "create directory"
+msgid "Create directory"
 msgstr ""
 
 #
@@ -12702,7 +12702,7 @@ msgid "remove cable services"
 msgstr ""
 
 #
-msgid "remove directory"
+msgid "Remove directory"
 msgstr ""
 
 #
@@ -12962,12 +12962,12 @@ msgid "successful"
 msgstr ""
 
 #
-msgid "switch to bookmarks"
+msgid "Switch to bookmarks"
 msgstr ""
 
 #
-msgid "switch to filelist"
-msgstr "canviar a la llista de fitxers"
+msgid "Switch to filelist"
+msgstr "Canviar a la llista de fitxers"
 
 #
 msgid "switch to the next angle"
@@ -13059,7 +13059,7 @@ msgstr ""
 
 #
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Recerca automàtica"
 
 msgid "used"

--- a/po/cs.po
+++ b/po/cs.po
@@ -6301,7 +6301,7 @@ msgstr "Norsko"
 msgid "Norwegian"
 msgstr "Norsky"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Nedefinován"
 
 #
@@ -12278,7 +12278,7 @@ msgid "copy to bouquets"
 msgstr "Zkopírovat do přehledů"
 
 #
-msgid "create directory"
+msgid "Create directory"
 msgstr "Založit adresář"
 
 #
@@ -12934,7 +12934,7 @@ msgid "remove cable services"
 msgstr "Odstranit programy kabelové televize"
 
 #
-msgid "remove directory"
+msgid "Remove directory"
 msgstr "Smazat adresář"
 
 #
@@ -13199,11 +13199,11 @@ msgid "successful"
 msgstr "úspěšné"
 
 #
-msgid "switch to bookmarks"
+msgid "Switch to bookmarks"
 msgstr "Přepnout do záložek"
 
 #
-msgid "switch to filelist"
+msgid "Switch to filelist"
 msgstr "Přepnout na seznam souborů"
 
 #
@@ -13297,7 +13297,7 @@ msgid "until standby/restart"
 msgstr "do standby/restartu"
 
 #
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Aktualizovat záložky"
 
 msgid "used"

--- a/po/da.po
+++ b/po/da.po
@@ -6253,7 +6253,7 @@ msgstr "Norsk"
 msgid "Norwegian"
 msgstr "Norsk"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Ikke defineret"
 
 #
@@ -12238,8 +12238,8 @@ msgid "copy to bouquets"
 msgstr "kopier til favoritlister"
 
 #
-msgid "create directory"
-msgstr "opret mappe"
+msgid "Create directory"
+msgstr "Opret mappe"
 
 #
 msgid "daily"
@@ -12890,8 +12890,8 @@ msgid "remove cable services"
 msgstr "Fjern kabelservices"
 
 #
-msgid "remove directory"
-msgstr "fjern mappe"
+msgid "Remove directory"
+msgstr "Fjern mappe"
 
 #
 msgid "remove entry"
@@ -13151,12 +13151,12 @@ msgid "successful"
 msgstr "succesfuld"
 
 #
-msgid "switch to bookmarks"
-msgstr "skift til bogmærker"
+msgid "Switch to bookmarks"
+msgstr "Skift til bogmærker"
 
 #
-msgid "switch to filelist"
-msgstr "skift til filliste"
+msgid "Switch to filelist"
+msgstr "Skift til filliste"
 
 #
 msgid "switch to the next angle"
@@ -13246,7 +13246,7 @@ msgid "until standby/restart"
 msgstr "indtil standby/genstart"
 
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Automatisk Skan"
 
 msgid "used"

--- a/po/de.po
+++ b/po/de.po
@@ -5502,7 +5502,7 @@ msgstr "Norwegen"
 msgid "Norwegian"
 msgstr "Norwegisch"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Nicht definiert"
 
 msgid "Not Installed"
@@ -10736,7 +10736,7 @@ msgstr "Kochen"
 msgid "copy to bouquets"
 msgstr "In Bouquets kopieren"
 
-msgid "create directory"
+msgid "Create directory"
 msgstr "Verzeichnis erstellen"
 
 msgid "daily"
@@ -11291,7 +11291,7 @@ msgstr "Bouquet aus Jugendschutz entfernen"
 msgid "remove cable services"
 msgstr "Kabel-Dienste entfernen"
 
-msgid "remove directory"
+msgid "Remove directory"
 msgstr "Verzeichnis entfernen"
 
 msgid "remove entry"
@@ -11520,10 +11520,10 @@ msgstr "Nicht mehr als Anschaltkanal nutzen"
 msgid "successful"
 msgstr "erfolgreich"
 
-msgid "switch to bookmarks"
+msgid "Switch to bookmarks"
 msgstr "Gehe zu den Lesezeichen"
 
-msgid "switch to filelist"
+msgid "Switch to filelist"
 msgstr "In Dateiliste wechseln"
 
 msgid "switch to the next angle"
@@ -11601,7 +11601,7 @@ msgstr "untestbar"
 msgid "until standby/restart"
 msgstr "Bis zum Standby/Neustart"
 
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Automatische Lesezeichen"
 
 msgid "used"

--- a/po/el.po
+++ b/po/el.po
@@ -5489,7 +5489,7 @@ msgstr "Νορβηγία"
 msgid "Norwegian"
 msgstr "Νορβηγικά"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Απροσδιόριστο"
 
 msgid "Not Installed"
@@ -10702,8 +10702,8 @@ msgstr "μαγειρική"
 msgid "copy to bouquets"
 msgstr "αντιγραφή στα μπουκέτα"
 
-msgid "create directory"
-msgstr "δημιουργία φακέλου"
+msgid "Create directory"
+msgstr "Δημιουργία φακέλου"
 
 msgid "daily"
 msgstr "καθημερινά"
@@ -11257,8 +11257,8 @@ msgstr "αφαίρεση μπουκέτου από τη γονική προστ�
 msgid "remove cable services"
 msgstr "αφαίρεση καλωδιακών υπηρεσιών"
 
-msgid "remove directory"
-msgstr "διαγραφή φακέλου"
+msgid "Remove directory"
+msgstr "Διαγραφή φακέλου"
 
 msgid "remove entry"
 msgstr "διαγραφή στοιχείου"
@@ -11486,11 +11486,11 @@ msgstr "τέλος χρήσης ως υπηρεσία εκκίνησης"
 msgid "successful"
 msgstr "επιτυχία"
 
-msgid "switch to bookmarks"
-msgstr "μετάβαση στους σελιδοδείκτες"
+msgid "Switch to bookmarks"
+msgstr "Μετάβαση στους σελιδοδείκτες"
 
-msgid "switch to filelist"
-msgstr "μετάβαση στη λίστα αρχείων"
+msgid "Switch to filelist"
+msgstr "Μετάβαση στη λίστα αρχείων"
 
 msgid "switch to the next angle"
 msgstr "μετάβαση στην επόμενη γωνία"
@@ -11567,8 +11567,8 @@ msgstr "μη δυνατή δοκιμή"
 msgid "until standby/restart"
 msgstr "μέχρι την αναμονή/επανεκκίνηση"
 
-msgid "update bookmarks"
-msgstr "ενημέρωση σελιδοδεικτών"
+msgid "Update bookmarks"
+msgstr "Ενημέρωση σελιδοδεικτών"
 
 msgid "used"
 msgstr "σε χρήση"

--- a/po/en.po
+++ b/po/en.po
@@ -5545,7 +5545,7 @@ msgstr "Norwegian"
 msgid "Norwegian"
 msgstr "Norwegian"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr ""
 
 #, fuzzy
@@ -10822,8 +10822,8 @@ msgstr "cooking"
 msgid "copy to bouquets"
 msgstr "copy to bouquets"
 
-msgid "create directory"
-msgstr "create directory"
+msgid "Create directory"
+msgstr "Create directory"
 
 msgid "daily"
 msgstr "daily"
@@ -11383,8 +11383,8 @@ msgstr ""
 msgid "remove cable services"
 msgstr ""
 
-msgid "remove directory"
-msgstr "remove directory"
+msgid "Remove directory"
+msgstr "Remove directory"
 
 msgid "remove entry"
 msgstr "remove entry"
@@ -11615,11 +11615,11 @@ msgstr "stop using as startup service"
 msgid "successful"
 msgstr ""
 
-msgid "switch to bookmarks"
-msgstr "switch to bookmarks"
+msgid "Switch to bookmarks"
+msgstr "Switch to bookmarks"
 
-msgid "switch to filelist"
-msgstr "switch to filelist"
+msgid "Switch to filelist"
+msgstr "Switch to filelist"
 
 msgid "switch to the next angle"
 msgstr "switch to the next angle"
@@ -11697,9 +11697,8 @@ msgstr ""
 msgid "until standby/restart"
 msgstr "until standby/restart"
 
-#, fuzzy
-msgid "update bookmarks"
-msgstr "Automatic scan"
+msgid "Update bookmarks"
+msgstr "Update bookmarks"
 
 msgid "used"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -6126,8 +6126,8 @@ msgstr "Noruega"
 msgid "Norwegian"
 msgstr "Noruego"
 
-msgid "Not Defined"
-msgstr "No Definido"
+msgid "Not defined"
+msgstr "No definido"
 
 #
 #, fuzzy
@@ -11953,8 +11953,8 @@ msgid "copy to bouquets"
 msgstr "copiar a listas"
 
 #
-msgid "create directory"
-msgstr "crear directorio"
+msgid "Create directory"
+msgstr "Crear directorio"
 
 #
 msgid "daily"
@@ -12599,8 +12599,8 @@ msgid "remove cable services"
 msgstr "Eliminar servicios de cable"
 
 #
-msgid "remove directory"
-msgstr "borrar directorio"
+msgid "Remove directory"
+msgstr "Borrar directorio"
 
 #
 msgid "remove entry"
@@ -12857,12 +12857,12 @@ msgid "successful"
 msgstr "exitoso"
 
 #
-msgid "switch to bookmarks"
-msgstr "pasar a marcadores"
+msgid "Switch to bookmarks"
+msgstr "Pasar a marcadores"
 
 #
-msgid "switch to filelist"
-msgstr "cambiar a lista de ficheros"
+msgid "Switch to filelist"
+msgstr "Cambiar a lista de ficheros"
 
 #
 msgid "switch to the next angle"
@@ -12950,8 +12950,8 @@ msgstr "Intachable"
 msgid "until standby/restart"
 msgstr "hasta reposo/reinicio"
 
-msgid "update bookmarks"
-msgstr "actualizar marcadores"
+msgid "Update bookmarks"
+msgstr "Actualizar marcadores"
 
 msgid "used"
 msgstr ""

--- a/po/et.po
+++ b/po/et.po
@@ -5507,7 +5507,7 @@ msgstr "Norra"
 msgid "Norwegian"
 msgstr "Norra"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Määramata"
 
 #, fuzzy
@@ -10791,7 +10791,7 @@ msgstr "kokasaade"
 msgid "copy to bouquets"
 msgstr "kopeeri nimekirjadesse"
 
-msgid "create directory"
+msgid "Create directory"
 msgstr "Loo kataloog"
 
 msgid "daily"
@@ -11350,8 +11350,8 @@ msgstr "eemalda lemmiknimekirja lukustus"
 msgid "remove cable services"
 msgstr "kustuta kaabelTV teenused"
 
-msgid "remove directory"
-msgstr "kustuta kataloog"
+msgid "Remove directory"
+msgstr "Kustuta kataloog"
 
 msgid "remove entry"
 msgstr "kustuta kirje"
@@ -11579,11 +11579,11 @@ msgstr "ära kasuta käivituskanalina"
 msgid "successful"
 msgstr "edukas"
 
-msgid "switch to bookmarks"
-msgstr "mine lemmikute-loendisse"
+msgid "Switch to bookmarks"
+msgstr "Mine lemmikute-loendisse"
 
-msgid "switch to filelist"
-msgstr "mine faililoendisse"
+msgid "Switch to filelist"
+msgstr "Mine faililoendisse"
 
 msgid "switch to the next angle"
 msgstr "vali järgmine vaatenurk"
@@ -11661,7 +11661,7 @@ msgid "until standby/restart"
 msgstr "kuni ooterežiimini/taaskäivitamiseni"
 
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Automaatne järjehoidjad"
 
 msgid "used"

--- a/po/fa.po
+++ b/po/fa.po
@@ -5644,7 +5644,7 @@ msgstr "نروژی"
 msgid "Norwegian"
 msgstr "نروژی"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr ""
 
 #, fuzzy
@@ -10911,7 +10911,7 @@ msgstr ""
 msgid "copy to bouquets"
 msgstr ""
 
-msgid "create directory"
+msgid "Create directory"
 msgstr ""
 
 msgid "daily"
@@ -11470,7 +11470,7 @@ msgstr ""
 msgid "remove cable services"
 msgstr ""
 
-msgid "remove directory"
+msgid "Remove directory"
 msgstr ""
 
 msgid "remove entry"
@@ -11699,10 +11699,10 @@ msgstr ""
 msgid "successful"
 msgstr ""
 
-msgid "switch to bookmarks"
+msgid "Switch to bookmarks"
 msgstr ""
 
-msgid "switch to filelist"
+msgid "Switch to filelist"
 msgstr ""
 
 msgid "switch to the next angle"
@@ -11781,7 +11781,7 @@ msgid "until standby/restart"
 msgstr ""
 
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "اسکن خودکار"
 
 msgid "used"

--- a/po/fi.po
+++ b/po/fi.po
@@ -6112,7 +6112,7 @@ msgid "Norwegian"
 msgstr "Norja"
 
 #
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Ei määritetty"
 
 #
@@ -11976,7 +11976,7 @@ msgid "copy to bouquets"
 msgstr "kopioi suosikkilistalle"
 
 #
-msgid "create directory"
+msgid "Create directory"
 msgstr "Luo hakemisto"
 
 #
@@ -12620,7 +12620,7 @@ msgid "remove cable services"
 msgstr ""
 
 #
-msgid "remove directory"
+msgid "Remove directory"
 msgstr "Poista hakemisto"
 
 #
@@ -12882,11 +12882,11 @@ msgid "successful"
 msgstr ""
 
 #
-msgid "switch to bookmarks"
+msgid "Switch to bookmarks"
 msgstr "Vaihda kirjanmerkkeihin"
 
 #
-msgid "switch to filelist"
+msgid "Switch to filelist"
 msgstr "Vaihda tiedostolistaan"
 
 #
@@ -12977,7 +12977,7 @@ msgstr ""
 msgid "until standby/restart"
 msgstr "valmiustilaan/uudelleenkäynnistykseen asti"
 
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Päivitä kirjanmerkit"
 
 msgid "used"

--- a/po/fr.po
+++ b/po/fr.po
@@ -5491,7 +5491,7 @@ msgstr "Norvége"
 msgid "Norwegian"
 msgstr "Norvégien"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Pas défini"
 
 msgid "Not Installed"
@@ -10717,7 +10717,7 @@ msgstr "Cuisine"
 msgid "copy to bouquets"
 msgstr "Copier vers bouquets"
 
-msgid "create directory"
+msgid "Create directory"
 msgstr "Création répertoire"
 
 msgid "daily"
@@ -11272,7 +11272,7 @@ msgstr "Supprimer le bouquet de la protection parentale"
 msgid "remove cable services"
 msgstr "supprimer les services câbles"
 
-msgid "remove directory"
+msgid "Remove directory"
 msgstr "Supprimer le répertoire"
 
 msgid "remove entry"
@@ -11501,10 +11501,10 @@ msgstr "Arrêter d'utiliser comme service de démarrage"
 msgid "successful"
 msgstr "réussi"
 
-msgid "switch to bookmarks"
+msgid "Switch to bookmarks"
 msgstr "Basculer vers les signets"
 
-msgid "switch to filelist"
+msgid "Switch to filelist"
 msgstr "Basculer vers la liste des fichiers"
 
 msgid "switch to the next angle"
@@ -11582,8 +11582,8 @@ msgstr "non testable"
 msgid "until standby/restart"
 msgstr "Jusqu'à veille/redémarrage"
 
-msgid "update bookmarks"
-msgstr "mettre à jour les signets"
+msgid "Update bookmarks"
+msgstr "Mettre à jour les signets"
 
 msgid "used"
 msgstr "utilisé"

--- a/po/fy.po
+++ b/po/fy.po
@@ -6294,7 +6294,7 @@ msgstr "Noarsk"
 msgid "Norwegian"
 msgstr "Noarsk"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr ""
 
 #
@@ -12302,8 +12302,8 @@ msgid "copy to bouquets"
 msgstr "kopieer nei boeketten"
 
 #
-msgid "create directory"
-msgstr "map meitsje"
+msgid "Create directory"
+msgstr "Map meitsje"
 
 #
 msgid "daily"
@@ -12955,8 +12955,8 @@ msgid "remove cable services"
 msgstr ""
 
 #
-msgid "remove directory"
-msgstr "map ferwiderje"
+msgid "Remove directory"
+msgstr "Map ferwiderje"
 
 #
 msgid "remove entry"
@@ -13215,12 +13215,12 @@ msgid "successful"
 msgstr ""
 
 #
-msgid "switch to bookmarks"
-msgstr "skeakelje nei boekmerkers"
+msgid "Switch to bookmarks"
+msgstr "Skeakelje nei boekmerkers"
 
 #
-msgid "switch to filelist"
-msgstr "skeakelje nei triemlyst"
+msgid "Switch to filelist"
+msgstr "Skeakelje nei triemlyst"
 
 #
 msgid "switch to the next angle"
@@ -13312,7 +13312,7 @@ msgstr ""
 
 #
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Automatysk sykjen"
 
 msgid "used"

--- a/po/he.po
+++ b/po/he.po
@@ -5948,7 +5948,7 @@ msgstr "נורווגית"
 msgid "Norwegian"
 msgstr "נורווגית"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr ""
 
 #
@@ -11621,7 +11621,7 @@ msgstr ""
 msgid "copy to bouquets"
 msgstr "העתק לתיקית ערוצים"
 
-msgid "create directory"
+msgid "Create directory"
 msgstr "צור תיקיה"
 
 #
@@ -12217,8 +12217,8 @@ msgstr ""
 msgid "remove cable services"
 msgstr ""
 
-msgid "remove directory"
-msgstr "remove directory"
+msgid "Remove directory"
+msgstr "Remove directory"
 
 msgid "remove entry"
 msgstr "remove entry"
@@ -12455,10 +12455,10 @@ msgid "successful"
 msgstr ""
 
 #
-msgid "switch to bookmarks"
+msgid "Switch to bookmarks"
 msgstr "העבר לסימניות"
 
-msgid "switch to filelist"
+msgid "Switch to filelist"
 msgstr "העבר לרשימת הקבצים"
 
 msgid "switch to the next angle"
@@ -12543,7 +12543,7 @@ msgstr "until standby/restart"
 
 #
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "סריקה אוטומטית"
 
 msgid "used"

--- a/po/hr.po
+++ b/po/hr.po
@@ -5511,7 +5511,7 @@ msgstr "Norveška"
 msgid "Norwegian"
 msgstr "Norveški"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Nije definirano"
 
 msgid "Not Installed"
@@ -10728,8 +10728,8 @@ msgstr "kuhanje"
 msgid "copy to bouquets"
 msgstr "kopiraj u pakete"
 
-msgid "create directory"
-msgstr "kreiraj direktorij"
+msgid "Create directory"
+msgstr "Kreiraj direktorij"
 
 msgid "daily"
 msgstr "dnevno"
@@ -11283,8 +11283,8 @@ msgstr "izbrišite paket iz roditeljske zaštite"
 msgid "remove cable services"
 msgstr "izbrišite kabelske usluge"
 
-msgid "remove directory"
-msgstr "izbrišite direktorij"
+msgid "Remove directory"
+msgstr "Izbrišite direktorij"
 
 msgid "remove entry"
 msgstr "brisanje unosa"
@@ -11512,11 +11512,11 @@ msgstr "prestati koristiti kao startup kanal"
 msgid "successful"
 msgstr "uspješno"
 
-msgid "switch to bookmarks"
-msgstr "prebacite se na oznake"
+msgid "Switch to bookmarks"
+msgstr "Prebacite se na oznake"
 
-msgid "switch to filelist"
-msgstr "prebacite se na popis datoteka"
+msgid "Switch to filelist"
+msgstr "Prebacite se na popis datoteka"
 
 msgid "switch to the next angle"
 msgstr "prebacite na sljedeći kut"
@@ -11593,8 +11593,8 @@ msgstr "nestabilan"
 msgid "until standby/restart"
 msgstr "do stanja čekanja/ponovnog pokretanja"
 
-msgid "update bookmarks"
-msgstr "ažurirati oznake"
+msgid "Update bookmarks"
+msgstr "Ažurirati oznake"
 
 msgid "used"
 msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -5489,7 +5489,7 @@ msgstr "Norvégia"
 msgid "Norwegian"
 msgstr "Norvég"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Nincs megadva"
 
 msgid "Not Installed"
@@ -10708,8 +10708,8 @@ msgstr "főzés"
 msgid "copy to bouquets"
 msgstr "másolás listába"
 
-msgid "create directory"
-msgstr "mappa létrehozása"
+msgid "Create directory"
+msgstr "Mappa létrehozása"
 
 msgid "daily"
 msgstr "naponta"
@@ -11263,8 +11263,8 @@ msgstr "lista eltávolítása a gyermekzár védelem alól"
 msgid "remove cable services"
 msgstr "kábeles szolgáltatás eltávolítása"
 
-msgid "remove directory"
-msgstr "mappa eltávolítása"
+msgid "Remove directory"
+msgstr "Mappa eltávolítása"
 
 msgid "remove entry"
 msgstr "bejegyzés törlése"
@@ -11492,11 +11492,11 @@ msgstr "beállítás indítási csatornának"
 msgid "successful"
 msgstr "sikeres"
 
-msgid "switch to bookmarks"
-msgstr "átkapcsolás a bookmarkokra"
+msgid "Switch to bookmarks"
+msgstr "Átkapcsolás a bookmarkokra"
 
-msgid "switch to filelist"
-msgstr "kapcsolás fájllistára"
+msgid "Switch to filelist"
+msgstr "Kapcsolás fájllistára"
 
 msgid "switch to the next angle"
 msgstr "váltás a következő nézőszögre"
@@ -11573,8 +11573,8 @@ msgstr "nem tesztelhető"
 msgid "until standby/restart"
 msgstr "kikapcsolásig/újraindításig"
 
-msgid "update bookmarks"
-msgstr "könyvjelzők frissítése"
+msgid "Update bookmarks"
+msgstr "Könyvjelzők frissítése"
 
 msgid "used"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -5616,7 +5616,7 @@ msgstr "Norwegia"
 msgid "Norwegian"
 msgstr "Norwegia"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Tak ditetapkan"
 
 #, fuzzy
@@ -10946,8 +10946,8 @@ msgstr "memasak"
 msgid "copy to bouquets"
 msgstr "salin ke buket"
 
-msgid "create directory"
-msgstr "buat direktori"
+msgid "Create directory"
+msgstr "Buat direktori"
 
 msgid "daily"
 msgstr "harian"
@@ -11508,8 +11508,8 @@ msgstr "hapus buket dari proteksi orangtua"
 msgid "remove cable services"
 msgstr "hapus layanan kabel"
 
-msgid "remove directory"
-msgstr "hapus directori"
+msgid "Remove directory"
+msgstr "Hapus directori"
 
 msgid "remove entry"
 msgstr "hapus entri"
@@ -11740,11 +11740,11 @@ msgstr "berhenti gunakan sbg layanan mulai"
 msgid "successful"
 msgstr "sukses"
 
-msgid "switch to bookmarks"
-msgstr "ganti ke penandabuku"
+msgid "Switch to bookmarks"
+msgstr "Ganti ke penandabuku"
 
-msgid "switch to filelist"
-msgstr "ganti ke daftarberkas"
+msgid "Switch to filelist"
+msgstr "Ganti ke daftarberkas"
 
 msgid "switch to the next angle"
 msgstr "ganti ke sudut berikutnya"
@@ -11823,7 +11823,7 @@ msgid "until standby/restart"
 msgstr "sampai standby/mulai ulang"
 
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Penanda buku otomatis"
 
 msgid "used"

--- a/po/is.po
+++ b/po/is.po
@@ -6143,7 +6143,7 @@ msgstr "Norska"
 msgid "Norwegian"
 msgstr "Norska"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr ""
 
 #
@@ -12132,8 +12132,8 @@ msgid "copy to bouquets"
 msgstr "afrita til rásavanda"
 
 #
-msgid "create directory"
-msgstr "búa til möppu"
+msgid "Create directory"
+msgstr "Búa til möppu"
 
 #
 msgid "daily"
@@ -12783,8 +12783,8 @@ msgid "remove cable services"
 msgstr ""
 
 #
-msgid "remove directory"
-msgstr "eyða möppu"
+msgid "Remove directory"
+msgstr "Eyða möppu"
 
 #
 msgid "remove entry"
@@ -13040,12 +13040,12 @@ msgid "successful"
 msgstr ""
 
 #
-msgid "switch to bookmarks"
-msgstr "fara á bókamerki"
+msgid "Switch to bookmarks"
+msgstr "Fara á bókamerki"
 
 #
-msgid "switch to filelist"
-msgstr "skipta í skráarlista"
+msgid "Switch to filelist"
+msgstr "Skipta í skráarlista"
 
 #
 msgid "switch to the next angle"
@@ -13136,7 +13136,7 @@ msgid "until standby/restart"
 msgstr "bíða til biðstöðu/endurræsingu"
 
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Sjálfvirk leit"
 
 msgid "used"

--- a/po/it.po
+++ b/po/it.po
@@ -5530,7 +5530,7 @@ msgstr "Norvegia"
 msgid "Norwegian"
 msgstr "Norvegese"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Non definito"
 
 #, fuzzy
@@ -10827,7 +10827,7 @@ msgstr "Cucina"
 msgid "copy to bouquets"
 msgstr "Copiare nei bouquet"
 
-msgid "create directory"
+msgid "Create directory"
 msgstr "Creare una nuova cartella"
 
 msgid "daily"
@@ -11388,7 +11388,7 @@ msgstr "Escludere il bouquet dal Controllo genitori"
 msgid "remove cable services"
 msgstr "Eliminare il canale via cavo"
 
-msgid "remove directory"
+msgid "Remove directory"
 msgstr "Eliminare la cartella"
 
 msgid "remove entry"
@@ -11617,10 +11617,10 @@ msgstr "Non utilizzare più come canale di avvio"
 msgid "successful"
 msgstr "riuscito"
 
-msgid "switch to bookmarks"
+msgid "Switch to bookmarks"
 msgstr "Passare ai percorsi preferiti"
 
-msgid "switch to filelist"
+msgid "Switch to filelist"
 msgstr "Passare all'elenco dei file"
 
 msgid "switch to the next angle"
@@ -11699,7 +11699,7 @@ msgid "until standby/restart"
 msgstr "Fino a Sospensione/Riavvio"
 
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Segnalibri automatici"
 
 msgid "used"

--- a/po/ku.po
+++ b/po/ku.po
@@ -5549,7 +5549,7 @@ msgstr "Norwegian"
 msgid "Norwegian"
 msgstr "Norwegian"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr ""
 
 #, fuzzy
@@ -10822,8 +10822,8 @@ msgstr "cooking"
 msgid "copy to bouquets"
 msgstr "copy to bouquets"
 
-msgid "create directory"
-msgstr "create directory"
+msgid "Create directory"
+msgstr "Create directory"
 
 msgid "daily"
 msgstr "daily"
@@ -11383,8 +11383,8 @@ msgstr ""
 msgid "remove cable services"
 msgstr ""
 
-msgid "remove directory"
-msgstr "remove directory"
+msgid "Remove directory"
+msgstr "Remove directory"
 
 msgid "remove entry"
 msgstr "remove entry"
@@ -11615,11 +11615,11 @@ msgstr "stop using as startup service"
 msgid "successful"
 msgstr ""
 
-msgid "switch to bookmarks"
-msgstr "switch to bookmarks"
+msgid "Switch to bookmarks"
+msgstr "Switch to bookmarks"
 
-msgid "switch to filelist"
-msgstr "switch to filelist"
+msgid "Switch to filelist"
+msgstr "Switch to filelist"
 
 msgid "switch to the next angle"
 msgstr "switch to the next angle"
@@ -11698,7 +11698,7 @@ msgid "until standby/restart"
 msgstr "until standby/restart"
 
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Automatic Légerin"
 
 msgid "used"

--- a/po/lt.po
+++ b/po/lt.po
@@ -5517,7 +5517,7 @@ msgstr "Norvegija"
 msgid "Norwegian"
 msgstr "Norvegų"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Neapibrėžta"
 
 #, fuzzy
@@ -10754,8 +10754,8 @@ msgstr "valgio gaminimas"
 msgid "copy to bouquets"
 msgstr "kopijuoti į paketus"
 
-msgid "create directory"
-msgstr "sukurti katalogą"
+msgid "Create directory"
+msgstr "Sukurti katalogą"
 
 msgid "daily"
 msgstr "kasdien"
@@ -11310,8 +11310,8 @@ msgstr "pašalinti paketą iš tėvų kontrolės"
 msgid "remove cable services"
 msgstr "pašalinti kabelinius kanalus"
 
-msgid "remove directory"
-msgstr "pašalinti katalogą"
+msgid "Remove directory"
+msgstr "Pašalinti katalogą"
 
 msgid "remove entry"
 msgstr "pašalinti"
@@ -11539,11 +11539,11 @@ msgstr "nustoti naudoti kaip paleisties kanalą"
 msgid "successful"
 msgstr "sėkmingai"
 
-msgid "switch to bookmarks"
-msgstr "perjungti į žymes"
+msgid "Switch to bookmarks"
+msgstr "Perjungti į žymes"
 
-msgid "switch to filelist"
-msgstr "perjungti į failų sąrašą"
+msgid "Switch to filelist"
+msgstr "Perjungti į failų sąrašą"
 
 msgid "switch to the next angle"
 msgstr "perjungti į kitą kampą"
@@ -11621,7 +11621,7 @@ msgid "until standby/restart"
 msgstr "iki budėjimo/paleidimo iš naujo"
 
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Automatinės žymos"
 
 msgid "used"

--- a/po/lv.po
+++ b/po/lv.po
@@ -5510,7 +5510,7 @@ msgstr "Norvēģija"
 msgid "Norwegian"
 msgstr "Norvēģu"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Nav definēts"
 
 #, fuzzy
@@ -10736,8 +10736,8 @@ msgstr "cepšana"
 msgid "copy to bouquets"
 msgstr "kopēt uz buķetēm"
 
-msgid "create directory"
-msgstr "izveidot mapi"
+msgid "Create directory"
+msgstr "Izveidot mapi"
 
 msgid "daily"
 msgstr "ik dienu"
@@ -11292,8 +11292,8 @@ msgstr "dzēst buķeti no vecāku kontroles"
 msgid "remove cable services"
 msgstr "dzēst kabeļu kanālus"
 
-msgid "remove directory"
-msgstr "dzēst mapi"
+msgid "Remove directory"
+msgstr "Dzēst mapi"
 
 msgid "remove entry"
 msgstr "dzēst ierakstu"
@@ -11521,11 +11521,11 @@ msgstr "pārtraukt lietot kā ieslēgšanas kanālu"
 msgid "successful"
 msgstr "veiksmīgi"
 
-msgid "switch to bookmarks"
-msgstr "iet uz grāmatzīmēm"
+msgid "Switch to bookmarks"
+msgstr "Iet uz grāmatzīmēm"
 
-msgid "switch to filelist"
-msgstr "pāriet uz failu sarakstu"
+msgid "Switch to filelist"
+msgstr "Pāriet uz failu sarakstu"
 
 msgid "switch to the next angle"
 msgstr "pārslēgt uz nākamo leņķi"
@@ -11602,8 +11602,8 @@ msgstr "netestēts"
 msgid "until standby/restart"
 msgstr "līdz gaidstāvei/pārstartēšanai"
 
-msgid "update bookmarks"
-msgstr "atjaunot grāmatzīmes"
+msgid "Update bookmarks"
+msgstr "Atjaunot grāmatzīmes"
 
 msgid "used"
 msgstr ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -6110,7 +6110,7 @@ msgid "Norwegian"
 msgstr "Norsk"
 
 #
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Ikke angitt"
 
 #
@@ -11899,8 +11899,8 @@ msgstr "matlaging"
 msgid "copy to bouquets"
 msgstr "kopier til kanallister"
 
-msgid "create directory"
-msgstr "opprett mappe"
+msgid "Create directory"
+msgstr "Opprett mappe"
 
 #
 msgid "daily"
@@ -12540,8 +12540,8 @@ msgstr "fjern kanallisten fra foreldrekontroll beskyttelsen"
 msgid "remove cable services"
 msgstr "fjern kabel TV kanaler"
 
-msgid "remove directory"
-msgstr "fjern mappe"
+msgid "Remove directory"
+msgstr "Fjern mappe"
 
 msgid "remove entry"
 msgstr "fjern denne kanal fra kanallisten"
@@ -12788,11 +12788,11 @@ msgstr "slutte å bruke som oppstartskanal"
 msgid "successful"
 msgstr "vellykket"
 
-msgid "switch to bookmarks"
-msgstr "gå til bokmerker"
+msgid "Switch to bookmarks"
+msgstr "Gå til bokmerker"
 
-msgid "switch to filelist"
-msgstr "gå til mappe liste"
+msgid "Switch to filelist"
+msgstr "Gå til mappe liste"
 
 msgid "switch to the next angle"
 msgstr "gå til neste posisjon"
@@ -12877,8 +12877,8 @@ msgstr "lar seg ikke teste"
 msgid "until standby/restart"
 msgstr "til slår av/starter på nytt"
 
-msgid "update bookmarks"
-msgstr "oppdatere bokmerker"
+msgid "Update bookmarks"
+msgstr "Oppdatere bokmerker"
 
 msgid "used"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -5693,7 +5693,7 @@ msgstr "Noorwegen"
 msgid "Norwegian"
 msgstr "Noors"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Niet vestgelegd"
 
 msgid "Not Installed"
@@ -11020,7 +11020,7 @@ msgstr "Kookprogramma"
 msgid "copy to bouquets"
 msgstr "Kopieer naar bouquetten"
 
-msgid "create directory"
+msgid "Create directory"
 msgstr "Map aanmaken"
 
 msgid "daily"
@@ -11575,7 +11575,7 @@ msgstr "verwijder bouquet uit het kinderslot"
 msgid "remove cable services"
 msgstr "verwijder kabelkanalen"
 
-msgid "remove directory"
+msgid "Remove directory"
 msgstr "Map verwijderen"
 
 msgid "remove entry"
@@ -11805,10 +11805,10 @@ msgstr "stop met het gebruiken als opstartzender"
 msgid "successful"
 msgstr "gelukt"
 
-msgid "switch to bookmarks"
+msgid "Switch to bookmarks"
 msgstr "Ga naar markeerpunten"
 
-msgid "switch to filelist"
+msgid "Switch to filelist"
 msgstr "Ga naar bestandenlijst"
 
 msgid "switch to the next angle"
@@ -11886,8 +11886,8 @@ msgstr "niet te testen"
 msgid "until standby/restart"
 msgstr "tot standby/herstart"
 
-msgid "update bookmarks"
-msgstr "actualiseer de bladwijzers"
+msgid "Update bookmarks"
+msgstr "Actualiseer de bladwijzers"
 
 msgid "used"
 msgstr "gebruikte"

--- a/po/nn.po
+++ b/po/nn.po
@@ -6079,7 +6079,7 @@ msgstr "Norsk"
 msgid "Norwegian"
 msgstr "Norsk"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr ""
 
 #
@@ -11808,8 +11808,8 @@ msgstr "matlaging"
 msgid "copy to bouquets"
 msgstr "kopiere til kanallister"
 
-msgid "create directory"
-msgstr "opprette katalog"
+msgid "Create directory"
+msgstr "Opprette katalog"
 
 #
 msgid "daily"
@@ -12449,8 +12449,8 @@ msgstr ""
 msgid "remove cable services"
 msgstr ""
 
-msgid "remove directory"
-msgstr "slette katalog"
+msgid "Remove directory"
+msgstr "Slette katalog"
 
 msgid "remove entry"
 msgstr "fjerne denne"
@@ -12699,11 +12699,11 @@ msgstr "slutt og bruke som oppstarttjeneste"
 msgid "successful"
 msgstr ""
 
-msgid "switch to bookmarks"
-msgstr "gå til bokmerker"
+msgid "Switch to bookmarks"
+msgstr "Gå til bokmerker"
 
-msgid "switch to filelist"
-msgstr "gå til filliste"
+msgid "Switch to filelist"
+msgstr "Gå til filliste"
 
 msgid "switch to the next angle"
 msgstr "gå til neste posisjon"
@@ -12787,7 +12787,7 @@ msgid "until standby/restart"
 msgstr "til slår av/starter på nytt"
 
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Automatisk søk"
 
 msgid "used"

--- a/po/pl.po
+++ b/po/pl.po
@@ -5507,7 +5507,7 @@ msgstr "Norwegia"
 msgid "Norwegian"
 msgstr "Norweski"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Niezdefiniowany"
 
 msgid "Not Installed"
@@ -10727,7 +10727,7 @@ msgstr "Gotowanie"
 msgid "copy to bouquets"
 msgstr "Kopiuj do bukietów"
 
-msgid "create directory"
+msgid "Create directory"
 msgstr "Utwórz katalog"
 
 msgid "daily"
@@ -11282,7 +11282,7 @@ msgstr "Usuń bukiet z kontroli rodzicielskiej"
 msgid "remove cable services"
 msgstr "Usuń kanały tv kablowej"
 
-msgid "remove directory"
+msgid "Remove directory"
 msgstr "Usuń katalog"
 
 msgid "remove entry"
@@ -11511,10 +11511,10 @@ msgstr "Przestań używać jako kanał startowy"
 msgid "successful"
 msgstr "udane"
 
-msgid "switch to bookmarks"
+msgid "Switch to bookmarks"
 msgstr "Przejdź do zakładek"
 
-msgid "switch to filelist"
+msgid "Switch to filelist"
 msgstr "Przjdź do listy plików"
 
 msgid "switch to the next angle"
@@ -11592,7 +11592,7 @@ msgstr "nietestowalne"
 msgid "until standby/restart"
 msgstr "Do standby/restartu"
 
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Aktualizuj zakładki"
 
 msgid "used"

--- a/po/pt.po
+++ b/po/pt.po
@@ -6350,7 +6350,7 @@ msgstr "Norueguês"
 msgid "Norwegian"
 msgstr "Norueguês"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr ""
 
 #
@@ -12472,8 +12472,8 @@ msgid "copy to bouquets"
 msgstr "copiar para bouquets"
 
 #
-msgid "create directory"
-msgstr "criar directório"
+msgid "Create directory"
+msgstr "Criar directório"
 
 #
 msgid "daily"
@@ -13127,8 +13127,8 @@ msgid "remove cable services"
 msgstr ""
 
 #
-msgid "remove directory"
-msgstr "apagar directório"
+msgid "Remove directory"
+msgstr "Apagar directório"
 
 #
 msgid "remove entry"
@@ -13390,12 +13390,12 @@ msgid "successful"
 msgstr ""
 
 #
-msgid "switch to bookmarks"
-msgstr "mudar para favoritos"
+msgid "Switch to bookmarks"
+msgstr "Mudar para favoritos"
 
 #
-msgid "switch to filelist"
-msgstr "mudar para Lista de Ficheiros"
+msgid "Switch to filelist"
+msgstr "Mudar para Lista de Ficheiros"
 
 #
 msgid "switch to the next angle"
@@ -13486,7 +13486,7 @@ msgstr "até Standby/reiniciar"
 
 #
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Pesquisa automática"
 
 msgid "used"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -5542,7 +5542,7 @@ msgstr "Norueguês"
 msgid "Norwegian"
 msgstr "Norueguês"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr ""
 
 #, fuzzy
@@ -10818,7 +10818,7 @@ msgstr "Cozinha"
 msgid "copy to bouquets"
 msgstr "Copiar para grupo de favoritos"
 
-msgid "create directory"
+msgid "Create directory"
 msgstr "Criar diretório"
 
 msgid "daily"
@@ -11380,7 +11380,7 @@ msgstr ""
 msgid "remove cable services"
 msgstr ""
 
-msgid "remove directory"
+msgid "Remove directory"
 msgstr "Remover diretório"
 
 msgid "remove entry"
@@ -11612,10 +11612,10 @@ msgstr "Não usar como canal inicial"
 msgid "successful"
 msgstr ""
 
-msgid "switch to bookmarks"
+msgid "Switch to bookmarks"
 msgstr "Ir para favoritos"
 
-msgid "switch to filelist"
+msgid "Switch to filelist"
 msgstr "Ir para lista de arquivos"
 
 msgid "switch to the next angle"
@@ -11695,7 +11695,7 @@ msgid "until standby/restart"
 msgstr "até standby/reiniciar"
 
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Busca automática"
 
 msgid "used"

--- a/po/ro.po
+++ b/po/ro.po
@@ -5644,7 +5644,7 @@ msgstr "Norvegiana"
 msgid "Norwegian"
 msgstr "Norvegiana"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr ""
 
 #, fuzzy
@@ -10992,8 +10992,8 @@ msgstr ""
 msgid "copy to bouquets"
 msgstr "copiaza in bouquete"
 
-msgid "create directory"
-msgstr "creaza director"
+msgid "Create directory"
+msgstr "Creaza director"
 
 msgid "daily"
 msgstr "zilnic"
@@ -11554,8 +11554,8 @@ msgstr ""
 msgid "remove cable services"
 msgstr ""
 
-msgid "remove directory"
-msgstr "elimina directorul"
+msgid "Remove directory"
+msgstr "Elimina directorul"
 
 msgid "remove entry"
 msgstr "elimina intrarea"
@@ -11784,11 +11784,11 @@ msgstr ""
 msgid "successful"
 msgstr ""
 
-msgid "switch to bookmarks"
-msgstr "mergi la bookmarks"
+msgid "Switch to bookmarks"
+msgstr "Mergi la bookmarks"
 
-msgid "switch to filelist"
-msgstr "mergi la filelist"
+msgid "Switch to filelist"
+msgstr "Mergi la filelist"
 
 msgid "switch to the next angle"
 msgstr "mergi la urmatorul unghi"
@@ -11867,7 +11867,7 @@ msgid "until standby/restart"
 msgstr ""
 
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Scanare automata"
 
 msgid "used"

--- a/po/ru.po
+++ b/po/ru.po
@@ -5505,7 +5505,7 @@ msgstr "Norway"
 msgid "Norwegian"
 msgstr "Норвежский"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Не определено"
 
 msgid "Not Installed"
@@ -10723,8 +10723,8 @@ msgstr "приготовление"
 msgid "copy to bouquets"
 msgstr "копировать в пакет"
 
-msgid "create directory"
-msgstr "создать директорию"
+msgid "Create directory"
+msgstr "Создать директорию"
 
 msgid "daily"
 msgstr "ежедневно"
@@ -11278,8 +11278,8 @@ msgstr "удалить букет из родительского контрол
 msgid "remove cable services"
 msgstr "удалить кабельные сервисы"
 
-msgid "remove directory"
-msgstr "удалить директорию"
+msgid "Remove directory"
+msgstr "Удалить директорию"
 
 msgid "remove entry"
 msgstr "удалить выбранное"
@@ -11507,11 +11507,11 @@ msgstr "отмена сервиса как стартового при загр�
 msgid "successful"
 msgstr "успешно"
 
-msgid "switch to bookmarks"
-msgstr "перейти на закладки"
+msgid "Switch to bookmarks"
+msgstr "Перейти на закладки"
 
-msgid "switch to filelist"
-msgstr "перейти на список файлов"
+msgid "Switch to filelist"
+msgstr "Перейти на список файлов"
 
 msgid "switch to the next angle"
 msgstr "перейти в следующей угол"
@@ -11588,8 +11588,8 @@ msgstr "непроверяема"
 msgid "until standby/restart"
 msgstr "до режима ожидания/перезагрузки"
 
-msgid "update bookmarks"
-msgstr "обновить закладки"
+msgid "Update bookmarks"
+msgstr "Обновить закладки"
 
 msgid "used"
 msgstr "используется"

--- a/po/sk.po
+++ b/po/sk.po
@@ -5518,7 +5518,7 @@ msgstr "Nórsko"
 msgid "Norwegian"
 msgstr "Nórčina"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Nedefinované"
 
 msgid "Not Installed"
@@ -10736,8 +10736,8 @@ msgstr "varenie"
 msgid "copy to bouquets"
 msgstr "skopírovať do prehľadov"
 
-msgid "create directory"
-msgstr "vytvoriť adresár"
+msgid "Create directory"
+msgstr "Vytvoriť adresár"
 
 msgid "daily"
 msgstr "denne"
@@ -11291,8 +11291,8 @@ msgstr "odobrať zoznam staníc z rodičovskej kontroly"
 msgid "remove cable services"
 msgstr "odtrániť stanice káblovej TV"
 
-msgid "remove directory"
-msgstr "odstrániť adresár"
+msgid "Remove directory"
+msgstr "Odstrániť adresár"
 
 msgid "remove entry"
 msgstr "odstrániť položku"
@@ -11520,11 +11520,11 @@ msgstr "nepoužívať ako stanicu po spustení"
 msgid "successful"
 msgstr "úspešný"
 
-msgid "switch to bookmarks"
-msgstr "prepnúť na záložky"
+msgid "Switch to bookmarks"
+msgstr "Prepnúť na záložky"
 
-msgid "switch to filelist"
-msgstr "prepnúť na zoznam súborov"
+msgid "Switch to filelist"
+msgstr "Prepnúť na zoznam súborov"
 
 msgid "switch to the next angle"
 msgstr "prepnúť na nasledujúci uhol kamery"
@@ -11601,8 +11601,8 @@ msgstr "neskúšateľné"
 msgid "until standby/restart"
 msgstr "do vypnutia alebo reštartu"
 
-msgid "update bookmarks"
-msgstr "aktualizovať záložky"
+msgid "Update bookmarks"
+msgstr "Aktualizovať záložky"
 
 msgid "used"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -6348,7 +6348,7 @@ msgstr "Norveško"
 msgid "Norwegian"
 msgstr "Norveško"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr ""
 
 #
@@ -12399,7 +12399,7 @@ msgid "copy to bouquets"
 msgstr "Prenos v seznam priljubljenih paketov"
 
 #
-msgid "create directory"
+msgid "Create directory"
 msgstr "Ustvarite novo mapo"
 
 #
@@ -13056,8 +13056,8 @@ msgid "remove cable services"
 msgstr "odstrani kabelske kanale"
 
 #
-msgid "remove directory"
-msgstr "odstranitev mape"
+msgid "Remove directory"
+msgstr "Odstranitev mape"
 
 #
 msgid "remove entry"
@@ -13320,12 +13320,12 @@ msgid "successful"
 msgstr ""
 
 #
-msgid "switch to bookmarks"
-msgstr "preklop na zaznamke"
+msgid "Switch to bookmarks"
+msgstr "Preklop na zaznamke"
 
 #
-msgid "switch to filelist"
-msgstr "preklop na seznam datotek"
+msgid "Switch to filelist"
+msgstr "Preklop na seznam datotek"
 
 #
 msgid "switch to the next angle"
@@ -13415,7 +13415,7 @@ msgid "until standby/restart"
 msgstr "do stanja pripravljenosti/resetiranja"
 
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Samodejno iskanje "
 
 msgid "used"

--- a/po/sr.po
+++ b/po/sr.po
@@ -6395,7 +6395,7 @@ msgstr "Norveški"
 msgid "Norwegian"
 msgstr "Norveški"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr ""
 
 #
@@ -12473,7 +12473,7 @@ msgid "copy to bouquets"
 msgstr "kopiraj u bukete"
 
 #
-msgid "create directory"
+msgid "Create directory"
 msgstr "Kreiraj direktorijum"
 
 #
@@ -13128,7 +13128,7 @@ msgid "remove cable services"
 msgstr ""
 
 #
-msgid "remove directory"
+msgid "Remove directory"
 msgstr "Uklonite direktorijum"
 
 #
@@ -13387,12 +13387,12 @@ msgid "successful"
 msgstr ""
 
 #
-msgid "switch to bookmarks"
+msgid "Switch to bookmarks"
 msgstr "Prebaci na oznake"
 
 #
-msgid "switch to filelist"
-msgstr "prebaci u listu datoteka"
+msgid "Switch to filelist"
+msgstr "Prebaci u listu datoteka"
 
 #
 msgid "switch to the next angle"
@@ -13485,7 +13485,7 @@ msgstr "do spreman/restart"
 
 #
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Automatsko skeniranje "
 
 msgid "used"

--- a/po/sv.po
+++ b/po/sv.po
@@ -6224,7 +6224,7 @@ msgstr "Norska"
 msgid "Norwegian"
 msgstr "Norska"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Inte definerad"
 
 #
@@ -12213,8 +12213,8 @@ msgid "copy to bouquets"
 msgstr "kopiera till favoritlista"
 
 #
-msgid "create directory"
-msgstr "skapa bibliotek"
+msgid "Create directory"
+msgstr "Skapa bibliotek"
 
 #
 msgid "daily"
@@ -12865,8 +12865,8 @@ msgid "remove cable services"
 msgstr "ta bort kabel-tv kanaler"
 
 #
-msgid "remove directory"
-msgstr "ta bort bibliotek"
+msgid "Remove directory"
+msgstr "Ta bort bibliotek"
 
 #
 msgid "remove entry"
@@ -13125,12 +13125,12 @@ msgid "successful"
 msgstr "lyckad"
 
 #
-msgid "switch to bookmarks"
-msgstr "byt till bokmärke"
+msgid "Switch to bookmarks"
+msgstr "Byt till bokmärke"
 
 #
-msgid "switch to filelist"
-msgstr "byt till fillista"
+msgid "Switch to filelist"
+msgstr "Byt till fillista"
 
 #
 msgid "switch to the next angle"
@@ -13221,7 +13221,7 @@ msgid "until standby/restart"
 msgstr "tills viloläge / omstart"
 
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Automatisk Sökning"
 
 msgid "used"

--- a/po/th.po
+++ b/po/th.po
@@ -5670,7 +5670,7 @@ msgstr "ภาษานอร์เว"
 msgid "Norwegian"
 msgstr "ภาษานอร์เว"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr ""
 
 #, fuzzy
@@ -11045,7 +11045,7 @@ msgstr ""
 msgid "copy to bouquets"
 msgstr "คัดลอกเข้าสู่กลุ่มรายการ"
 
-msgid "create directory"
+msgid "Create directory"
 msgstr "สร้างโฟล์เดอร์"
 
 msgid "daily"
@@ -11609,7 +11609,7 @@ msgstr ""
 msgid "remove cable services"
 msgstr ""
 
-msgid "remove directory"
+msgid "Remove directory"
 msgstr "ลบโฟล์เดอร์ออก"
 
 msgid "remove entry"
@@ -11839,10 +11839,10 @@ msgstr ""
 msgid "successful"
 msgstr ""
 
-msgid "switch to bookmarks"
+msgid "Switch to bookmarks"
 msgstr "เข้าสู่บุ๊คมาร์ค"
 
-msgid "switch to filelist"
+msgid "Switch to filelist"
 msgstr "เข้าสู่สารบัญไฟล์"
 
 msgid "switch to the next angle"
@@ -11922,7 +11922,7 @@ msgid "until standby/restart"
 msgstr ""
 
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "ค้นหาอัตโนมัติ"
 
 msgid "used"

--- a/po/tr.po
+++ b/po/tr.po
@@ -5568,7 +5568,7 @@ msgstr "Norveççe"
 msgid "Norwegian"
 msgstr "Norveççe"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Tanımlanmamış"
 
 #, fuzzy
@@ -10873,7 +10873,7 @@ msgstr "Yemek"
 msgid "copy to bouquets"
 msgstr "Buketlere Kopyala"
 
-msgid "create directory"
+msgid "Create directory"
 msgstr "Klasör Oluştur"
 
 msgid "daily"
@@ -11435,7 +11435,7 @@ msgstr "Aile korumasından çıkar"
 msgid "remove cable services"
 msgstr "Kablo servisleri sil"
 
-msgid "remove directory"
+msgid "Remove directory"
 msgstr "Klasörü sil"
 
 msgid "remove entry"
@@ -11667,10 +11667,10 @@ msgstr "Başlangıç servislerini durdurun"
 msgid "successful"
 msgstr ""
 
-msgid "switch to bookmarks"
+msgid "Switch to bookmarks"
 msgstr "İşaretçileri atla"
 
-msgid "switch to filelist"
+msgid "Switch to filelist"
 msgstr "Dosya listesine geç"
 
 msgid "switch to the next angle"
@@ -11750,7 +11750,7 @@ msgid "until standby/restart"
 msgstr "H.Bekle/Y.Başlatana Kadar"
 
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Otomatik Tarama"
 
 msgid "used"

--- a/po/uk.po
+++ b/po/uk.po
@@ -5613,7 +5613,7 @@ msgstr "Норвезька"
 msgid "Norwegian"
 msgstr "Норвезька"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Не визначений"
 
 #, fuzzy
@@ -10990,8 +10990,8 @@ msgstr "приготування"
 msgid "copy to bouquets"
 msgstr "копіювати в пакет"
 
-msgid "create directory"
-msgstr "створити каталог"
+msgid "Create directory"
+msgstr "Створити каталог"
 
 msgid "daily"
 msgstr "щодня"
@@ -11552,8 +11552,8 @@ msgstr "видалити букет з батьківського контрол
 msgid "remove cable services"
 msgstr "видалити кабельні послуги"
 
-msgid "remove directory"
-msgstr "видалити каталог"
+msgid "Remove directory"
+msgstr "Видалити каталог"
 
 msgid "remove entry"
 msgstr "видалити обране"
@@ -11784,11 +11784,11 @@ msgstr "відключити від автостарту сервіс"
 msgid "successful"
 msgstr "успішний"
 
-msgid "switch to bookmarks"
-msgstr "перейти на закладки"
+msgid "Switch to bookmarks"
+msgstr "Перейти на закладки"
 
-msgid "switch to filelist"
-msgstr "переключити на список файлів"
+msgid "Switch to filelist"
+msgstr "Переключити на список файлів"
 
 msgid "switch to the next angle"
 msgstr "перейти в наступній кут"
@@ -11867,7 +11867,7 @@ msgid "until standby/restart"
 msgstr "до режиму очікування/перезавантаження"
 
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "Автоматичне Сканування"
 
 msgid "used"

--- a/po/vi.po
+++ b/po/vi.po
@@ -5492,7 +5492,7 @@ msgstr "Na Uy"
 msgid "Norwegian"
 msgstr "Na Uy"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr "Không xác định"
 
 msgid "Not Installed"
@@ -10704,8 +10704,8 @@ msgstr "nấu ăn"
 msgid "copy to bouquets"
 msgstr "sao chép vào gói kênh"
 
-msgid "create directory"
-msgstr "tạo thư mục"
+msgid "Create directory"
+msgstr "Tạo thư mục"
 
 msgid "daily"
 msgstr "hằng ngày"
@@ -11259,8 +11259,8 @@ msgstr "loại bỏ bó hoa khỏi sự bảo vệ của cha mẹ"
 msgid "remove cable services"
 msgstr "loại bỏ dịch vụ cáp"
 
-msgid "remove directory"
-msgstr "xóa thư mục"
+msgid "Remove directory"
+msgstr "Xóa thư mục"
 
 msgid "remove entry"
 msgstr "xoá mục nhập"
@@ -11488,11 +11488,11 @@ msgstr "ngừng sử dụng làm dịch vụ khởi động"
 msgid "successful"
 msgstr "thành công"
 
-msgid "switch to bookmarks"
-msgstr "chuyển sang đánh dấu"
+msgid "Switch to bookmarks"
+msgstr "Chuyển sang đánh dấu"
 
-msgid "switch to filelist"
-msgstr "chuyển sang filelist"
+msgid "Switch to filelist"
+msgstr "Chuyển sang filelist"
 
 msgid "switch to the next angle"
 msgstr "chuyển sang góc tiếp theo"
@@ -11569,8 +11569,8 @@ msgstr "không thể kiểm chứng"
 msgid "until standby/restart"
 msgstr "cho đến khi chờ / khởi động lại"
 
-msgid "update bookmarks"
-msgstr "cập nhật dấu trang"
+msgid "Update bookmarks"
+msgstr "Cập nhật dấu trang"
 
 msgid "used"
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -5500,7 +5500,7 @@ msgstr "挪威语"
 msgid "Norwegian"
 msgstr "挪威语"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr ""
 
 #, fuzzy
@@ -10687,7 +10687,7 @@ msgstr ""
 msgid "copy to bouquets"
 msgstr "复制到自定义组"
 
-msgid "create directory"
+msgid "Create directory"
 msgstr "创建目录"
 
 msgid "daily"
@@ -11250,7 +11250,7 @@ msgstr ""
 msgid "remove cable services"
 msgstr ""
 
-msgid "remove directory"
+msgid "Remove directory"
 msgstr "移除目录"
 
 msgid "remove entry"
@@ -11482,10 +11482,10 @@ msgstr "停止用作启动频道"
 msgid "successful"
 msgstr ""
 
-msgid "switch to bookmarks"
+msgid "Switch to bookmarks"
 msgstr "切换到书签"
 
-msgid "switch to filelist"
+msgid "Switch to filelist"
 msgstr "切换到文件列表"
 
 msgid "switch to the next angle"
@@ -11564,7 +11564,7 @@ msgid "until standby/restart"
 msgstr "直到待机/重启"
 
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "自动扫描"
 
 msgid "used"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -5497,7 +5497,7 @@ msgstr "挪威語"
 msgid "Norwegian"
 msgstr "挪威語"
 
-msgid "Not Defined"
+msgid "Not defined"
 msgstr ""
 
 #, fuzzy
@@ -10691,7 +10691,7 @@ msgstr ""
 msgid "copy to bouquets"
 msgstr "複製到自定義組"
 
-msgid "create directory"
+msgid "Create directory"
 msgstr "創建目錄"
 
 msgid "daily"
@@ -11254,7 +11254,7 @@ msgstr ""
 msgid "remove cable services"
 msgstr ""
 
-msgid "remove directory"
+msgid "Remove directory"
 msgstr "移除目錄"
 
 msgid "remove entry"
@@ -11486,10 +11486,10 @@ msgstr ""
 msgid "successful"
 msgstr ""
 
-msgid "switch to bookmarks"
+msgid "Switch to bookmarks"
 msgstr "切換到書簽"
 
-msgid "switch to filelist"
+msgid "Switch to filelist"
 msgstr "切換到檔列表"
 
 msgid "switch to the next angle"
@@ -11568,7 +11568,7 @@ msgid "until standby/restart"
 msgstr ""
 
 #, fuzzy
-msgid "update bookmarks"
+msgid "Update bookmarks"
 msgstr "自動掃描"
 
 msgid "used"


### PR DESCRIPTION
Most strings come from the help window of the "LocationBox" screen and a couple from the "menu" option of the MovieSelection" screen. I don't see a reason why they should not start with an uppercase letter. Most of them are already translated with uppercase first letter anyway!

All translations are updated and corrected as needed. No extra work is needed from the translators.