### PR TITLE
[DiseqcTester] Renamed string

### DIFF
--- a/lib/python/Plugins/SystemPlugins/DiseqcTester/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/DiseqcTester/plugin.py
@@ -203,9 +203,9 @@ class DiseqcTester(Screen, TuneTest, ResultParser):
 		if index in self.indexlist:
 			for entry in self.list:
 				if entry[0] == index:
-					self.changeProgressListStatus(index, _("working"))
+					self.changeProgressListStatus(index, _("testing"))
 					return
-			self.list.append(self.getProgressListComponent(index, _("working")))
+			self.list.append(self.getProgressListComponent(index, _("testing")))
 			self["progress_list"].list = self.list
 			self["progress_list"].setIndex(len(self.list) - 1)
 
@@ -411,7 +411,7 @@ class DiseqcTester(Screen, TuneTest, ResultParser):
 		elif oldstatus == _("not_tested"):
 			self.results[index]["status"] = status
 
-		if self.results[index]["status"] != _("working"):
+		if self.results[index]["status"] != _("testing"):
 			self.results[index]["internalstatus"] = self.results[index]["status"]
 		self.results[index]["failed"] = failedTune + self.results[index]["failed"]
 		self.results[index]["successful"] = successfullyTune + self.results[index]["successful"]

--- a/po/ar.po
+++ b/po/ar.po
@@ -12442,7 +12442,7 @@ msgstr ""
 msgid "with_errors"
 msgstr ""
 
-msgid "working"
+msgid "testing"
 msgstr "يعمل"
 
 msgid "xp1000"

--- a/po/bg.po
+++ b/po/bg.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: enigma2 3.0.0\n"
-"Report-Msgid-Bugs-To: \n"                                
+"Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-30 07:47+0100\n"
 "PO-Revision-Date: 2018-11-12 20:51+0200\n"
 "Last-Translator: Мартин Петков <marto74bg@yahoo.co.uk>\n"
@@ -11351,7 +11351,7 @@ msgstr "с име на тунера"
 msgid "with_errors"
 msgstr "с грешки"
 
-msgid "working"
+msgid "testing"
 msgstr "работи"
 
 msgid "xp1000"

--- a/po/ca.po
+++ b/po/ca.po
@@ -13107,7 +13107,7 @@ msgid "with_errors"
 msgstr ""
 
 #
-msgid "working"
+msgid "testing"
 msgstr ""
 
 msgid "xp1000"

--- a/po/cs.po
+++ b/po/cs.po
@@ -13328,7 +13328,7 @@ msgid "with_errors"
 msgstr "s_chybami"
 
 #
-msgid "working"
+msgid "testing"
 msgstr "pracuji"
 
 msgid "xp1000"

--- a/po/da.po
+++ b/po/da.po
@@ -13279,7 +13279,7 @@ msgid "with_errors"
 msgstr "med_fejl"
 
 #
-msgid "working"
+msgid "testing"
 msgstr "fungerer"
 
 msgid "xp1000"

--- a/po/de.po
+++ b/po/de.po
@@ -11618,7 +11618,7 @@ msgstr "mit Tuner Namen"
 msgid "with_errors"
 msgstr "mit_Fehlern"
 
-msgid "working"
+msgid "testing"
 msgstr "Arbeite"
 
 msgid "xp1000"

--- a/po/el.po
+++ b/po/el.po
@@ -11589,8 +11589,8 @@ msgstr "με όνομα tuner"
 msgid "with_errors"
 msgstr "με_σφάλματα"
 
-msgid "working"
-msgstr "σε λειτουργία"
+msgid "testing"
+msgstr "υπό έλεγχο"
 
 msgid "xp1000"
 msgstr "xp1000"

--- a/po/en.po
+++ b/po/en.po
@@ -11720,8 +11720,8 @@ msgstr ""
 msgid "with_errors"
 msgstr ""
 
-msgid "working"
-msgstr "working"
+msgid "testing"
+msgstr "testing"
 
 msgid "xp1000"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -12984,7 +12984,7 @@ msgid "with_errors"
 msgstr "Con errores"
 
 #
-msgid "working"
+msgid "testing"
 msgstr "trabajando"
 
 msgid "xp1000"

--- a/po/et.po
+++ b/po/et.po
@@ -11689,7 +11689,7 @@ msgstr "koos tuuneri nimega"
 msgid "with_errors"
 msgstr "vigadega"
 
-msgid "working"
+msgid "testing"
 msgstr "töös"
 
 msgid "xp1000"

