### PR TITLE
Correct issues with Directories.py

### DIFF
--- a/lib/python/Tools/Directories.py
+++ b/lib/python/Tools/Directories.py
@@ -143,20 +143,20 @@ def resolveFilename(scope, base="", path_prefix=None):
 		# This import must be here as this module finds the config file as part of the config initialisation.
 		from Components.config import config
 		skin = os.path.dirname(config.skin.primary_skin.value)
-		if hasattr(config.skin, "display_skin"):
-			display = os.path.dirname(config.skin.display_skin.value)
-		else:
-			display = ""
+		display = os.path.dirname(config.skin.display_skin.value) if hasattr(config.skin, "display_skin") else None
 		resolveList = [
 			os.path.join(defaultPaths[SCOPE_CONFIG][0], "fonts"),
-			os.path.join(defaultPaths[SCOPE_SKIN][0], skin),
-			os.path.join(defaultPaths[SCOPE_SKIN][0], "skin_default"),
-			os.path.join(defaultPaths[SCOPE_LCDSKIN][0], display),
-			os.path.join(defaultPaths[SCOPE_LCDSKIN][0], "skin_default"),
-			os.path.join(defaultPaths[SCOPE_CONFIG][0], skin),
-			os.path.join(defaultPaths[SCOPE_CONFIG][0], display),
-			defaultPaths[SCOPE_FONTS][0]
+			os.path.join(defaultPaths[SCOPE_CONFIG][0], skin)
 		]
+		if display:
+			resolveList.append(os.path.join(defaultPaths[SCOPE_CONFIG][0], "display", display))
+		resolveList.append(defaultPaths[SCOPE_CONFIG][0])  # Can we deprecate top level of SCOPE_CONFIG directory to allow a clean up?
+		resolveList.append(os.path.join(defaultPaths[SCOPE_SKIN][0], skin))
+		resolveList.append(os.path.join(defaultPaths[SCOPE_SKIN][0], "skin_default"))
+		if display:
+			resolveList.append(os.path.join(defaultPaths[SCOPE_LCDSKIN][0], display))
+		resolveList.append(os.path.join(defaultPaths[SCOPE_LCDSKIN][0], "skin_default"))
+		resolveList.append(defaultPaths[SCOPE_FONTS][0])
 		for item in resolveList:
 			file = os.path.join(item, base)
 			if pathExists(file):

--- a/lib/python/Tools/Directories.py
+++ b/lib/python/Tools/Directories.py
@@ -108,11 +108,12 @@ def resolveFilename(scope, base="", path_prefix=None):
 		skin = os.path.dirname(config.skin.primary_skin.value)
 		resolveList = [
 			os.path.join(defaultPaths[SCOPE_CONFIG][0], skin),
-			defaultPaths[SCOPE_CONFIG][0],  # Deprecated top level of SCOPE_CONFIG directory.
+			os.path.join(defaultPaths[SCOPE_CONFIG][0], "skin_common"),
+			defaultPaths[SCOPE_CONFIG][0],  # Can we deprecate top level of SCOPE_CONFIG directory to allow a clean up?
 			os.path.join(defaultPaths[SCOPE_SKIN][0], skin),
 			os.path.join(defaultPaths[SCOPE_SKIN][0], "skin_fallback_%d" % getDesktop(0).size().height()),
 			os.path.join(defaultPaths[SCOPE_SKIN][0], "skin_default"),
-			defaultPaths[SCOPE_SKIN][0]
+			defaultPaths[SCOPE_SKIN][0]  # Can we deprecate top level of SCOPE_SKIN directory to allow a clean up?
 		]
 		for item in resolveList:
 			file = os.path.join(item, base)
@@ -128,11 +129,12 @@ def resolveFilename(scope, base="", path_prefix=None):
 			skin = ""
 		resolveList = [
 			os.path.join(defaultPaths[SCOPE_CONFIG][0], "display", skin),
-			defaultPaths[SCOPE_CONFIG][0],  # Deprecated top level of SCOPE_CONFIG directory.
+			os.path.join(defaultPaths[SCOPE_CONFIG][0], "display", "skin_common"),
+			defaultPaths[SCOPE_CONFIG][0],  # Can we deprecate top level of SCOPE_CONFIG directory to allow a clean up?
 			os.path.join(defaultPaths[SCOPE_LCDSKIN][0], skin),
 			os.path.join(defaultPaths[SCOPE_LCDSKIN][0], "skin_fallback_%s" % getDesktop(1).size().height()),
 			os.path.join(defaultPaths[SCOPE_LCDSKIN][0], "skin_default"),
-			defaultPaths[SCOPE_LCDSKIN][0]
+			defaultPaths[SCOPE_LCDSKIN][0]  # Can we deprecate top level of SCOPE_LCDSKIN directory to allow a clean up?
 		]
 		for item in resolveList:
 			file = os.path.join(item, base)
