### PR TITLE
Renamed "Exit/OK" to "Exit"

### DIFF
--- a/lib/python/Plugins/SystemPlugins/PositionerSetup/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/PositionerSetup/plugin.py
@@ -1254,7 +1254,7 @@ class PositionerSetupLog(Screen):
 		self.session = session
 		Screen.__init__(self, session)
 		self.setTitle(_("Positioner setup log"))
-		self["key_red"] = Button(_("Exit/OK"))
+		self["key_red"] = Button(_("Exit"))
 		self["key_green"] = Button(_("Save"))
 		self["key_blue"] = Button(_("Clear"))
 		self["list"] = ScrollLabel(log.getvalue())


### PR DESCRIPTION
This is the text for the red button in the "PositionerSetupLog" screen. Just use "Exit" which is nicer and more common.

Existing translations don't need any changes, as the new string (Exit) already exists. 