### PR TITLE
[UsageConfig.py] Added Ancient Greek to auto language selection

### DIFF
--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -693,7 +693,7 @@ def InitUsageConfig():
 		("fin", _("Finnish")),
 		("fra fre", _("French")),
 		("deu ger", _("German")),
-		("ell gre", _("Greek")),
+		("ell gre grc", _("Greek")),
 		("heb", _("Hebrew")),
 		("hun", _("Hungarian")),
 		("ind", _("Indonesian")),


### PR DESCRIPTION
Some retarded channels still set the language code to Ancient Greek (grc) instead of Modern Greek (ell, gre).