### PR TITLE
[PliExtranInfo.py] Made string available for translation

### DIFF
--- a/lib/python/Components/Converter/PliExtraInfo.py
+++ b/lib/python/Components/Converter/PliExtraInfo.py
@@ -173,7 +173,7 @@ class PliExtraInfo(Poll, Converter):
 		return ("SDR", "HDR", "HDR10", "HLG", "")[info.getInfo(iServiceInformation.sGamma)]
 
 	def createVideoCodec(self, info):
-		return codec_data.get(info.getInfo(iServiceInformation.sVideoType), "N/A")
+		return codec_data.get(info.getInfo(iServiceInformation.sVideoType), _("N/A"))
 
 	def createPIDInfo(self, info):
 		vpid = info.getInfo(iServiceInformation.sVideoPID)


### PR DESCRIPTION
This was reverted as part  of https://github.com/OpenPLi/enigma2/commit/ca2a1b142eae4bd131fc1c6724f8420759f50c5c but it didn't cause the problem, as far as I understand.

This time I kept the "N/A" inside the "get" function.