### PR TITLE
{sec] Set MAX_LNBNUM 70

### DIFF
--- a/lib/dvb/sec.h
+++ b/lib/dvb/sec.h
@@ -249,7 +249,7 @@ class eDVBSatelliteLNBParameters
 			SatCR_format = SatCR_format_none;
 #ifndef SWIG
 			m_12V_relais_state = OFF;
-			m_lof_hi = m_lof_lo = m_lof_threshold = 0;
+			m_lof_hi = m_lof_lo = m_lof_threshold = LNBNum = 0;
 			m_increased_voltage = false;
 			m_prio = -1;
 #endif
@@ -274,13 +274,16 @@ class eDVBSatelliteLNBParameters
 	eDVBSatelliteRotorParameters m_rotor_parameters;
 
 	int m_prio; // to override automatic tuner management ... -1 is Auto
+	int LNBNum;
 #endif
 public:
 #define guard_offset_min -8000
 #define guard_offset_max 8000
 #define guard_offset_step 8000
 #define MAX_SATCR 32
-#define MAX_LNBNUM 32
+#define MAX_FIXED_LNB_POSITIONS 64
+#define MAX_MOVABLE_LNBS 6
+#define MAX_LNBNUM (MAX_FIXED_LNB_POSITIONS + MAX_MOVABLE_LNBS)
 
 	SatCR_format_t SatCR_format;
 	int SatCR_positions;
@@ -294,7 +297,6 @@ public:
 	int old_orbital_position;
 	int guard_offset_old;
 	int guard_offset;
-	int LNBNum;
 };
 
 class eDVBRegisteredFrontend;
@@ -363,7 +365,9 @@ public:
 	RESULT setLNBThreshold(int threshold);
 	RESULT setLNBIncreasedVoltage(bool onoff);
 	RESULT setLNBPrio(int prio);
-	RESULT setLNBNum(int LNBNum);
+	RESULT setLNBNum(int lnbnum);
+	RESULT getMaxFixedLnbPositions() {return MAX_FIXED_LNB_POSITIONS;}
+	RESULT getMaxLnbNum() {return MAX_LNBNUM;}
 /* DiSEqC Specific Parameters */
 	RESULT setDiSEqCMode(int diseqcmode);
 	RESULT setToneburst(int toneburst);

--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -124,6 +124,7 @@ class SecConfigure:
 	def update(self):
 		sec = secClass.getInstance()
 		self.configuredSatellites = set()
+		self.maxLnbNum = sec.getMaxLnbNum()
 		for slotid in self.NimManager.getNimListOfType("DVB-S"):
 			if self.NimManager.nimInternallyConnectableTo(slotid) is not None:
 				self.NimManager.nimRemoveInternalLink(slotid)
@@ -295,7 +296,7 @@ class SecConfigure:
 				currLnb = config.Nims[slotid].advanced.lnb[x]
 				sec.addLNB()
 
-				if x < 65:
+				if x <= self.maxLnbNum:
 					sec.setLNBNum(x)
 
 				tunermask = 1 << slotid


### PR DESCRIPTION
#define MAX_FIXED_LNB_POSITIONS 64
#define MAX_MOVABLE_LNBS 6
#define MAX_LNBNUM (MAX_FIXED_LNB_POSITIONS + MAX_MOVABLE_LNBS)
LNB65 3601 All satellites 1 (USALS)
LNB66 3602 All satellites 2(USALS)
LNB67 3603 All satellites 3 (USALS)
LNB68 3604 All satellites 4 (USALS)
LNB69 3605 Selecting satellites 1 (USALS)
LNB70 3606 Selecting satellites 2 (USALS)