### PR TITLE
Update empty timer description with EPG info

### DIFF
--- a/lib/python/Screens/TimerEdit.py
+++ b/lib/python/Screens/TimerEdit.py
@@ -173,6 +173,7 @@ class TimerEditList(Screen):
 						text = _("Timer:") + " " + text + "\n\n" + _("EPG:") + " " + short_description
 					elif short_description:
 						text = short_description
+						cur.description = short_description
 				if ext_description and ext_description != text:
 					if text:
 						text += "\n\n" + ext_description


### PR DESCRIPTION
A good proposal of Dimitrij in the forum:
https://forums.openpli.org/topic/73197-timer-overview-please-add-full-description/page-3#entry1147837

If the timer description is empty during user check then update the timer description with actual EPG information. 
That makes sense, because we show the short description from the EPG like it was already included in the timer but the actual timer description is empty.