### PR TITLE
[skin.py] Improve fix for display and default skins

### DIFF
--- a/skin.py
+++ b/skin.py
@@ -15,7 +15,7 @@ from Tools.LoadPixmap import LoadPixmap
 
 DEFAULT_SKIN = SystemInfo["HasFullHDSkinSupport"] and "PLi-FullNightHD/skin.xml" or "PLi-HD/skin.xml"  # On SD hardware PLi-HD will not be available.
 DEFAULT_SD_SKIN = "Magic/skin.xml"
-EMERGENCY_SKIN = "skin.xml"
+EMERGENCY_SKIN = "/usr/share/enigma2/skin.xml"
 DEFAULT_DISPLAY_SKIN = "skin_display.xml"
 USER_SKIN = "skin_user.xml"
 USER_SKIN_TEMPLATE = "skin_user_%s.xml"
@@ -162,6 +162,7 @@ for skin, name in [(config.skin.primary_skin.value, "current"), (DEFAULT_SKIN, "
 # to enable basic GUI functions to work.
 if config.skin.primary_skin.value != EMERGENCY_SKIN:
 	addSkin(EMERGENCY_SKIN, scope=SCOPE_CURRENT_SKIN)
+	addSkin("skin_default.xml", scope=SCOPE_CURRENT_SKIN)
 
 # Remove global working variables.
 del skin
@@ -882,7 +883,7 @@ def loadSkin(filename, scope=SCOPE_SKIN):
 								elem.clear()
 								continue
 							if name in domScreens:
-								print "loadSkin: Screen already defined elsewhere:", name
+								print "[Skin] Warning: Screen '%s' already defined!  Using first definition." % name
 								elem.clear()
 							else:
 								domScreens[name] = (elem, path)


### PR DESCRIPTION
- This change further improves the temporary fix that caused display skins to not be loaded correctly.
- Add the "skin_default.xml" skin that was previously omitted (accidentally).
- Improve the error log message for duplicate screens.
