### PR TITLE
Directories.py: Get rid of deprecated scope functions.

### DIFF
--- a/lib/python/Tools/Directories.py
+++ b/lib/python/Tools/Directories.py
@@ -14,30 +14,29 @@ SCOPE_TRANSPONDERDATA = 0
 SCOPE_SYSETC = 1
 SCOPE_FONTS = 2
 SCOPE_SKIN = 3
-SCOPE_SKIN_IMAGE = 4  # DEBUG: How is this different from SCOPE_SKIN?
-SCOPE_USERETC = 5  # DEBUG: Not used in Enigma2.
-SCOPE_CONFIG = 6
-SCOPE_LANGUAGE = 7
-SCOPE_HDD = 8
-SCOPE_PLUGINS = 9
-SCOPE_MEDIA = 10
-SCOPE_PLAYLIST = 11
-SCOPE_CURRENT_SKIN = 12
-SCOPE_CURRENT_PLUGIN_ABSOLUTE = 13
-SCOPE_CURRENT_PLUGIN_RELATIVE = 14
-SCOPE_KEYMAPS = 15
-SCOPE_METADIR = 16
-SCOPE_CURRENT_PLUGIN = 17
-SCOPE_TIMESHIFT = 18
-SCOPE_ACTIVE_SKIN = 19  # DEBUG: Deprecated scope function - use SCOPE_CURRENT_SKIN instead.
-SCOPE_LCDSKIN = 20
-SCOPE_CURRENT_LCDSKIN = 21
-SCOPE_ACTIVE_LCDSKIN = 21  # DEBUG: Deprecated scope function name - use SCOPE_CURRENT_LCDSKIN instead.
-SCOPE_AUTORECORD = 22
-SCOPE_DEFAULTDIR = 23
-SCOPE_DEFAULTPARTITION = 24
-SCOPE_DEFAULTPARTITIONMOUNTDIR = 25
-SCOPE_LIBDIR = 26
+SCOPE_USERETC = 4  # DEBUG: Not used in Enigma2.
+SCOPE_CONFIG = 5
+SCOPE_LANGUAGE = 6
+SCOPE_HDD = 7
+SCOPE_PLUGINS = 8
+SCOPE_MEDIA = 9
+SCOPE_PLAYLIST = 10
+# SCOPE_SKIN_IMAGE and SCOPE_ACTIVE_SKIN are deprecated scope functions - use SCOPE_CURRENT_SKIN instead.
+SCOPE_SKIN_IMAGE = SCOPE_ACTIVE_SKIN = SCOPE_CURRENT_SKIN = 11
+SCOPE_CURRENT_PLUGIN_ABSOLUTE = 12
+SCOPE_CURRENT_PLUGIN_RELATIVE = 13
+SCOPE_KEYMAPS = 14
+SCOPE_METADIR = 15
+SCOPE_CURRENT_PLUGIN = 16
+SCOPE_TIMESHIFT = 17
+SCOPE_LCDSKIN = 18
+# SCOPE_ACTIVE_LCDSKIN is a deprecated scope function name - use SCOPE_CURRENT_LCDSKIN instead.
+SCOPE_ACTIVE_LCDSKIN = SCOPE_CURRENT_LCDSKIN = 19
+SCOPE_AUTORECORD = 20
+SCOPE_DEFAULTDIR = 21
+SCOPE_DEFAULTPARTITION = 22
+SCOPE_DEFAULTPARTITIONMOUNTDIR = 23
+SCOPE_LIBDIR = 24
 
 PATH_CREATE = 0
 PATH_DONTCREATE = 1
