### PR TITLE
Introduce SCOPE_LIBDIR and get rid of hard-coded /usr/lib/ for multilib

### DIFF
--- a/lib/python/Components/About.py
+++ b/lib/python/Components/About.py
@@ -2,6 +2,7 @@
 import sys, os, time
 import re
 from Tools.HardwareInfo import HardwareInfo
+from Tools.Directories import resolveFilename, SCOPE_LIBDIR
 
 def getVersionString():
 	return getImageVersionString()
@@ -11,7 +12,7 @@ def getImageVersionString():
 		if os.path.isfile('/var/lib/opkg/status'):
 			st = os.stat('/var/lib/opkg/status')
 		else:
-			st = os.stat('/usr/lib/ipkg/status')
+			st = os.stat(resolveFilename(SCOPE_LIBDIR, 'ipkg/status'))
 		tm = time.localtime(st.st_mtime)
 		if tm.tm_year >= 2011:
 			return time.strftime("%Y-%m-%d %H:%M:%S", tm)

--- a/lib/python/Components/Ipkg.py
+++ b/lib/python/Components/Ipkg.py
@@ -1,6 +1,7 @@
 import os
 from enigma import eConsoleAppContainer
 from Components.Harddisk import harddiskmanager
+from Tools.Directories import resolveFilename, SCOPE_LIBDIR
 
 opkgDestinations = []
 opkgStatusPath = ''
@@ -26,7 +27,7 @@ def onPartitionChange(why, part):
 				opkgStatusPath = 'var/lib/opkg/status'
 				if not os.path.exists(os.path.join('/', opkgStatusPath)):
 					# older opkg versions
-					opkgStatusPath = 'usr/lib/opkg/status'
+					opkgStatusPath = resolveFilename(SCOPE_LIBDIR, 'opkg/status')
 			if os.path.exists(os.path.join(mountpoint, opkgStatusPath)):
 				opkgAddDestination(mountpoint)
 		elif why == 'remove':

--- a/lib/python/Plugins/Extensions/TuxboxPlugins/plugin.py
+++ b/lib/python/Plugins/Extensions/TuxboxPlugins/plugin.py
@@ -1,12 +1,12 @@
 # must be fixed for the new plugin interface
 from Tools.BoundFunction import boundFunction
-from Tools.Directories import pathExists
+from Tools.Directories import pathExists, resolveFilename, SCOPE_LIBDIR
 from Plugins.Plugin import PluginDescriptor
 from pluginrunner import PluginRunner
 
 from os import listdir
 
-TUXBOX_PLUGINS_PATH = "/usr/lib/tuxbox/plugins/"
+TUXBOX_PLUGINS_PATH = resolveFilename(SCOPE_LIBDIR, "tuxbox/plugins/")
 
 def getPlugins():
 	pluginlist = []

--- a/lib/python/Tools/Directories.py
+++ b/lib/python/Tools/Directories.py
@@ -37,6 +37,7 @@ SCOPE_AUTORECORD = 22
 SCOPE_DEFAULTDIR = 23
 SCOPE_DEFAULTPARTITION = 24
 SCOPE_DEFAULTPARTITIONMOUNTDIR = 25
+SCOPE_LIBDIR = 26
 
 PATH_CREATE = 0
 PATH_DONTCREATE = 1
@@ -52,6 +53,7 @@ defaultPaths = {
 	SCOPE_LANGUAGE: (eEnv.resolve("${datadir}/enigma2/po/"), PATH_DONTCREATE),
 	SCOPE_HDD: ("/media/hdd/movie/", PATH_DONTCREATE),
 	SCOPE_PLUGINS: (eEnv.resolve("${libdir}/enigma2/python/Plugins/"), PATH_CREATE),
+	SCOPE_LIBDIR: (eEnv.resolve("${libdir}/"), PATH_DONTCREATE),
 	SCOPE_MEDIA: ("/media/", PATH_DONTCREATE),
 	SCOPE_PLAYLIST: (eEnv.resolve("${sysconfdir}/enigma2/playlist/"), PATH_CREATE),
 	SCOPE_CURRENT_SKIN: (eEnv.resolve("${datadir}/enigma2/"), PATH_DONTCREATE),


### PR DESCRIPTION
Examples:

https://github.com/OpenVisionE2/enigma2-plugins/commit/a7de14c03fd0f454f19db62cc2c8cfa12bab68f8
https://github.com/OpenVisionE2/alliance-plugins/commit/3af73508c84eaec647dfed5cce7f6cafb2ca1008
https://github.com/OpenVisionE2/2boom-plugins/commit/7987c8af57ada126fba7a9e812740cb1b10e64c6
https://github.com/OpenVisionE2/BackupSuite/commit/df4b6d9af901a2d0785f3958bf5ab9b5addff8e4

skin and xml related examples:

https://github.com/OpenVisionE2/BackupSuite/commit/0fb3dead77596627e2a6e75b6fcc17c24babddcb
https://github.com/OpenVisionE2/NewVirtualKeyBoard/commit/889888270e57f2ac5552cf97aa2ff564069062b3