### PR TITLE
Fixed "LcdSkinSelector" for 3rd party skins

### DIFF
--- a/lib/python/Screens/SkinSelector.py
+++ b/lib/python/Screens/SkinSelector.py
@@ -261,6 +261,7 @@ class SkinSelector(Screen, HelpableScreen):
 class LcdSkinSelector(SkinSelector):
 	def __init__(self, session, screenTitle=_("Display Skin")):
 		SkinSelector.__init__(self, session, screenTitle=screenTitle)
+		self.skinName = ["LcdSkinSelector", "SkinSelector"]
 		self.rootDir = resolveFilename(SCOPE_LCDSKIN)
 		self.config = config.skin.display_skin
 		self.current = currentDisplaySkin


### PR DESCRIPTION
If a skin defines only the "SkinSelector" skin, enigma2 crashes when opening the "Lcd Skin" screen.