@@ -47,29 +46,27 @@ defaultPaths = {
 	SCOPE_SYSETC: (eEnv.resolve("${sysconfdir}/"), PATH_DONTCREATE),
 	SCOPE_FONTS: (eEnv.resolve("${datadir}/fonts/"), PATH_DONTCREATE),
 	SCOPE_SKIN: (eEnv.resolve("${datadir}/enigma2/"), PATH_DONTCREATE),
-	SCOPE_SKIN_IMAGE: (eEnv.resolve("${datadir}/enigma2/"), PATH_DONTCREATE),
 	SCOPE_USERETC: ("", PATH_DONTCREATE),  # User home directory
 	SCOPE_CONFIG: (eEnv.resolve("${sysconfdir}/enigma2/"), PATH_CREATE),
 	SCOPE_LANGUAGE: (eEnv.resolve("${datadir}/enigma2/po/"), PATH_DONTCREATE),
 	SCOPE_HDD: ("/media/hdd/movie/", PATH_DONTCREATE),
 	SCOPE_PLUGINS: (eEnv.resolve("${libdir}/enigma2/python/Plugins/"), PATH_CREATE),
-	SCOPE_LIBDIR: (eEnv.resolve("${libdir}/"), PATH_DONTCREATE),
 	SCOPE_MEDIA: ("/media/", PATH_DONTCREATE),
 	SCOPE_PLAYLIST: (eEnv.resolve("${sysconfdir}/enigma2/playlist/"), PATH_CREATE),
 	SCOPE_CURRENT_SKIN: (eEnv.resolve("${datadir}/enigma2/"), PATH_DONTCREATE),
+	SCOPE_CURRENT_PLUGIN_ABSOLUTE: (eEnv.resolve("${libdir}/enigma2/python/Plugins/"), PATH_DONTCREATE),
+	SCOPE_CURRENT_PLUGIN_RELATIVE: (eEnv.resolve("${libdir}/enigma2/python/Plugins/"), PATH_DONTCREATE),
 	SCOPE_KEYMAPS: (eEnv.resolve("${datadir}/keymaps/"), PATH_CREATE),
 	SCOPE_METADIR: (eEnv.resolve("${datadir}/meta"), PATH_CREATE),
 	SCOPE_CURRENT_PLUGIN: (eEnv.resolve("${libdir}/enigma2/python/Plugins/"), PATH_CREATE),
 	SCOPE_TIMESHIFT: ("/media/hdd/timeshift/", PATH_DONTCREATE),
-	SCOPE_ACTIVE_SKIN: (eEnv.resolve("${datadir}/enigma2/"), PATH_DONTCREATE),
 	SCOPE_LCDSKIN: (eEnv.resolve("${datadir}/enigma2/display/"), PATH_DONTCREATE),
 	SCOPE_CURRENT_LCDSKIN: ("${datadir}/enigma2/display/", PATH_DONTCREATE),
 	SCOPE_AUTORECORD: ("/media/hdd/movie/", PATH_DONTCREATE),
 	SCOPE_DEFAULTDIR: (eEnv.resolve("${datadir}/enigma2/defaults/"), PATH_CREATE),
 	SCOPE_DEFAULTPARTITION: ("/dev/mtdblock6", PATH_DONTCREATE),
 	SCOPE_DEFAULTPARTITIONMOUNTDIR: (eEnv.resolve("${datadir}/enigma2/dealer"), PATH_CREATE),
-	SCOPE_CURRENT_PLUGIN_ABSOLUTE: (eEnv.resolve("${libdir}/enigma2/python/Plugins/"), PATH_DONTCREATE),
-	SCOPE_CURRENT_PLUGIN_RELATIVE: (eEnv.resolve("${libdir}/enigma2/python/Plugins/"), PATH_DONTCREATE)
+	SCOPE_LIBDIR: (eEnv.resolve("${libdir}/"), PATH_DONTCREATE)
 }
 
 def resolveFilename(scope, base="", path_prefix=None):
@@ -105,8 +102,8 @@ def resolveFilename(scope, base="", path_prefix=None):
 	# If base is "" then set path to the scope.  Otherwise use the scope to resolve the base filename.
 	if base is "":
 		path, flags = defaultPaths.get(scope)
-		# If the scope is SCOPE_CURRENT_SKIN or SCOPE_ACTIVE_SKIN append the current skin to the scope path.
-		if scope in (SCOPE_CURRENT_SKIN, SCOPE_ACTIVE_SKIN):
+		# If the scope is SCOPE_CURRENT_SKIN append the current skin to the scope path.
+		if scope == SCOPE_CURRENT_SKIN:
 			# This import must be here as this module finds the config file as part of the config initialisation.
 			from Components.config import config
 			skin = os.path.dirname(config.skin.primary_skin.value)
@@ -120,7 +117,7 @@ def resolveFilename(scope, base="", path_prefix=None):
 				if len(pluginCode) > 2:
 					relative = "%s%s%s" % (pluginCode[0], os.sep, pluginCode[1])
 					path = os.path.join(plugins, relative)
-	elif scope in (SCOPE_CURRENT_SKIN, SCOPE_ACTIVE_SKIN):
+	elif scope == SCOPE_CURRENT_SKIN:
 		# This import must be here as this module finds the config file as part of the config initialisation.
 		from Components.config import config
 		skin = os.path.dirname(config.skin.primary_skin.value)


### PR DESCRIPTION
for SCOPE_SKIN_IMAGE use SCOPE_CURRENT_SKIN instead.
for SCOPE_ACTIVE_SKIN use SCOPE_CURRENT_SKIN instead.
for SCOPE_ACTIVE_LCDSKIN use SCOPE_CURRENT_LCDSKIN instead.

With this method all the old things work normally as it's backward-compatible but at least we won't have duplicates and check them again and again.

Also I did sort things again.