--- a/po/fa.po
+++ b/po/fa.po
@@ -11812,7 +11812,7 @@ msgstr ""
 msgid "with_errors"
 msgstr ""
 
-msgid "working"
+msgid "testing"
 msgstr ""
 
 msgid "xp1000"

--- a/po/fi.po
+++ b/po/fi.po
@@ -13009,7 +13009,7 @@ msgid "with_errors"
 msgstr ""
 
 #
-msgid "working"
+msgid "testing"
 msgstr "Työskentelee"
 
 msgid "xp1000"

--- a/po/fr.po
+++ b/po/fr.po
@@ -11604,7 +11604,7 @@ msgstr "avec nom du tuner"
 msgid "with_errors"
 msgstr "Avec_erreurs"
 
-msgid "working"
+msgid "testing"
 msgstr "Travail en cours..."
 
 msgid "xp1000"

--- a/po/fy.po
+++ b/po/fy.po
@@ -13359,7 +13359,7 @@ msgid "with_errors"
 msgstr ""
 
 #
-msgid "working"
+msgid "testing"
 msgstr ""
 
 msgid "xp1000"

--- a/po/he.po
+++ b/po/he.po
@@ -12581,7 +12581,7 @@ msgstr ""
 msgid "with_errors"
 msgstr ""
 
-msgid "working"
+msgid "testing"
 msgstr "עובד"
 
 msgid "xp1000"

--- a/po/hr.po
+++ b/po/hr.po
@@ -11611,7 +11611,7 @@ msgstr "s imenom tjunera"
 msgid "with_errors"
 msgstr "s_greškama"
 
-msgid "working"
+msgid "testing"
 msgstr "u radu"
 
 msgid "xp1000"

--- a/po/hu.po
+++ b/po/hu.po
@@ -11594,7 +11594,7 @@ msgstr "tuner névvel"
 msgid "with_errors"
 msgstr "hibákkal"
 
-msgid "working"
+msgid "testing"
 msgstr "működőképes"
 
 msgid "xp1000"

--- a/po/id.po
+++ b/po/id.po
@@ -11850,7 +11850,7 @@ msgstr "dgn nama penala"
 msgid "with_errors"
 msgstr "dgn_kesalahan"
 
-msgid "working"
+msgid "testing"
 msgstr "berfungsi"
 
 msgid "xp1000"

--- a/po/is.po
+++ b/po/is.po
@@ -13175,7 +13175,7 @@ msgid "with_errors"
 msgstr ""
 
 #
-msgid "working"
+msgid "testing"
 msgstr "er að vinna"
 
 msgid "xp1000"

--- a/po/it.po
+++ b/po/it.po
@@ -11604,7 +11604,7 @@ msgstr "Con nome sintonizzatore"
 msgid "with_errors"
 msgstr "Con errori"
 
-msgid "working"
+msgid "testing"
 msgstr "funzionante"
 
 msgid "xp1000"

--- a/po/ku.po
+++ b/po/ku.po
@@ -11722,8 +11722,8 @@ msgstr ""
 msgid "with_errors"
 msgstr ""
 
-msgid "working"
-msgstr "working"
+msgid "testing"
+msgstr "testing"
 
 msgid "xp1000"
 msgstr ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -11617,7 +11617,7 @@ msgstr "su imtuvo pavadinimu"
 msgid "with_errors"
 msgstr "su klaidomis"
 
-msgid "working"
+msgid "testing"
 msgstr "dirba"
 
 msgid "xp1000"

--- a/po/lv.po
+++ b/po/lv.po
@@ -11631,7 +11631,7 @@ msgstr "ar uztvērēja nosaukumu"
 msgid "with_errors"
 msgstr "ar_kļūdām"
 
-msgid "working"
+msgid "testing"
 msgstr "darbojas"
 
 msgid "xp1000"

--- a/po/nb.po
+++ b/po/nb.po
@@ -12904,7 +12904,7 @@ msgid "with_errors"
 msgstr "med_feil"
 
 #
-msgid "working"
+msgid "testing"
 msgstr "arbeider"
 
 msgid "xp1000"

--- a/po/nl.po
+++ b/po/nl.po
@@ -11906,7 +11906,7 @@ msgstr "Met de tunernaam"
 msgid "with_errors"
 msgstr "met_fouten"
 
-msgid "working"
+msgid "testing"
 msgstr "bezig"
 
 msgid "xp1000"

--- a/po/nn.po
+++ b/po/nn.po
@@ -12818,7 +12818,7 @@ msgid "with_errors"
 msgstr ""
 
 #
