### PR TITLE
Skin - added parse string into parseParameters

### DIFF
--- a/skin.py
+++ b/skin.py
@@ -226,7 +226,9 @@ def parseColor(s):
 	return gRGB(int(s[1:], 0x10))
 
 def parseParameter(s):
-	"""This function is responsible for parsing parameters in the skin, it can parse integers, floats, hex colors, hex integers and named colors."""
+	"""This function is responsible for parsing parameters in the skin, it can parse integers, floats, hex colors, hex integers, named colors and string."""
+	if s[0] == '*':
+		return s[1:]
 	if s[0] == '#':
 		return int(s[1:], 16)
 	elif s[:2] == '0x':


### PR DESCRIPTION
- each string parameter used in skin.xml must to have '*' as prefix
- used for pass picture pathes from skin as parameter

example of using:

or in skin.xml under `<parameters>`:

`<parameter name="MyPictures" value="*small/icons/picture1.png,*small/icons/picture2.png"/>`

or in skin.py (without prefix) as:
parameters["MyPictures"] = ("small/icons/picture1.png","small/icons/picture2.png")

then get it in python code:
my1, my2 = skin.parameters.get("MyPictures",("icons/picture1.png","icons/picture2.png"))