### PR TITLE
[Setup.py] Restore fallback strings to previous values

### DIFF
--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -126,8 +126,8 @@ class Setup(ConfigListScreen, Screen):
 				if conditional and not eval(conditional):
 					continue
 
-				item_text = _(x.get("text", "unknown entry").encode("UTF-8"))
-				item_description = _(x.get("description", "unknown entry").encode("UTF-8"))
+				item_text = _(x.get("text", "??").encode("UTF-8"))
+				item_description = _(x.get("description", " ").encode("UTF-8")) # don't change
 				b = eval(x.text or "")
 				if b == "":
 					continue


### PR DESCRIPTION
This reverts commit https://github.com/OpenPLi/enigma2/commit/4d853c931badcca8d7851209c75db0a6dfe47e67

The "??" will never be displayed under normal circumstances, while it clearly indicates (to the average user) that someting is wrong.
The " " will be displayed when there's no description available, so it shouldn't be changed.