### PR TITLE
[ChoiceBox.py] Fix list entry alignment when no key is available

### DIFF
--- a/lib/python/Screens/ChoiceBox.py
+++ b/lib/python/Screens/ChoiceBox.py
@@ -26,9 +26,9 @@ class ChoiceBox(Screen):
 		self.list = []
 		self.summarylist = []
 		if keys is None:
-			self.__keys = [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "red", "green", "yellow", "blue" ] + (len(list) - 14) * [""]
+			self.__keys = [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "red", "green", "yellow", "blue" ] + (len(list) - 14) * ["dummy"]
 		else:
-			self.__keys = keys + (len(list) - len(keys)) * [""]
+			self.__keys = keys + (len(list) - len(keys)) * ["dummy"]
 
 		self.keymap = {}
 		pos = 0


### PR DESCRIPTION
This is similar to #2278 and #2279. See the last entry in the list (which does not have a key assigned to it):

before
![1_0_1_834_68_212C_EEEE0000_0_0_0_20191021134929](https://user-images.githubusercontent.com/1540233/67199609-5c7c2180-f40a-11e9-8fa1-aa7f9e26d122.jpg)

after
![1_0_1_834_68_212C_EEEE0000_0_0_0_20191021134833](https://user-images.githubusercontent.com/1540233/67199611-5c7c2180-f40a-11e9-948a-60beba790957.jpg)
