### PR TITLE
Added skin parameter for setting frontend colors

### DIFF
--- a/lib/python/Components/Converter/FrontendInfo.py
+++ b/lib/python/Components/Converter/FrontendInfo.py
@@ -2,6 +2,8 @@ from Components.Converter.Converter import Converter
 from Components.Element import cached
 from Components.config import config
 from Components.NimManager import nimmanager
+from skin import parameters
+from Tools.Hex2strColor import Hex2strColor
 
 class FrontendInfo(Converter, object):
 	BER = 0
@@ -44,6 +46,7 @@ class FrontendInfo(Converter, object):
 		assert self.type not in (self.LOCK, self.SLOT_NUMBER), "the text output of FrontendInfo cannot be used for lock info"
 		percent = None
 		swapsnr = config.usage.swap_snr_on_osd.value
+		colors = parameters.get("FrontendInfoColors", (0x0000FF00, 0x00FFFF00, 0x007F7F7F)) # tuner active, busy, available colors
 		if self.type == self.BER: # as count
 			count = self.source.ber
 			if count is not None:
@@ -66,11 +69,11 @@ class FrontendInfo(Converter, object):
 			for n in nimmanager.nim_slots:
 				if n.type:
 					if n.slot == self.source.slot_number:
-						color = "\c0000??00"
+						color = Hex2strColor(colors[0])
 					elif self.source.tuner_mask & 1 << n.slot:
-						color = "\c00????00"
+						color = Hex2strColor(colors[1])
 					elif len(nimmanager.nim_slots) <= self.space_for_tuners or self.show_all_non_link_tuners and not (n.isFBCLink() or n.internally_connectable):
-						color = "\c007?7?7?"
+						color = Hex2strColor(colors[2])
 					else:
 						continue
 					if string and len(nimmanager.nim_slots) <= self.space_for_tuners_with_spaces:
@@ -82,9 +85,9 @@ class FrontendInfo(Converter, object):
 			for n in nimmanager.nim_slots:
 				if n.type:
 					if n.slot == self.source.slot_number:
-						color = "\c0000??00"
+						color = Hex2strColor(colors[0])
 					elif self.source.tuner_mask & 1 << n.slot:
-						color = "\c00????00"
+						color = Hex2strColor(colors[1])
 					else:
 						continue
 					if string:

--- a/lib/python/Components/Renderer/NextEpgInfo.py
+++ b/lib/python/Components/Renderer/NextEpgInfo.py
@@ -3,6 +3,7 @@ from Renderer import Renderer
 from enigma import eLabel, eEPGCache, eServiceReference
 from time import time, localtime, strftime
 from skin import parseColor
+from Tools.Hex2strColor import Hex2strColor
 
 class NextEpgInfo(Renderer, VariableText):
 	def __init__(self):
@@ -13,7 +14,7 @@ class NextEpgInfo(Renderer, VariableText):
 		self.hideLabel = 0
 		self.timecolor = ""
 		self.labelcolor = ""
-		self.foregroundColor = "00?0?0?0"
+		self.foregroundColor = "\c00?0?0?0"
 		self.numOfSpaces = 1
 
 	GUI_WIDGET = eLabel
@@ -54,32 +55,18 @@ class NextEpgInfo(Renderer, VariableText):
 				self.numOfSpaces = int(value)
 				attribs.append((attrib, value))
 			if attrib == "timeColor":
-				self.timecolor = self.hex2strColor(parseColor(value).argb())
+				self.timecolor = Hex2strColor(parseColor(value).argb())
 				attribs.append((attrib, value))
 			if attrib == "labelColor":
-				self.labelcolor = self.hex2strColor(parseColor(value).argb())
+				self.labelcolor = Hex2strColor(parseColor(value).argb())
 				attribs.append((attrib, value))
 			if attrib == "foregroundColor":
-				self.foregroundColor = self.hex2strColor(parseColor(value).argb())
+				self.foregroundColor = Hex2strColor(parseColor(value).argb())
 				attribs.append((attrib, value))
 		for (attrib, value) in attribs:
 			self.skinAttributes.remove((attrib, value))
-		self.timecolor = self.formatColorString(self.timecolor)
-		self.labelcolor  = self.formatColorString(self.labelcolor)
-		self.foregroundColor  = self.formatColorString(self.foregroundColor)
+		if self.timecolor == "": # fallback to foregroundColor
+			self.timecolor = self.foregroundColor
+		if self.labelcolor == "": # fallback to foregroundColor
+			self.labelcolor = self.foregroundColor
 		return Renderer.applySkin(self, desktop, parent)
-
-# 	hex:
-#	0 1 2 3 4 5 6 7 8 9 a b c d e f
-# 	converts to:
-#	0 1 2 3 4 5 6 7 8 9 : ; < = > ?
-	def hex2strColor(self, rgb):
-		out = ""
-		for i in range(28,-1,-4):
-			out += "%s" % chr(0x30 + (rgb>>i & 0xf))
-		return  out
-
-	def formatColorString(self, color):
-		if color:
-			return "%s%s" % ('\c', color)
-		return "%s%s" % ('\c', self.foregroundColor)

--- a/lib/python/Tools/Hex2strColor.py
+++ b/lib/python/Tools/Hex2strColor.py
@@ -1,0 +1,13 @@
+# Converts hex colors to formatted strings,
+# suitable for embedding in python code.
+#
+# hex:
+# 0 1 2 3 4 5 6 7 8 9 a b c d e f
+# converts to:
+# 0 1 2 3 4 5 6 7 8 9 : ; < = > ?
+
+def Hex2strColor(rgb):
+	out = ""
+	for i in range(28, -1, -4):
+		out += "%s" % chr(0x30 + (rgb >> i & 0x0F))
+	return "\c%s" % out


### PR DESCRIPTION
This allows skins to set the color for the different tuner status. For example, in infobar, now the color is configurable. See picture below. The default colors remain the same (green, yellow, grey).

![tunercolors](https://user-images.githubusercontent.com/1540233/69485407-b6c43400-0e47-11ea-80a6-14b92fa9f466.jpg)
