### PR TITLE
Made string available for translation

### DIFF
--- a/lib/python/Components/Converter/PliExtraInfo.py
+++ b/lib/python/Components/Converter/PliExtraInfo.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # shamelessly copied from pliExpertInfo (Vali, Mirakels, Littlesat)
 
 from enigma import iServiceInformation, iPlayableService
@@ -261,9 +262,9 @@ class PliExtraInfo(Poll, Converter):
 	def createOrbPos(self, feraw):
 		orbpos = feraw.get("orbital_position")
 		if orbpos > 1800:
-			return str((float(3600 - orbpos)) / 10.0) + "\xc2\xb0 W"
+			return _("%.1f° W") % ((3600 - orbpos) / 10.0)
 		elif orbpos > 0:
-			return str((float(orbpos)) / 10.0) + "\xc2\xb0 E"
+			return _("%.1f° E") % (orbpos / 10.0)
 		return ""
 
 	def createOrbPosOrTunerSystem(self, fedata, feraw):

--- a/lib/python/Screens/Dish.py
+++ b/lib/python/Screens/Dish.py
@@ -246,8 +246,8 @@ class Dish(Screen):
 			return _("N/A")
 		if orbpos > 1800:
 			orbpos = 3600 - orbpos
-			return _("%.1f°W") % (orbpos / 10.0)
-		return _("%.1f°E") % (orbpos / 10.0)
+			return _("%.1f° W") % (orbpos / 10.0)
+		return _("%.1f° E") % (orbpos / 10.0)
 
 	def FormatTurnTime(self, time):
 		t = abs(time)

--- a/po/de.po
+++ b/po/de.po
@@ -117,12 +117,12 @@ msgid "%.0f kB"
 msgstr "%.0f kB"
 
 #, python-format
-msgid "%.1f°E"
-msgstr "%.1f°E"
+msgid "%.1f° E"
+msgstr "%.1f° E"
 
 #, python-format
-msgid "%.1f°W"
-msgstr "%.1f°W"
+msgid "%.1f° W"
+msgstr "%.1f° W"
 
 #, python-format
 msgid "%.2f GB"

--- a/po/el.po
+++ b/po/el.po
@@ -117,12 +117,12 @@ msgid "%.0f kB"
 msgstr "%.0f kB"
 
 #, python-format
-msgid "%.1f°E"
-msgstr "%.1f°Α"
+msgid "%.1f° E"
+msgstr "%.1f° Α"
 
 #, python-format
-msgid "%.1f°W"
-msgstr "%.1f°Δ"
+msgid "%.1f° W"
+msgstr "%.1f° Δ"
 
 #, python-format
 msgid "%.2f GB"

--- a/po/fr.po
+++ b/po/fr.po
@@ -116,12 +116,12 @@ msgid "%.0f kB"
 msgstr "%.0f kB"
 
 #, python-format
-msgid "%.1f°E"
-msgstr "%.1f°E"
+msgid "%.1f° E"
+msgstr "%.1f° E"
 
 #, python-format
-msgid "%.1f°W"
-msgstr "%.1f°O"
+msgid "%.1f° W"
+msgstr "%.1f° O"
 
 #, python-format
 msgid "%.2f GB"

--- a/po/hr.po
+++ b/po/hr.po
@@ -116,12 +116,12 @@ msgid "%.0f kB"
 msgstr "%.0f kB"
 
 #, python-format
-msgid "%.1f°E"
-msgstr "%.1f°I"
+msgid "%.1f° E"
+msgstr "%.1f° I"
 
 #, python-format
-msgid "%.1f°W"
-msgstr "%.1f°Z"
+msgid "%.1f° W"
+msgstr "%.1f° Z"
 
 #, python-format
 msgid "%.2f GB"

--- a/po/hu.po
+++ b/po/hu.po
@@ -116,12 +116,12 @@ msgid "%.0f kB"
 msgstr "%.0f kB"
 
 #, python-format
-msgid "%.1f°E"
-msgstr "%.1f°K"
+msgid "%.1f° E"
+msgstr "%.1f° K"
 
 #, python-format
-msgid "%.1f°W"
-msgstr "%.1f°NY"
+msgid "%.1f° W"
+msgstr "%.1f° NY"
 
 #, python-format
 msgid "%.2f GB"

--- a/po/lt.po
+++ b/po/lt.po
@@ -117,12 +117,12 @@ msgid "%.0f kB"
 msgstr "%.0f kB"
 
 #, python-format
-msgid "%.1f°E"
-msgstr "%.1f°E"
+msgid "%.1f° E"
+msgstr "%.1f° E"
 
 #, python-format
-msgid "%.1f°W"
-msgstr "%.1f°W"
+msgid "%.1f° W"
+msgstr "%.1f° W"
 
 #, python-format
 msgid "%.2f GB"

--- a/po/nb.po
+++ b/po/nb.po
@@ -127,12 +127,12 @@ msgid "%.0f kB"
 msgstr "%.0f kB"
 
 #, python-format
-msgid "%.1f°E"
-msgstr "%.1f°E"
+msgid "%.1f° E"
+msgstr "%.1f° E"
 
 #, python-format
-msgid "%.1f°W"
-msgstr "%.1f°W"
+msgid "%.1f° W"
+msgstr "%.1f° W"
 
 #, python-format
 msgid "%.2f GB"

--- a/po/nl.po
+++ b/po/nl.po
@@ -116,12 +116,12 @@ msgid "%.0f kB"
 msgstr "%.0f kB"
 
 #, python-format
-msgid "%.1f°E"
-msgstr "%.1f°O"
+msgid "%.1f° E"
+msgstr "%.1f° O"
 
 #, python-format
-msgid "%.1f°W"
-msgstr "%.1f°W"
+msgid "%.1f° W"
+msgstr "%.1f° W"
 
 #, python-format
 msgid "%.2f GB"

--- a/po/ru.po
+++ b/po/ru.po
@@ -116,12 +116,12 @@ msgid "%.0f kB"
 msgstr "%.0f kB"
 
 #, python-format
-msgid "%.1f°E"
-msgstr "%.1f°E"
+msgid "%.1f° E"
+msgstr "%.1f° E"
 
 #, python-format
-msgid "%.1f°W"
-msgstr "%.1f°W"
+msgid "%.1f° W"
+msgstr "%.1f° W"
 
 #, python-format
 msgid "%.2f GB"

--- a/po/vi.po
+++ b/po/vi.po
@@ -116,12 +116,12 @@ msgid "%.0f kB"
 msgstr "%.0f kB"
 
 #, python-format
-msgid "%.1f°E"
-msgstr "%.1f°E"
+msgid "%.1f° E"
+msgstr "%.1f° E"
 
 #, python-format
-msgid "%.1f°W"
-msgstr "%.1f°W"
+msgid "%.1f° W"
+msgstr "%.1f° W"
 
 #, python-format
 msgid "%.2f GB"


### PR DESCRIPTION
This patch makes the orbital position in the PliExtraInfo translatable.

It also adds a space to the corresponding strings in Dish.py, so they match to the ones in PliExtraInfo and can be translated with the same entry.

Existing translations are updated as necessary.