### PR TITLE
Fixed "Taiwan" in country codes

### DIFF
--- a/lib/python/Tools/CountryCodes.py
+++ b/lib/python/Tools/CountryCodes.py
@@ -216,7 +216,7 @@ ISO3166 = [
 	(_("Sweden"), "SE", "SWE"),
 	(_("Switzerland"), "CH", "CHE"),
 	(_("Syrian Arab Republic"), "SY", "SYR"),
-	(_("[a]"), "TW", "TWN"),
+	(_("Taiwan"), "TW", "TWN"),
 	(_("Tajikistan"), "TJ", "TJK"),
 	(_("Tanzania, United Republic of"), "TZ", "TZA"),
 	(_("Thailand"), "TH", "THA"),


### PR DESCRIPTION
I don't know what this "[a]" was, maybe a typo? Unless I'm missing something....