### PR TITLE
[SatelliteEquipmentControl] avoid hard coded values

### DIFF
--- a/lib/python/Plugins/SystemPlugins/SatelliteEquipmentControl/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/SatelliteEquipmentControl/plugin.py
@@ -12,19 +12,22 @@ class SecParameterSetup(Screen, ConfigListScreen):
 	def __init__(self, session):
 		Screen.__init__(self, session)
 		self.skinName = ["SecParameterSetup", "Setup"]
-		self.setTitle(_("Satellite equipment setup"))
+		self.setTitle(_("Satellite equipment control setup"))
 		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("OK"))
+		self["key_green"] = StaticText(_("Save and exit"))
+		self["key_blue"] = StaticText(_("Restore defaults"))
 
-		self["actions"] = ActionMap(["SetupActions", "MenuActions"],
+		self["actions"] = ActionMap(["SetupActions", "MenuActions", "ColorActions"],
 		{
 			"ok": self.keySave,
-			"save": self.keySave,
+			"green": self.keySave,
 			"cancel": self.keyCancel,
-			"menu": self.setDefault,
+			"red": self.keyCancel,
+			"blue": self.resetDefaults,
+			"menu": self.closeRecursive,
 		}, -2)
 
-		list = [
+		self.secList = [
 			(_("Delay after diseqc reset command"), config.sec.delay_after_diseqc_reset_cmd),
 			(_("Delay after diseqc peripherial poweron command"), config.sec.delay_after_diseqc_peripherial_poweron_cmd),
 			(_("Delay after continuous tone disable before diseqc"), config.sec.delay_after_continuous_tone_disable_before_diseqc),
@@ -46,50 +49,17 @@ class SecParameterSetup(Screen, ConfigListScreen):
 			(_("Unicable delay after enable voltage before switch command"), config.sec.unicable_delay_after_enable_voltage_before_switch_command),
 			(_("Unicable delay after change voltage before switch command"), config.sec.unicable_delay_after_change_voltage_before_switch_command),
 			(_("Unicable delay after last diseqc command"), config.sec.unicable_delay_after_last_diseqc_command) ]
-		ConfigListScreen.__init__(self, list)
+		ConfigListScreen.__init__(self, [])
+		self.createSetup()
 
-	def setDefault(self):
-		self.session.openWithCallback(self.setDefaultCallback, MessageBox, _("Set default settings?"), MessageBox.TYPE_YESNO)
+	def createSetup(self):
+		self["config"].list = self.secList
+		self["config"].l.setList(self.secList)
 
-	def setDefaultCallback(self, answer):
-		if answer:
-			config.sec.delay_after_diseqc_reset_cmd.value = 50
-			config.sec.delay_after_diseqc_peripherial_poweron_cmd.value = 150
-			config.sec.delay_after_continuous_tone_disable_before_diseqc.value = 25
-			config.sec.delay_after_final_continuous_tone_change.value = 10
-			config.sec.delay_after_final_voltage_change.value = 10
-			config.sec.delay_between_diseqc_repeats.value = 120
-			config.sec.delay_after_last_diseqc_command.value = 50
-			config.sec.delay_after_toneburst.value = 50
-			config.sec.delay_after_change_voltage_before_switch_command.value = 20
-			config.sec.delay_after_enable_voltage_before_switch_command.value = 200
-			config.sec.delay_between_switch_and_motor_command.value = 700
-			config.sec.delay_after_voltage_change_before_measure_idle_inputpower.value = 500
-			config.sec.delay_after_enable_voltage_before_motor_command.value = 900
-			config.sec.delay_after_motor_stop_command.value = 500
-			config.sec.delay_after_voltage_change_before_motor_command.value = 500
-			config.sec.delay_before_sequence_repeat.value = 70
-			config.sec.motor_running_timeout.value = 360
-			config.sec.motor_command_retries.value = 1
-			config.sec.delay_after_diseqc_reset_cmd.save()
-			config.sec.delay_after_diseqc_peripherial_poweron_cmd.save()
-			config.sec.delay_after_continuous_tone_disable_before_diseqc.save()
-			config.sec.delay_after_final_continuous_tone_change.save()
-			config.sec.delay_after_final_voltage_change.save()
-			config.sec.delay_between_diseqc_repeats.save()
-			config.sec.delay_after_last_diseqc_command.save()
-			config.sec.delay_after_toneburst.save()
-			config.sec.delay_after_change_voltage_before_switch_command.save()
-			config.sec.delay_after_enable_voltage_before_switch_command.save()
-			config.sec.delay_between_switch_and_motor_command.save()
-			config.sec.delay_after_voltage_change_before_measure_idle_inputpower.save()
-			config.sec.delay_after_enable_voltage_before_motor_command.save()
-			config.sec.delay_after_motor_stop_command.save()
-			config.sec.delay_after_voltage_change_before_motor_command.save()
-			config.sec.delay_before_sequence_repeat.save()
-			config.sec.motor_running_timeout.save()
-			config.sec.motor_command_retries.save()
-			self.close(True)
+	def resetDefaults(self):
+		for description, secItem in self.secList:
+			secItem.value = secItem.default
+		self.createSetup() # force new values to show
 
 session = None
 
@@ -118,7 +88,7 @@ def SecSetupStart(menuid):
 	return [ ]
 
 def Plugins(**kwargs):
-	if (nimmgr.hasNimType("DVB-S")):
+	if nimmgr.hasNimType("DVB-S"):
 		return PluginDescriptor(name=_("Satellite equipment setup"), description=_("Setup your satellite equipment"), where = PluginDescriptor.WHERE_MENU, needsRestart = False, fnc=SecSetupStart)
 	else:
 		return []


### PR DESCRIPTION
1) Remove hard coded values as these should come from "config.sec", not be stored in the plugin.

2) Remove duplicated list code (this cured a hidden bug).

3) Add "blue" button to restore sec values to their defaults found in NimManager. The "blue" button is used for restoring defaults in other screens so this maintains that known behaviour.

4) Add a "createSetup" so a screen redraw can be forced.

5) Remove weird spaghetti code when exiting the plugin by "menu" button and return to previous simple code. This now means restoring defaults is not a hidden function that users have to find by accident.

6) Use the correct plugin name in the screen title.

7) Remove unnecessary parenthesis.