### PR TITLE
[SoftwareManager] Removed full stop from string

### DIFF
--- a/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
@@ -1900,7 +1900,7 @@ def filescan(**kwargs):
 					ScanPath(path = "", with_subdirs = False),
 				],
 			name = "Ipkg",
-			description = _("Install extensions."),
+			description = _("Install extensions"),
 			openfnc = filescan_open, )
 
 def UpgradeMain(session, **kwargs):


### PR DESCRIPTION
This is a menu list entry, so it doesn't need a full stop at the end.
Translations need NO change at all because a matching string without the full stop already exists!