@@ -150,6 +152,7 @@ def resolveFilename(scope, base="", path_prefix=None):
 		]
 		if display:
 			resolveList.append(os.path.join(defaultPaths[SCOPE_CONFIG][0], "display", display))
+		resolveList.append(os.path.join(defaultPaths[SCOPE_CONFIG][0], "skin_common"))
 		resolveList.append(defaultPaths[SCOPE_CONFIG][0])  # Can we deprecate top level of SCOPE_CONFIG directory to allow a clean up?
 		resolveList.append(os.path.join(defaultPaths[SCOPE_SKIN][0], skin))
 		resolveList.append(os.path.join(defaultPaths[SCOPE_SKIN][0], "skin_default"))

--- a/lib/python/Tools/Directories.py
+++ b/lib/python/Tools/Directories.py
@@ -108,10 +108,10 @@ def resolveFilename(scope, base="", path_prefix=None):
 		skin = os.path.dirname(config.skin.primary_skin.value)
 		resolveList = [
 			os.path.join(defaultPaths[SCOPE_CONFIG][0], skin),
+			defaultPaths[SCOPE_CONFIG][0],  # Deprecated top level of SCOPE_CONFIG directory.
 			os.path.join(defaultPaths[SCOPE_SKIN][0], skin),
 			os.path.join(defaultPaths[SCOPE_SKIN][0], "skin_fallback_%d" % getDesktop(0).size().height()),
 			os.path.join(defaultPaths[SCOPE_SKIN][0], "skin_default"),
-			defaultPaths[SCOPE_CONFIG][0],  # Deprecated top level of SCOPE_CONFIG directory.
 			defaultPaths[SCOPE_SKIN][0]
 		]
 		for item in resolveList:
@@ -128,10 +128,10 @@ def resolveFilename(scope, base="", path_prefix=None):
 			skin = ""
 		resolveList = [
 			os.path.join(defaultPaths[SCOPE_CONFIG][0], "display", skin),
+			defaultPaths[SCOPE_CONFIG][0],  # Deprecated top level of SCOPE_CONFIG directory.
 			os.path.join(defaultPaths[SCOPE_LCDSKIN][0], skin),
 			os.path.join(defaultPaths[SCOPE_LCDSKIN][0], "skin_fallback_%s" % getDesktop(1).size().height()),
 			os.path.join(defaultPaths[SCOPE_LCDSKIN][0], "skin_default"),
-			defaultPaths[SCOPE_CONFIG][0],  # Deprecated top level of SCOPE_CONFIG directory.
 			defaultPaths[SCOPE_LCDSKIN][0]
 		]
 		for item in resolveList:


### PR DESCRIPTION
- [Directories.py] Raise priority of "/etc/enigma2"

  This change corrects an error where the USER priority for "/etc/enigma2/" was set too low and below that of the SKIN priority.

  This change correctly implements the USER, SKIN, DEFAULT priority protocol.

- [Directories.py] Fix SCOPE_FONTS

  This change corrects a few issues with the SCOPE_FONTS search list.
    - If there is no display skin in use redundant search entries were added to the search list
    - The "/etc/enigma2/" search item was omitted from the list

  This change correctly implements the USER, SKIN, DEFAULT priority protocol.

- [Directories.py] Add common directory

  Add new skin common directory to store shared or common skin override components.  This location can be used to store shared or common skin override components in a more logical location without cluttering up the higher level "/etc/enigma2/" directory.

  This directory can become the appropriate alternative for "/etc/enigma2/" if the proposal to deprecate "/etc/enigma2/" as a skin component storage location is accepted.  The "/etc/enigma2/" directory is becoming cluttered with too many objects for too many different purposes.  This directory currently can contain tuner data, bouquet data, timer data, user setting data, plugin setting data, resume data and more.  Do we really want/need to have parts of skins stored in here as well?   The clutter increases the chances of files becoming confused and potentially removed or damaged.  The new "/etc/enigma2/skin_common/" directory can be the replacement for the "/etc/enigma2/" general catch all location for all skin overrides.  (The "/etc/enigma2/" directory itself is not being nominated for deprecation.  The deprecation only applies to its use for storing skin components at the top level.)

  Adjust the text of the deprecation comments to better explain that the deprecation is simply a proposal.  Also add information to explain the potential benefit is to clean up and remove skin components from the top levels of the "/etc/enigma2/", "/etc/share/enigma2/" and "/etc/share/enigma2/display/" directories.