-msgid "working"
+msgid "testing"
 msgstr "fungerer"
 
 msgid "xp1000"

--- a/po/pl.po
+++ b/po/pl.po
@@ -11614,7 +11614,7 @@ msgstr "Z nazwą tunera"
 msgid "with_errors"
 msgstr "z błędami"
 
-msgid "working"
+msgid "testing"
 msgstr "Pracuje"
 
 msgid "xp1000"

--- a/po/pt.po
+++ b/po/pt.po
@@ -13517,7 +13517,7 @@ msgid "with_errors"
 msgstr ""
 
 #
-msgid "working"
+msgid "testing"
 msgstr "em curso"
 
 msgid "xp1000"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -11721,7 +11721,7 @@ msgstr ""
 msgid "with_errors"
 msgstr ""
 
-msgid "working"
+msgid "testing"
 msgstr "trabalhando"
 
 msgid "xp1000"

--- a/po/ro.po
+++ b/po/ro.po
@@ -11902,7 +11902,7 @@ msgstr ""
 msgid "with_errors"
 msgstr ""
 
-msgid "working"
+msgid "testing"
 msgstr "lucreaza"
 
 msgid "xp1000"

--- a/po/ru.po
+++ b/po/ru.po
@@ -11611,7 +11611,7 @@ msgstr "с именем тюнера"
 msgid "with_errors"
 msgstr "с ошибками"
 
-msgid "working"
+msgid "testing"
 msgstr "в работе"
 
 msgid "xp1000"

--- a/po/sk.po
+++ b/po/sk.po
@@ -11630,7 +11630,7 @@ msgstr "s názvom tunera"
 msgid "with_errors"
 msgstr "s chybami"
 
-msgid "working"
+msgid "testing"
 msgstr "pracujem"
 
 msgid "xp1000"

--- a/po/sl.po
+++ b/po/sl.po
@@ -13450,7 +13450,7 @@ msgid "with_errors"
 msgstr ""
 
 #
-msgid "working"
+msgid "testing"
 msgstr "deluje"
 
 msgid "xp1000"

--- a/po/sr.po
+++ b/po/sr.po
@@ -13522,7 +13522,7 @@ msgid "with_errors"
 msgstr ""
 
 #
-msgid "working"
+msgid "testing"
 msgstr "U radu"
 
 msgid "xp1000"

--- a/po/sv.po
+++ b/po/sv.po
@@ -13254,7 +13254,7 @@ msgid "with_errors"
 msgstr "med_fel"
 
 #
-msgid "working"
+msgid "testing"
 msgstr "arbetar"
 
 msgid "xp1000"

--- a/po/th.po
+++ b/po/th.po
@@ -11957,7 +11957,7 @@ msgstr ""
 msgid "with_errors"
 msgstr ""
 
-msgid "working"
+msgid "testing"
 msgstr "กำลังทำงาน"
 
 msgid "xp1000"

--- a/po/tr.po
+++ b/po/tr.po
@@ -11776,7 +11776,7 @@ msgstr "Tuner adının yanında"
 msgid "with_errors"
 msgstr ""
 
-msgid "working"
+msgid "testing"
 msgstr "Çalışıyor"
 
 msgid "xp1000"

--- a/po/uk.po
+++ b/po/uk.po
@@ -11895,7 +11895,7 @@ msgstr "з назвою тюнера"
 msgid "with_errors"
 msgstr "з помилками"
 
-msgid "working"
+msgid "testing"
 msgstr "працюючий"
 
 msgid "xp1000"

--- a/po/vi.po
+++ b/po/vi.po
@@ -11586,7 +11586,7 @@ msgstr "với tên bộ chỉnh"
 msgid "with_errors"
 msgstr "có -nỗi"
 
-msgid "working"
+msgid "testing"
 msgstr "đang làm việc"
 
 msgid "xp1000"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -11595,7 +11595,7 @@ msgstr ""
 msgid "with_errors"
 msgstr ""
 
-msgid "working"
+msgid "testing"
 msgstr ""
 
 msgid "xp1000"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -11599,7 +11599,7 @@ msgstr ""
 msgid "with_errors"
 msgstr ""
 
-msgid "working"
+msgid "testing"
 msgstr ""
 
 msgid "xp1000"


### PR DESCRIPTION
This string is displayed while a diseqc command is tested, so it should be called "testing" and not "working". After the test is over, the string is changed to "successful" or "failed", thus it makes sense. All existing translations are kept as they are.

If you feel the meaning of the string is altered significantly, ask me to push another commit without keeping the translations.