### PR TITLE
Apply more skin fixes

### DIFF
--- a/skin.py
+++ b/skin.py
@@ -385,10 +385,10 @@ class AttributeParser:
 		else:
 			self.guiObject.resize(parseSize(value, self.scaleTuple, self.guiObject, self.desktop))
 
-# OpenPLi is missing the C++ code to support these animation methods.
-#
-# 	def animationPaused(self, value):
-# 		pass
+	def animationPaused(self, value):
+		pass
+
+# OpenPLi is missing the C++ code to support this animation method.
 #
 # 	def animationMode(self, value):
 # 		try:

--- a/skin.py
+++ b/skin.py
@@ -460,7 +460,8 @@ class AttributeParser:
 			print "[Skin] Error: Invalid alphatest '%s'!  Must be one of 'on', 'off' or 'blend'." % value
 
 	def scale(self, value):
-		self.guiObject.setScale(1)
+		value = 1 if value.lower() in ("1", "enabled", "on", "scale", "true", "yes") else 0
+		self.guiObject.setScale(value)
 
 	def orientation(self, value):  # used by eSlider
 		try:
@@ -578,7 +579,8 @@ class AttributeParser:
 			print "[Skin] Error: Invalid scrollbarMode '%s'!  Must be one of 'showOnDemand', 'showAlways', 'showNever' or 'showLeft'." % value
 
 	def enableWrapAround(self, value):
-		self.guiObject.setWrapAround(True)
+		value = True if value.lower() in ("1", "enabled", "enablewraparound", "on", "true", "yes") else False
+		self.guiObject.setWrapAround(value)
 
 	def itemHeight(self, value):
 		self.guiObject.setItemHeight(int(value))
@@ -599,7 +601,8 @@ class AttributeParser:
 		self.guiObject.setShadowOffset(parsePosition(value, self.scaleTuple))
 
 	def noWrap(self, value):
-		self.guiObject.setNoWrap(1)
+		value = 1 if value.lower() in ("1", "enabled", "nowrap", "on", "true", "yes") else 0
+		self.guiObject.setNoWrap(value)
 
 def applySingleAttribute(guiObject, desktop, attrib, value, scale=((1, 1), (1, 1))):
 	# Is anyone still using applySingleAttribute?


### PR DESCRIPTION
- [skin.py] Add the animationPaused() method

  The "animationPaused()" method can be added to OpenPLi as this method does nothing.  Allowing this attribute makes more skins compatible with OpenPLi.

- [skin.py] Fix a few hard coded skin attributes

  Change the "scale", "enableWrapAround" and "noWrap" skin tag attributes so that skin provided values are no longer ignored and replaced with hardcoded default values.  Some validation is done of the attribute values.  The old values "0" and "1" are still valid.  Skinners can now also use case insensitive "Yes", "Enabled", "On", "True", "Yes" and the attribute name as alternate values to indicate that the attribute is being asserted.  Any other values will be considered that the attribute is being negated.
