### PR TITLE
Reworked some strings

### DIFF
--- a/RecordTimer.py
+++ b/RecordTimer.py
@@ -445,7 +445,7 @@ class RecordTimerEntry(timer.TimerEntry, object):
 								self.InfoBarInstance.session.pip.servicePath = self.InfoBarInstance.servicelist and self.InfoBarInstance.servicelist.getCurrentServicePath()
 								self.log(11, "zapping as PiP")
 								if notify:
-									Notifications.AddPopup(text=_("Zapped to timer service %s as PiP!") % self.service_ref.getServiceName(), type=MessageBox.TYPE_INFO, timeout=5)
+									Notifications.AddPopup(text=_("Zapped to timer service %s as Picture in Picture!") % self.service_ref.getServiceName(), type=MessageBox.TYPE_INFO, timeout=5)
 								return True
 							else:
 								del self.InfoBarInstance.session.pip

--- a/data/setup.xml
+++ b/data/setup.xml
@@ -84,9 +84,9 @@
 		<item level="2" text="Show picons in display" description="Configure if service picons will be shown in display (when supported by the skin)." requires="HasFrontDisplayPicon">config.usage.show_picon_in_display</item>
 		<item level="2" text="Infobar frontend data source" description="Configure the source of the frontend data as shown on the infobars. 'Settings' is as stored on the settings. 'Tuner' is as reported by the tuner.">config.usage.infobar_frontend_source</item>
 		<item level="2" text="Show SNR percentage instead of dB value" description="By default, SNR will be shown in dB (when supported by the tuner). This setting forces SNR to be shown as a percentage instead.">config.usage.swap_snr_on_osd</item>
-		<item level="2" text="Behavior of 0 key in PiP-mode" description="Configure the function of the '0' button do when PIP is active." requires="PIPAvailable">config.usage.pip_zero_button</item>
-		<item level="2" text="Close PiP on exit" description="When enabled the PiP can be closed by the exit button." requires="PIPAvailable">config.usage.pip_hideOnExit</item>
-		<item level="2" text="Remember last service in PiP" description="Configure if and how long the latest service in the PiP will be remembered." requires="PIPAvailable">config.usage.pip_last_service_timeout</item>
+		<item level="2" text="Behavior of '0' button in PiP mode" description="Configure the function of the '0' button when Picture in Picture is active." requires="PIPAvailable">config.usage.pip_zero_button</item>
+		<item level="2" text="Close PiP with 'exit' button" description="When enabled the Picture in Picture window can be closed with 'exit' button." requires="PIPAvailable">config.usage.pip_hideOnExit</item>
+		<item level="2" text="Remember last service in PiP" description="Configure if and how long the latest service in Picture in Picture mode will be remembered." requires="PIPAvailable">config.usage.pip_last_service_timeout</item>
 		<item level="2" text="Show VCR scart on main menu" description="When enabled, the VCR scart option will be shown on the main menu" requires="ScartSwitch">config.usage.show_vcr_scart</item>
 		<item level="2" text="Show True/False as graphical switch" description="Enable to display all true/false, yes/no, on/off and enable/disable set up options as a graphical switch.">config.usage.boolean_graphic</item>
 	</setup>

--- a/lib/python/Screens/Hotkey.py
+++ b/lib/python/Screens/Hotkey.py
@@ -173,10 +173,10 @@ def getHotkeyFunctions():
 	hotkey.functions.append((_("Toggle infoBar"), "Infobar/toggleShow", "InfoBar"))
 	hotkey.functions.append((_("Letterbox zoom"), "Infobar/vmodeSelection", "InfoBar"))
 	if SystemInfo["PIPAvailable"]:
-		hotkey.functions.append((_("Show PIP"), "Infobar/showPiP", "InfoBar"))
-		hotkey.functions.append((_("Swap PIP"), "Infobar/swapPiP", "InfoBar"))
-		hotkey.functions.append((_("Move PIP"), "Infobar/movePiP", "InfoBar"))
-		hotkey.functions.append((_("Toggle PIPzap"), "Infobar/togglePipzap", "InfoBar"))
+		hotkey.functions.append((_("Show PiP"), "Infobar/showPiP", "InfoBar"))
+		hotkey.functions.append((_("Swap PiP"), "Infobar/swapPiP", "InfoBar"))
+		hotkey.functions.append((_("Move PiP"), "Infobar/movePiP", "InfoBar"))
+		hotkey.functions.append((_("Toggle PiPzap"), "Infobar/togglePipzap", "InfoBar"))
 	hotkey.functions.append((_("Activate HbbTV (Redbutton)"), "Infobar/activateRedButton", "InfoBar"))
 	hotkey.functions.append((_("Toggle HDMI In"), "Infobar/HDMIIn", "InfoBar"))
 	if SystemInfo["LcdLiveTV"]:

--- a/lib/python/Screens/PictureInPicture.py
+++ b/lib/python/Screens/PictureInPicture.py
@@ -210,7 +210,7 @@ class PictureInPicture(Screen):
 				self.currentService = None
 				self.currentServiceReference = None
 				if not config.usage.hide_zap_errors.value:
-					Notifications.AddPopup(text = _("Incorrect type service for PiP!"), type = MessageBox.TYPE_ERROR, timeout = 5, id = "ZapPipError")
+					Notifications.AddPopup(text = _("Incorrect service type for Picture in Picture!"), type = MessageBox.TYPE_ERROR, timeout = 5, id = "ZapPipError")
 		return False
 
 	def getCurrentService(self):

--- a/po/ar.po
+++ b/po/ar.po
@@ -1480,7 +1480,7 @@ msgstr "وقت البدأ"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr ""
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "سلوك الذر 0 فى وضعية صوره داخل صوره"
 
 #
@@ -1963,7 +1963,7 @@ msgstr ""
 msgid "Close"
 msgstr "أغلاق"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr ""
 
 msgid "Close title selection"
@@ -2097,7 +2097,7 @@ msgstr ""
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr ""
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr ""
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2208,7 +2208,7 @@ msgstr ""
 msgid "Configure the fourth subtitle language."
 msgstr "تكوين لغة الترجمة الرابعة."
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr ""
 
 #, fuzzy
@@ -2939,7 +2939,7 @@ msgstr "تعطيل"
 
 #
 msgid "Disable Picture in Picture"
-msgstr "تعطيل PIP"
+msgstr "تعطيل PiP"
 
 msgid "Disable background scanning"
 msgstr ""
@@ -4623,7 +4623,7 @@ msgstr ""
 msgid "Include EIT in http streams"
 msgstr ""
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr ""
 
 #
@@ -5457,7 +5457,7 @@ msgstr ""
 msgid "Move"
 msgstr ""
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr ""
 
 #, fuzzy
@@ -8401,7 +8401,7 @@ msgstr ""
 msgid "Show InfoBar"
 msgstr ""
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr ""
 
 msgid "Show SNR percentage instead of dB value"
@@ -9081,7 +9081,7 @@ msgid "Stop"
 msgstr "إيقاف"
 
 msgid "Stop PiP"
-msgstr "إيقاف PIP"
+msgstr "إيقاف PiP"
 
 msgid "Stop all current recordings"
 msgstr ""
@@ -9271,7 +9271,7 @@ msgstr "بخث عن القنوات"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr ""
 
 #, fuzzy
@@ -10033,7 +10033,7 @@ msgstr ""
 msgid "Toggle LCD LiveTV"
 msgstr ""
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr ""
 
 msgid "Toggle TV/RADIO mode"
@@ -10907,7 +10907,7 @@ msgstr "أي نوع من بحث القنوات تريد؟"
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "عند تمكينه. enigma2 ستقوم بتحميل userbouquets غير مرتبطة. وهذا يعني أنه لا يزال سيتم تحميل userbouquets التي تتوفر ، ولكن لم يتم تضمينها في bouquets.tv أو ملفات bouquets.radio. يتيح لك هذا على سبيل المثال الاحتفاظ بباقة المستخدم الخاصة بك بينما تتم ترقية الإعدادات المثبتة"
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr ""
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -11460,7 +11460,7 @@ msgid "Zap up"
 msgstr ""
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #, fuzzy, python-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -1376,7 +1376,7 @@ msgstr "Начало време"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr "Действие на 'пауза и ок' по време на пауза"
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Действие на бутон 0 в режим PiP"
 
 msgid "Behavior when a movie is started"
@@ -1831,7 +1831,7 @@ msgstr "Клониране ТВ екрана на LCD режим"
 msgid "Close"
 msgstr "Затваряне"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Затвори PiP при изход"
 
 msgid "Close title selection"
@@ -1964,7 +1964,7 @@ msgstr "Настройка режим на работа на вентилато�
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Настройка за показване на иконите за кодираните услуги в списъка за избор на канали."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Настройка - запомняне и за какъв период от време на последния канал PiP."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2072,8 +2072,8 @@ msgstr "Настройка на четвъртия аудио език."
 msgid "Configure the fourth subtitle language."
 msgstr "Настройка на четвъртия език за субтитри."
 
-msgid "Configure the function of the '0' button do when PIP is active."
-msgstr "Настройка на действието на бутон '0' когато PIP е активиран."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
+msgstr "Настройка на действието на бутон '0' когато PiP е активиран."
 
 msgid "Configure the gateway."
 msgstr "Настройка на шлюз."
@@ -4408,7 +4408,7 @@ msgstr "Включи ECM в http стриймове"
 msgid "Include EIT in http streams"
 msgstr "Включи EIT в http стриймове"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Некоректен тип канал за PiP!"
 
 msgid "Increased voltage"
@@ -5139,7 +5139,7 @@ msgstr "Монтиране"
 msgid "Move"
 msgstr "Преместване"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr "Преместване PiP"
 
 msgid "Move PiP to main picture"
@@ -7880,7 +7880,7 @@ msgstr "Показвай игрови шоута"
 msgid "Show InfoBar"
 msgstr "Показвай Инфо-лента"
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr "Покажи PiP"
 
 msgid "Show SNR percentage instead of dB value"
@@ -8676,7 +8676,7 @@ msgstr "Суринам"
 msgid "Svalbard and Jan Mayen"
 msgstr "Свалбард и Жан Маен"
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr "Размени PiP"
 
 msgid "Swap PiP and main picture"
@@ -9386,7 +9386,7 @@ msgstr "Включи HDMI In"
 msgid "Toggle LCD LiveTV"
 msgstr "Включи LCD LiveTV"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr "Превключи Pipzap"
 
 msgid "Toggle TV/RADIO mode"
@@ -10206,7 +10206,7 @@ msgstr "Какъв тип на търсене искате да изберете
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Ако е включено, при старт на енигма2 ще бъдат заредени достъпни букети, които на са включени в списъка bouquets.tv или bouquets.radio. Това Ви позволява например да запазите Вашите букети при актуализация на настройките"
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Ако е включено, PiP може да се затвори с бутона изход."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10749,7 +10749,7 @@ msgid "Zap up"
 msgstr "Превключване канал нагоре"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr "Таймер - превключих на канал %s като PiP!"
 
 #, python-format

--- a/po/ca.po
+++ b/po/ca.po
@@ -1523,7 +1523,7 @@ msgid "Behavior of 'pause and ok' when paused"
 msgstr ""
 
 #
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr ""
 
 #
@@ -2036,7 +2036,7 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr ""
 
 #
@@ -2199,7 +2199,7 @@ msgstr ""
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr ""
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr ""
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2311,7 +2311,7 @@ msgstr ""
 msgid "Configure the fourth subtitle language."
 msgstr ""
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr ""
 
 msgid "Configure the gateway."
@@ -4890,7 +4890,7 @@ msgstr ""
 msgid "Include EIT in http streams"
 msgstr ""
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr ""
 
 #
@@ -5753,7 +5753,7 @@ msgstr ""
 msgid "Move"
 msgstr ""
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr ""
 
 #
@@ -8934,7 +8934,7 @@ msgstr ""
 msgid "Show InfoBar"
 msgstr ""
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr ""
 
 msgid "Show SNR percentage instead of dB value"
@@ -9838,7 +9838,7 @@ msgstr "Recerca de canal"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr ""
 
 msgid "Swap PiP and main picture"
@@ -10573,7 +10573,7 @@ msgstr ""
 msgid "Toggle LCD LiveTV"
 msgstr ""
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr ""
 
 msgid "Toggle TV/RADIO mode"
@@ -11495,7 +11495,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr ""
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -12043,7 +12043,7 @@ msgid "Zap up"
 msgstr ""
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #

--- a/po/cs.po
+++ b/po/cs.po
@@ -1574,7 +1574,7 @@ msgid "Behavior of 'pause and ok' when paused"
 msgstr "Chování 'pauza a ok' při pozastavení"
 
 #
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Funkce tlačítka 0 v PiP módu"
 
 #
@@ -2093,8 +2093,8 @@ msgstr "Klonovat TV obrazovku na LCD"
 msgid "Close"
 msgstr "Zavřít"
 
-msgid "Close PiP on exit"
-msgstr "Zavřít PIP při ukončení"
+msgid "Close PiP with 'exit' button"
+msgstr "Zavřít PiP při ukončení"
 
 #
 msgid "Close title selection"
@@ -2242,8 +2242,8 @@ msgstr "Nastavuje režim práce ventilátoru."
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Nastavuje zda a jak budou zobrazovány ikony kódovaných programů v přehledech kanálů."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
-msgstr "Nastavuje zda a jak dlouho bude zapamatován poslední program v PIP."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
+msgstr "Nastavuje zda a jak dlouho bude zapamatován poslední program v PiP."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
 msgstr "Nastavuje zda a jak budou zobrazovány ikony typu programu v seznamu kanálů."
@@ -2363,8 +2363,8 @@ msgstr "Nastavuje čtvrtý jazyk zvuku."
 msgid "Configure the fourth subtitle language."
 msgstr "Nastavuje čtvrtý jazyk titulků."
 
-msgid "Configure the function of the '0' button do when PIP is active."
-msgstr "Nastavuje funkci tlačítka '0' při aktivním PIP."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
+msgstr "Nastavuje funkci tlačítka '0' při aktivním PiP."
 
 #
 msgid "Configure the gateway."
@@ -2588,7 +2588,7 @@ msgid "Connected to"
 msgstr "Připojeno k"
 
 msgid "Connected transcoding, limit - no PiP!"
-msgstr "Připojené překódování, omezení - bez PIP!"
+msgstr "Připojené překódování, omezení - bez PiP!"
 
 msgid "Console"
 msgstr "Console"
@@ -4987,7 +4987,7 @@ msgstr "Včetně ECM v http streamech"
 msgid "Include EIT in http streams"
 msgstr "Včetně EIT v http streamech"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Nekorektní typ služby pro PiP!"
 
 #
@@ -5844,12 +5844,12 @@ msgstr "Připojit"
 msgid "Move"
 msgstr "Přesunout"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr "Posunout PiP"
 
 #
 msgid "Move PiP to main picture"
-msgstr "Přesunout PIP do hlavního okna"
+msgstr "Přesunout PiP do hlavního okna"
 
 #
 msgid "Move Picture in Picture"
@@ -9005,7 +9005,7 @@ msgstr "zábava"
 msgid "Show InfoBar"
 msgstr "Zobrazit infobar"
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr "Zobrazit PiP"
 
 msgid "Show SNR percentage instead of dB value"
@@ -9727,7 +9727,7 @@ msgstr "Zastavit"
 
 #
 msgid "Stop PiP"
-msgstr "Ukončit PIP"
+msgstr "Ukončit PiP"
 
 msgid "Stop all current recordings"
 msgstr "Ukončit všechna nahrávání"
@@ -9924,12 +9924,12 @@ msgstr "Surinam"
 msgid "Svalbard and Jan Mayen"
 msgstr "Špicberky a Jan Mayen"
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr "Prohodit PiP"
 
 #
 msgid "Swap PiP and main picture"
-msgstr "Zaměnit PIP a hlavní obraz"
+msgstr "Zaměnit PiP a hlavní obraz"
 
 #
 msgid "Swap services"
@@ -10711,7 +10711,7 @@ msgstr "Přepnout HDMI vstup"
 msgid "Toggle LCD LiveTV"
 msgstr "Přepínat LCD LiveTV"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr "Přepínat PIPzap"
 
 msgid "Toggle TV/RADIO mode"
@@ -11641,8 +11641,8 @@ msgstr "Jaký typ vyhledání programů chcete?"
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Enigma2 bude načítat odstraněné uživatelské přehledy. To znamená, že uživatelské přehledy, které jsou k dispozici, ale nejsou zahrnuty v bouquets.tv nebo bouquets.radio, budou načteny. To například umožňuje zachovat vlastní uživatelské přehledy, zatímco instalovaná nastavení jsou aktualizována."
 
-msgid "When enabled the PiP can be closed by the exit button."
-msgstr "Jestliže je povoleno, pak PIP může být ukončen tlačítkem Exit."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
+msgstr "Jestliže je povoleno, pak PiP může být ukončen tlačítkem Exit."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
 msgstr "Jestliže je povoleno, pak šipky okolo tlačítka OK budou používat 'neutrino' styl přepínání namísto stylu enigma2."
@@ -12237,7 +12237,7 @@ msgid "Zap up"
 msgstr "Přepnout nahoru"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr "Program %s přepnut časovačem do PiP"
 
 #, python-format

--- a/po/da.po
+++ b/po/da.po
@@ -1544,7 +1544,7 @@ msgid "Behavior of 'pause and ok' when paused"
 msgstr "Opførsel af 'pause og ok' når pauset"
 
 #
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Opførsel af 0 tast i BiB tilstand"
 
 #
@@ -2058,7 +2058,7 @@ msgstr "Klon TV skærm til LCD"
 msgid "Close"
 msgstr "Afslut"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Luk BiB ved exit"
 
 #
@@ -2216,7 +2216,7 @@ msgstr "Konfigurer hvordan blæseren skal opføre sig."
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Konfigurer om og hvordan krypto ikoner skal blive vist i kanal listen."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Konfigurer hvis og hvor længe den seneste kanal i BiB vil blive husket."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2330,7 +2330,7 @@ msgstr "Konfigurer lydsprog nummer fire."
 msgid "Configure the fourth subtitle language."
 msgstr "Konfigurer undertekstsprog nummer fire."
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr "Konfigurer '0' knappens funktion når BiB er aktiv."
 
 #
@@ -4945,7 +4945,7 @@ msgstr "Inkluder ECM i http stream"
 msgid "Include EIT in http streams"
 msgstr "Inkluder EIT i http stream"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Ukorrekt kanaltype for BiB!"
 
 #
@@ -5802,8 +5802,8 @@ msgstr "Monter"
 msgid "Move"
 msgstr "Flyt"
 
-msgid "Move PIP"
-msgstr "Flyt PIP"
+msgid "Move PiP"
+msgstr "Flyt BiB"
 
 #
 msgid "Move PiP to main picture"
@@ -8949,7 +8949,7 @@ msgstr "Korte filnavne"
 
 #, fuzzy
 msgid "Show"
-msgstr "Vis PIP"
+msgstr "Vis"
 
 msgid "Show Audioselection"
 msgstr "Vis Audioselection"
@@ -8974,8 +8974,8 @@ msgstr "Vis Spil show"
 msgid "Show InfoBar"
 msgstr "Vis InfoBar"
 
-msgid "Show PIP"
-msgstr "Vis PIP"
+msgid "Show PiP"
+msgstr "Vis BiB"
 
 msgid "Show SNR percentage instead of dB value"
 msgstr "Vis SNR procent i stedet for dB værdi"
@@ -9878,7 +9878,7 @@ msgstr "Servicenavn"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr "Byt BiB"
 
 #
@@ -10687,7 +10687,7 @@ msgstr "Skift HDMI In"
 msgid "Toggle LCD LiveTV"
 msgstr "Skift mellem LCD LiveTV"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr "Skift mellem PIPzap"
 
 msgid "Toggle TV/RADIO mode"
@@ -11629,7 +11629,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Når aktiveret vil enigma2 indlæse ikke sammenkædet brugerbouquets. Dette betyder at brugerbouquets der er tilgængelig, men ikke inkluderet i bouquets.tv eller bouquets.radio filer, vil stadig blive indlæst. Dette tillader dig f.eks. til at beholde dine egn brugerbouquet imens installerede indstillinger bliver opgraderet"
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Ved aktivering kan BiB lukkes med exit knappen."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -12213,7 +12213,7 @@ msgid "Zap up"
 msgstr "Zap op"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #, fuzzy, python-format

--- a/po/de.po
+++ b/po/de.po
@@ -1370,7 +1370,7 @@ msgstr "Startzeit"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr "Verhalten von 'Pause und OK' wenn pausiert"
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Verhalten der '0'-Taste bei Bild im Bild"
 
 msgid "Behavior when a movie is started"
@@ -1835,7 +1835,7 @@ msgstr "Klonen Sie den TV-Bildschirm in den LCD-Modus"
 msgid "Close"
 msgstr "Schließen"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Schließe PiP mit Exit"
 
 msgid "Close title selection"
@@ -1963,7 +1963,7 @@ msgstr "Lüfterverhalten konfigurieren"
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Konfigurieren Sie ob und wie Verschlüsselungssymbole in der Kanalauswahlliste angezeigt werden sollen."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Konfiguriere, ob und wie lange der letzte PiP-Kanal gespeichert wird."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2075,7 +2075,7 @@ msgstr "Wahl der vierten Audiospur-Sprache."
 msgid "Configure the fourth subtitle language."
 msgstr "Wahl der vierten Untertitel Sprache."
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr "Funktion der '0' Taste während Bild im Bild aktiv ist."
 
 msgid "Configure the gateway."
@@ -4374,7 +4374,7 @@ msgstr "Integriere ECM in HTTP-Streams"
 msgid "Include EIT in http streams"
 msgstr "Integriere EIT in HTTP-Streams"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Nicht unterstützter Dienst für PiP!"
 
 msgid "Increased voltage"
@@ -5102,8 +5102,8 @@ msgstr "Einhängen"
 msgid "Move"
 msgstr "Verschieben"
 
-msgid "Move PIP"
-msgstr "Bild im Bild (PIP) verschieben"
+msgid "Move PiP"
+msgstr "Bild im Bild (PiP) verschieben"
 
 msgid "Move PiP to main picture"
 msgstr "Bild im Bild tauschen und beenden"
@@ -7818,8 +7818,8 @@ msgstr "Spielsendungen anzeigen"
 msgid "Show InfoBar"
 msgstr "Infoleiste anzeigen"
 
-msgid "Show PIP"
-msgstr "PIP (Bild in Bild) anzeigen"
+msgid "Show PiP"
+msgstr "PiP (Bild in Bild) anzeigen"
 
 msgid "Show SNR percentage instead of dB value"
 msgstr "SNR-Prozentsatz anstelle von dB-Wert anzeigen"
@@ -8614,8 +8614,8 @@ msgstr "Suriname"
 msgid "Svalbard and Jan Mayen"
 msgstr "Svalbard und Jan Mayen"
 
-msgid "Swap PIP"
-msgstr "Tausche PIP (Bild in Bild)"
+msgid "Swap PiP"
+msgstr "Tausche PiP (Bild in Bild)"
 
 msgid "Swap PiP and main picture"
 msgstr "Tausche Bild im Bild mit Hauptbild"
@@ -9328,8 +9328,8 @@ msgstr "Toggle HDMI In"
 msgid "Toggle LCD LiveTV"
 msgstr "Toggle LCD LiveTV"
 
-msgid "Toggle PIPzap"
-msgstr "Toggle PIPzap"
+msgid "Toggle PiPzap"
+msgstr "Toggle PiPzap"
 
 msgid "Toggle TV/RADIO mode"
 msgstr "Schalte TV/Radio Modus"
@@ -10135,7 +10135,7 @@ msgstr "Welche Art von Service-Scan wollen Sie durchführen?"
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Wenn Sie diese Option aktivieren, werden alle vorhandenen Kanallisten geladen, auch wenn diese nicht in der bouquets.tv oder bouquets.radio verlinkt sind. Dies erlaubt Ihnen z.B. Ihre eigenen Kanallisten zu erhalten, wenn eine Aktualisierung von installierten Kanallisten erfolgt."
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Falls aktiviert, kann PiP mit der Exit-Taste geschlossen werden."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10696,7 +10696,7 @@ msgid "Zap up"
 msgstr "Kanal -"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr "Zapped zum Timerdienst% s als PiP!"
 
 #, python-format

--- a/po/el.po
+++ b/po/el.po
@@ -1361,8 +1361,8 @@ msgstr "Ώρα έναρξης"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr "Συμπεριφορά των 'pause και ok' κατά την παύση"
 
-msgid "Behavior of 0 key in PiP-mode"
-msgstr "Συμπεριφορά του πλήκτρου 0 στη λειτουργία PiP"
+msgid "Behavior of '0' button in PiP mode"
+msgstr "Συμπεριφορά του πλήκτρου '0' στη λειτουργία PiP"
 
 msgid "Behavior when a movie is started"
 msgstr "Συμπεριφορά όταν μια ταινία παίζει"
@@ -1825,8 +1825,8 @@ msgstr "Λειτουργία κλωνοποίησης TV σε οθόνη LCD"
 msgid "Close"
 msgstr "Κλείσιμο"
 
-msgid "Close PiP on exit"
-msgstr "Κλείσιμο του PiP κατά την έξοδο"
+msgid "Close PiP with 'exit' button"
+msgstr "Κλείσιμο του PiP με το πλήκτρο 'exit'"
 
 msgid "Close title selection"
 msgstr "Κλείσιμο επιλογής τίτλου"
@@ -1952,8 +1952,8 @@ msgstr "Ρύθμιση του τρόπου λειτουργίας του ανε�
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Ρυθμίστε εάν και πώς θα εμφανίζονται τα κρυπτοεικονίδια στη λίστα επιλογής καναλιών."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
-msgstr "Ρυθμίστε εάν και για πόσο θα γίνεται υπενθύμιση της τελευταίας υπηρεσίας στο PIP."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
+msgstr "Ρυθμίστε εάν και για πόσο θα γίνεται υπενθύμιση της τελευταίας υπηρεσίας στο PiP."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
 msgstr "Ρυθμίστε εάν και πώς θα εμφανίζονται τα εικονίδια τύπου υπηρεσίας στη λίστα επιλογής καναλιών."
@@ -2060,8 +2060,8 @@ msgstr "Ρύθμιση της τέταρτης γλώσσας ήχου."
 msgid "Configure the fourth subtitle language."
 msgstr "Ρύθμιση της τέταρτης γλώσσας υποτίτλων."
 
-msgid "Configure the function of the '0' button do when PIP is active."
-msgstr "Ρύθμιση λειτουργίας του πλήκτρου '0' όταν το PIP είναι ενεργό."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
+msgstr "Ρύθμιση λειτουργίας του πλήκτρου '0' όταν η λειτουργία Εικόνα σε Εικόνα είναι ενεργή."
 
 msgid "Configure the gateway."
 msgstr "Ρύθμιση πύλης δικτύου."
@@ -4356,7 +4356,7 @@ msgstr "Συμπερίληψη του ECM στις ροές http"
 msgid "Include EIT in http streams"
 msgstr "Συμπερίληψη του ΕΙΤ στις ροές http"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Λανθασμένος τύπος υπηρεσίας για PiP!"
 
 msgid "Increased voltage"
@@ -5086,8 +5086,8 @@ msgstr "Προσάρτηση"
 msgid "Move"
 msgstr "Μετακίνηση"
 
-msgid "Move PIP"
-msgstr "Μετακίνηση PIP"
+msgid "Move PiP"
+msgstr "Μετακίνηση PiP"
 
 msgid "Move PiP to main picture"
 msgstr "Μετακίνηση PiP στην κύρια εικόνα"
@@ -7789,8 +7789,8 @@ msgstr "Εμφάνιση τηλεπαιχνιδιού"
 msgid "Show InfoBar"
 msgstr "Εμφάνιση μπάρας πληροφοριών"
 
-msgid "Show PIP"
-msgstr "Εμφάνιση PIP"
+msgid "Show PiP"
+msgstr "Εμφάνιση PiP"
 
 msgid "Show SNR percentage instead of dB value"
 msgstr "Εμφάνιση τιμής SNR σε ποσοστό αντί για dB"
@@ -8580,8 +8580,8 @@ msgstr "Σουρινάμ"
 msgid "Svalbard and Jan Mayen"
 msgstr "Σβάλμπαρντ και Γιαν Μαγιέν"
 
-msgid "Swap PIP"
-msgstr "Εναλλαγή PIP"
+msgid "Swap PiP"
+msgstr "Εναλλαγή PiP"
 
 msgid "Swap PiP and main picture"
 msgstr "Εναλλαγή PiP και κύριας εικόνας"
@@ -9291,8 +9291,8 @@ msgstr "Ενεργοποίηση HDMI In"
 msgid "Toggle LCD LiveTV"
 msgstr "Ενεργοποίηση ζωντανής TV στην LCD"
 
-msgid "Toggle PIPzap"
-msgstr "Ενεργοποίηση ζάπινγκ PIP"
+msgid "Toggle PiPzap"
+msgstr "Ενεργοποίηση ζάπινγκ PiP"
 
 msgid "Toggle TV/RADIO mode"
 msgstr "Εναλλαγή λειτουργίας TV/ΡΑΔΙΟΦΩΝΟ"
@@ -10098,7 +10098,7 @@ msgstr "Ποιον τύπο ανίχνευσης επιθυμείτε;"
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Όταν είναι ενεργό, το enigma2 θα φορτώνει τα ασύνδετα μπουκέτα χρήστη. Αυτό σημαίνει ότι τα μπουκέτα που είναι διαθέσιμα, αλλά δεν συμπεριλαμβάνονται στα αρχεία bouquets.tv ή bouquets.radio, θα φορτώνονται επίσης. Αυτό σας επιτρέπει για παράδειγμα να διατηρείτε το δικό σας μπουκέτον χρήστη όταν τα εγκατεστημένα θα ενημερώνονται"
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Όταν είναι ενεργό, το PiP μπορεί να τερματιστεί με το πλήκτρο εξόδου."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10651,7 +10651,7 @@ msgid "Zap up"
 msgstr "Ζάπινγκ προς τα επάνω"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr "Έγινε μετάβαση στην υπηρεσία %s ως PiP!"
 
 #, python-format

--- a/po/en.po
+++ b/po/en.po
@@ -1373,8 +1373,8 @@ msgstr "Begin time"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr ""
 
-msgid "Behavior of 0 key in PiP-mode"
-msgstr "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
+msgstr "Behavior of '0' button in PiP mode"
 
 msgid "Behavior when a movie is started"
 msgstr "Behavior when a movie is started"
@@ -1831,8 +1831,8 @@ msgstr ""
 msgid "Close"
 msgstr "Close"
 
-msgid "Close PiP on exit"
-msgstr "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
+msgstr "Close PiP with 'exit' button"
 
 msgid "Close title selection"
 msgstr "Close title selection"
@@ -1966,7 +1966,7 @@ msgstr ""
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr ""
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr ""
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2074,8 +2074,8 @@ msgstr "Configure the fourth audio language."
 msgid "Configure the fourth subtitle language."
 msgstr "Configure the fourth subtitle language."
 
-msgid "Configure the function of the '0' button do when PIP is active."
-msgstr "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
+msgstr "Configure the function of the '0' button when Picture in Picture is active."
 
 msgid "Configure the gateway."
 msgstr "Configure the gateway."
@@ -4397,7 +4397,7 @@ msgstr "Include ECM in http streams"
 msgid "Include EIT in http streams"
 msgstr "Include EIT in http streams"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr ""
 
 msgid "Increased voltage"
@@ -5140,7 +5140,7 @@ msgstr "Mount"
 msgid "Move"
 msgstr "Move"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr ""
 
 msgid "Move PiP to main picture"
@@ -7908,7 +7908,7 @@ msgstr "Show Games show"
 msgid "Show InfoBar"
 msgstr ""
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr ""
 
 msgid "Show SNR percentage instead of dB value"
@@ -8715,7 +8715,7 @@ msgstr "Service name"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr ""
 
 msgid "Swap PiP and main picture"
@@ -9417,7 +9417,7 @@ msgstr ""
 msgid "Toggle LCD LiveTV"
 msgstr ""
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr ""
 
 msgid "Toggle TV/RADIO mode"
@@ -10237,8 +10237,8 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
-msgid "When enabled the PiP can be closed by the exit button."
-msgstr "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
+msgstr "When enabled the Picture in Picture window can be closed with 'exit' button."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
 msgstr ""
@@ -10787,7 +10787,7 @@ msgid "Zap up"
 msgstr ""
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #, fuzzy, python-format

--- a/po/es.po
+++ b/po/es.po
@@ -1541,7 +1541,7 @@ msgid "Behavior of 'pause and ok' when paused"
 msgstr "Comportamiento de ‘pausa y ok’ cuando se detiene"
 
 #
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Tecla 0 en el modo PiP"
 
 #
@@ -2041,7 +2041,7 @@ msgstr "Clone la pantalla de TV al modo LCD"
 msgid "Close"
 msgstr "Cerrar"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Cerrar PiP en la salida"
 
 #
@@ -2189,7 +2189,7 @@ msgstr "Configurar cómo debe funcionar el ventilador"
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Configure si y cómo se mostrarán los iconos de criptografía en la lista de selección de canales."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Configure si y por cuánto tiempo se recordará el servicio más reciente en el PiP."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2304,8 +2304,8 @@ msgstr "Configure el cuarto idioma de audio."
 msgid "Configure the fourth subtitle language."
 msgstr "Configure el idioma del subtítulo cuarto."
 
-msgid "Configure the function of the '0' button do when PIP is active."
-msgstr "Configure la función del botón ‘0’ cuando PIP está activo."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
+msgstr "Configure la función del botón ‘0’ cuando PiP está activo."
 
 #
 msgid "Configure the gateway."
@@ -4857,7 +4857,7 @@ msgstr "Incluir ECM en los flujos http"
 msgid "Include EIT in http streams"
 msgstr "Incluir EIT en los flujos http"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Servicio de tipo incorrecto para PiP!"
 
 #
@@ -5688,8 +5688,8 @@ msgstr "Montar"
 msgid "Move"
 msgstr "Movimiento"
 
-msgid "Move PIP"
-msgstr "Mover PIP"
+msgid "Move PiP"
+msgstr "Mover PiP"
 
 #
 msgid "Move PiP to main picture"
@@ -8762,8 +8762,8 @@ msgstr "Mostrar juegos"
 msgid "Show InfoBar"
 msgstr "Mostrar InfoBar"
 
-msgid "Show PIP"
-msgstr "Mostrar PIP"
+msgid "Show PiP"
+msgstr "Mostrar PiP"
 
 msgid "Show SNR percentage instead of dB value"
 msgstr "Mostrar el porcentaje de SNR en lugar del valor de dB"
@@ -9645,8 +9645,8 @@ msgstr "Suriname"
 msgid "Svalbard and Jan Mayen"
 msgstr "Svalbard y Jan Mayen"
 
-msgid "Swap PIP"
-msgstr "Swap PIP"
+msgid "Swap PiP"
+msgstr "Swap PiP"
 
 #
 msgid "Swap PiP and main picture"
@@ -10441,7 +10441,7 @@ msgstr "Alternar HDMI In"
 msgid "Toggle LCD LiveTV"
 msgstr "Alternar LCD LiveTV"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr "Alternar PIPzap"
 
 msgid "Toggle TV/RADIO mode"
@@ -11352,7 +11352,7 @@ msgstr "¿Qué tipo de escaneo de servicio quieres?"
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Cuando está habilitado, enigma2 cargará los usuarios desvinculados. Esto significa que los userbouquets que están disponibles, pero que no están incluidos en los archivos bouquets.tv o bouquets.radio, seguirán cargándose. Esto le permite, por ejemplo, mantener su propio ramo de usuario mientras se instalan los ajustes instalados"
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Cuando está activado, el PiP se puede cerrar con el botón de salida."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -11931,7 +11931,7 @@ msgid "Zap up"
 msgstr "Zap up"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr "Zapped para dar servicio al temporizador% s como PiP!"
 
 #, python-format

--- a/po/et.po
+++ b/po/et.po
@@ -1376,7 +1376,7 @@ msgstr "Algusaeg"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr "'pausi ja OK' tegevus kui pilt on peatatud"
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "0-nupu funktsioon PiP-režiimis"
 
 msgid "Behavior when a movie is started"
@@ -1829,7 +1829,7 @@ msgstr "Klooni TV pilt LCD-le"
 msgid "Close"
 msgstr "Sulge"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Sulge PiP 'EXIT' nupuga"
 
 msgid "Close title selection"
@@ -1957,7 +1957,7 @@ msgstr "Määra, kuidas ventilaator peaks toimima"
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Määra, kas ja kuidas salastatuse ikoonid on näha kanalivaliku nimekirjas."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Määra, kas ja kui pikalt jääb PiP viimane kasutatud teenus vastuvõtja mällu."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2067,7 +2067,7 @@ msgstr "Määra heli keele neljas eelistus."
 msgid "Configure the fourth subtitle language."
 msgstr "Määra subtiitrite keele neljas eelistus."
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr "Määra, mida '0' nupp PiP- režiimis teeb."
 
 msgid "Configure the gateway."
@@ -2275,7 +2275,7 @@ msgid "Connected to"
 msgstr "Ühendatud"
 
 msgid "Connected transcoding, limit - no PiP!"
-msgstr "Ühendatud transkoodingu piirang - PIP ei ole võimalik!"
+msgstr "Ühendatud transkoodingu piirang - PiP ei ole võimalik!"
 
 msgid "Console"
 msgstr "Konsool"
@@ -4383,7 +4383,7 @@ msgstr "Kaasa ECM http voogudesse"
 msgid "Include EIT in http streams"
 msgstr "Kaasa EIT http voogudesse"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "PiP jaoks sobimatu teenus!"
 
 msgid "Increased voltage"
@@ -5112,7 +5112,7 @@ msgstr "Haagi"
 msgid "Move"
 msgstr "Liiguta"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr "Liiguta PiP"
 
 msgid "Move PiP to main picture"
@@ -7853,7 +7853,7 @@ msgstr "Näita telemängu"
 msgid "Show InfoBar"
 msgstr "Näita inforiba"
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr "Näita PiP"
 
 msgid "Show SNR percentage instead of dB value"
@@ -8649,8 +8649,8 @@ msgstr "Suriname"
 msgid "Svalbard and Jan Mayen"
 msgstr "Svalbard ja Jan Mayen"
 
-msgid "Swap PIP"
-msgstr "Vaheta PIP"
+msgid "Swap PiP"
+msgstr "Vaheta PiP"
 
 msgid "Swap PiP and main picture"
 msgstr "Vaheta PiP- ja peapilt"
@@ -9382,7 +9382,7 @@ msgstr "Lülita HDMI sisendeid"
 msgid "Toggle LCD LiveTV"
 msgstr "Lülita LCD LiveTV"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr "Lülita PiP valikut"
 
 msgid "Toggle TV/RADIO mode"
@@ -10201,7 +10201,7 @@ msgstr "Mis tüüpi teenuse otsingut soovid?"
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Määrates 'jah', laeb enigma2 ka sidumata lemmiknimekirjad. See tähendab, et lemmiknimekirjad, mis on olemas, aga puuduvad bouquets.tv või bouquets.radio failides, laetakse ikkagi. Nii on võimalik oma lemmiknimekirjad säilitada ka paigaldatud kanalinimekirjade uuendamisel."
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Määrates 'jah', saab PiP sulgeda EXIT nupuga."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10762,7 +10762,7 @@ msgid "Zap up"
 msgstr "Kanalivahetus -"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr "Salvestatud taimeri teenusesse %s nagu PiP!"
 
 #, python-format

--- a/po/fa.po
+++ b/po/fa.po
@@ -1388,7 +1388,7 @@ msgstr "زمان شروع"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr ""
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "عملکرد دکمه 0 در حالت تصویر در تصویر"
 
 msgid "Behavior when a movie is started"
@@ -1856,7 +1856,7 @@ msgstr ""
 msgid "Close"
 msgstr "بستن"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr ""
 
 msgid "Close title selection"
@@ -1995,7 +1995,7 @@ msgstr ""
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr ""
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr ""
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2105,7 +2105,7 @@ msgstr ""
 msgid "Configure the fourth subtitle language."
 msgstr ""
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr ""
 
 msgid "Configure the gateway."
@@ -4466,7 +4466,7 @@ msgstr "شامل ECM در جریان های http"
 msgid "Include EIT in http streams"
 msgstr "شامل EIT در جریان های http"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr ""
 
 msgid "Increased voltage"
@@ -5233,7 +5233,7 @@ msgstr ""
 msgid "Move"
 msgstr "جابجایی"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr ""
 
 #, fuzzy
@@ -8059,7 +8059,7 @@ msgstr ""
 msgid "Show InfoBar"
 msgstr ""
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr ""
 
 msgid "Show SNR percentage instead of dB value"
@@ -8893,7 +8893,7 @@ msgstr "نام وسیله:"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr ""
 
 msgid "Swap PiP and main picture"
@@ -9575,7 +9575,7 @@ msgstr ""
 msgid "Toggle LCD LiveTV"
 msgstr ""
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr ""
 
 msgid "Toggle TV/RADIO mode"
@@ -10362,7 +10362,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr ""
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10883,7 +10883,7 @@ msgid "Zap up"
 msgstr ""
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #, python-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -1510,7 +1510,7 @@ msgid "Behavior of 'pause and ok' when paused"
 msgstr "Pause- ja OK-näppäimien toiminta"
 
 #
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "0-näppäimen toiminta PiP-tilassa"
 
 #
@@ -2019,7 +2019,7 @@ msgid "Close"
 msgstr "Sulje"
 
 #
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Sulje PiP-kuva Exit-näppäimellä"
 
 msgid "Close title selection"
@@ -2159,7 +2159,7 @@ msgstr "Määritä tuulettimen toiminta"
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Määrittää näytetäänkö salauksen kuvakkeet kanavalistassa."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Määritä kuinka pitkään viimeisin käytetty PiP (kuva-kuvassa) kanava muistetaan."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2269,7 +2269,7 @@ msgstr "Määrittää neljännen äänen kielen."
 msgid "Configure the fourth subtitle language."
 msgstr "Määrittää neljännen tekstityskielen."
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr "Määrittää '0' näppäimen toiminnan PiP-tilassa."
 
 msgid "Configure the gateway."
@@ -4815,7 +4815,7 @@ msgstr "Liitä ECM http-striimeihin"
 msgid "Include EIT in http streams"
 msgstr "Sisällytä EIT http-striimeihin"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr ""
 
 #
@@ -5651,7 +5651,7 @@ msgstr "Liitä"
 msgid "Move"
 msgstr "Siirrä"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr "Siirrä PiP"
 
 #
@@ -5660,7 +5660,7 @@ msgstr "Siirrä PiP pääkuvaan"
 
 #
 msgid "Move Picture in Picture"
-msgstr "Siirrä PIP-kuvaa"
+msgstr "Siirrä PiP-kuvaa"
 
 #
 msgid "Move east"
@@ -8777,7 +8777,7 @@ msgstr "Show Visailu"
 msgid "Show InfoBar"
 msgstr "Näytä tietopalkki"
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr "Näytä PiP"
 
 msgid "Show SNR percentage instead of dB value"
@@ -9683,7 +9683,7 @@ msgstr "Suriname"
 msgid "Svalbard and Jan Mayen"
 msgstr "Svalbard and Jan Mayen"
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr "Vaihda PiP"
 
 #
@@ -10464,7 +10464,7 @@ msgstr "HDMI sisään päälle/pois"
 msgid "Toggle LCD LiveTV"
 msgstr "Valitse tv-kuva etupaneeliin"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr ""
 
 msgid "Toggle TV/RADIO mode"
@@ -11377,7 +11377,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Kun päällä, suosikkilistat jotka ovat saatavilla ladataan vaikka ne eivät olisi bouquets.tv tai bouquets.radio tiedostoissa. Tämä antaa sinun pitää omat suosikkilistasi samalla kun asennettuja päivitetään."
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Kun päällä, PiP voidaan sulkea exit-napilla."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -11953,7 +11953,7 @@ msgid "Zap up"
 msgstr "Kanava ylös"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr "Ajastettu vaihto kanavalle %s (PiP)!"
 
 #, python-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -1365,7 +1365,7 @@ msgstr "Heure de début"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr "Comportement de 'pause et ok’ en étant en pause"
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Effet touche 0 en mode PiP"
 
 msgid "Behavior when a movie is started"
@@ -1829,7 +1829,7 @@ msgstr "Mode de duplication de l'écran TV sur le LCD"
 msgid "Close"
 msgstr "Fermer"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Fermer PiP en quittant"
 
 msgid "Close title selection"
@@ -1956,7 +1956,7 @@ msgstr "Configure l'activité du ventilateur"
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Configure si et où les icônes de cryptage seront affichés dans la liste des chaînes."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Configure si et combien de temps le dernier service en PiP sera mémorisé."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2064,8 +2064,8 @@ msgstr "Configure la quatrième langue audio."
 msgid "Configure the fourth subtitle language."
 msgstr "Configure la quatrième langue des sous-titres."
 
-msgid "Configure the function of the '0' button do when PIP is active."
-msgstr "Configure la fonction du '0 'quand le bouton PIP est actif."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
+msgstr "Configure la fonction du '0' quand le bouton PiP est actif."
 
 msgid "Configure the gateway."
 msgstr "Configure la passerelle."
@@ -4358,7 +4358,7 @@ msgstr "Inclure ECM dans les flux HTTP"
 msgid "Include EIT in http streams"
 msgstr "Inclure EIT dans les flux HTTP"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Type de service incorrect pour PiP (image-dans-image)!"
 
 msgid "Increased voltage"
@@ -5088,7 +5088,7 @@ msgstr "Monter"
 msgid "Move"
 msgstr "Déplacer"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr "Déplacer PiP"
 
 msgid "Move PiP to main picture"
@@ -7791,7 +7791,7 @@ msgstr "Voir les jeux"
 msgid "Show InfoBar"
 msgstr "Afficher la barre d'information"
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr "Afficher PiP"
 
 msgid "Show SNR percentage instead of dB value"
@@ -8582,7 +8582,7 @@ msgstr "Suriname"
 msgid "Svalbard and Jan Mayen"
 msgstr "Svalbard et Jan Mayen"
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr "Permuter PiP"
 
 msgid "Swap PiP and main picture"
@@ -9300,7 +9300,7 @@ msgstr "Activer HDMI In"
 msgid "Toggle LCD LiveTV"
 msgstr "Activer la TV en direct sur le LCD"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr "Activer PiPZap"
 
 msgid "Toggle TV/RADIO mode"
@@ -10111,7 +10111,7 @@ msgstr "Quel type de recherche de service voulez-vous?"
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Lorsqu'elle est activée, enigma2 chargera les userbouquets non liés. Cela signifie que les userbouquets qui sont disponibles, mais pas repris dans les fichiers bouquets.tv ou bouquets.radio, seront chargés."
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Lorsqu'elle est activée, le PiP peut être fermé avec le bouton exit."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10666,7 +10666,7 @@ msgid "Zap up"
 msgstr "Zap haut"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr "Zapper vers le timer de service %s comme PiP!"
 
 #, python-format

--- a/po/fy.po
+++ b/po/fy.po
@@ -809,7 +809,7 @@ msgstr ""
 
 #
 msgid "Activate Picture in Picture"
-msgstr "PIP ynskeakelje"
+msgstr "PiP ynskeakelje"
 
 #
 #, fuzzy
@@ -1546,7 +1546,7 @@ msgid "Behavior of 'pause and ok' when paused"
 msgstr ""
 
 #
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Gedrach fan 0 toets yn PiP mode"
 
 #
@@ -2064,7 +2064,7 @@ msgstr ""
 msgid "Close"
 msgstr "Slúte"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr ""
 
 #
@@ -2227,7 +2227,7 @@ msgstr ""
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr ""
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr ""
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Configure the fourth subtitle language."
 msgstr "skeakelje nei de folgende undertiteling taal"
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr ""
 
 msgid "Configure the gateway."
@@ -3162,7 +3162,7 @@ msgstr "Utskeakelje"
 
 #
 msgid "Disable Picture in Picture"
-msgstr "PIP utskeakelje"
+msgstr "PiP utskeakelje"
 
 msgid "Disable background scanning"
 msgstr ""
@@ -4971,7 +4971,7 @@ msgstr ""
 msgid "Include EIT in http streams"
 msgstr ""
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr ""
 
 #
@@ -5852,7 +5852,7 @@ msgstr ""
 msgid "Move"
 msgstr ""
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr ""
 
 #
@@ -6752,7 +6752,7 @@ msgstr ""
 #
 #, fuzzy
 msgid "PiP setup"
-msgstr "PIP Ynstellingen"
+msgstr "PiP Ynstellingen"
 
 msgid "Picon"
 msgstr ""
@@ -9078,7 +9078,7 @@ msgstr ""
 msgid "Show InfoBar"
 msgstr ""
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr ""
 
 msgid "Show SNR percentage instead of dB value"
@@ -10001,7 +10001,7 @@ msgstr "Kanaal sykje"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr ""
 
 #
@@ -10788,7 +10788,7 @@ msgstr ""
 msgid "Toggle LCD LiveTV"
 msgstr ""
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr ""
 
 msgid "Toggle TV/RADIO mode"
@@ -11734,7 +11734,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr ""
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -12290,7 +12290,7 @@ msgid "Zap up"
 msgstr ""
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #

--- a/po/he.po
+++ b/po/he.po
@@ -1469,7 +1469,7 @@ msgstr "Begin time"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr ""
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "פעולת מקש ה - 0 במצב תמונה בתוך תמונה"
 
 #
@@ -1959,7 +1959,7 @@ msgstr ""
 msgid "Close"
 msgstr "סגור"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr ""
 
 msgid "Close title selection"
@@ -2100,7 +2100,7 @@ msgstr ""
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr ""
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr ""
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2216,7 +2216,7 @@ msgstr ""
 msgid "Configure the fourth subtitle language."
 msgstr "העבר לשפת תרגום הבאה"
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr ""
 
 #, fuzzy
@@ -4674,7 +4674,7 @@ msgstr ""
 msgid "Include EIT in http streams"
 msgstr ""
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr ""
 
 #
@@ -5519,7 +5519,7 @@ msgstr ""
 msgid "Move"
 msgstr ""
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr ""
 
 #, fuzzy
@@ -8511,7 +8511,7 @@ msgstr ""
 msgid "Show InfoBar"
 msgstr ""
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr ""
 
 msgid "Show SNR percentage instead of dB value"
@@ -9409,7 +9409,7 @@ msgstr "סרוקת שירות"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr ""
 
 #, fuzzy
@@ -10163,7 +10163,7 @@ msgstr ""
 msgid "Toggle LCD LiveTV"
 msgstr ""
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr ""
 
 msgid "Toggle TV/RADIO mode"
@@ -11049,7 +11049,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr ""
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -11592,7 +11592,7 @@ msgid "Zap up"
 msgstr ""
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #, fuzzy, python-format

--- a/po/hr.po
+++ b/po/hr.po
@@ -1375,7 +1375,7 @@ msgstr "Vrijeme početka"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr "Ponašanje 'pauziraj i ok' tijekom pauze"
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Ponašanje gumba 0 u PiP modu"
 
 msgid "Behavior when a movie is started"
@@ -1839,7 +1839,7 @@ msgstr "Kloniranje TV zaslona na LCD način"
 msgid "Close"
 msgstr "Zatvoriti"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Zatvorite PiP i izađite"
 
 msgid "Close title selection"
@@ -1966,7 +1966,7 @@ msgstr "Postavljanje načina rada ventilatora"
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Prilagodite ikone za kodirane usluge na popisu za odabir kanala."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Konfigurirajte koliko dugo će najnovija usluga u PiP biti zapamćena."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2074,8 +2074,8 @@ msgstr "Konfigurirajte četvrti jezik zvuka."
 msgid "Configure the fourth subtitle language."
 msgstr "Konfigurirajte četvrti jezik titla."
 
-msgid "Configure the function of the '0' button do when PIP is active."
-msgstr "Konfigurirajte funkciju gumba '0' kada je PIP aktivan."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
+msgstr "Konfigurirajte funkciju gumba '0' kada je PiP aktivan."
 
 msgid "Configure the gateway."
 msgstr "Konfigurirajte pristupnik."
@@ -4372,7 +4372,7 @@ msgstr "Uključite ECM u web prijenos"
 msgid "Include EIT in http streams"
 msgstr "Uključite EIT u web prijenos"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Pogrešan tip servisa za PiP!"
 
 msgid "Increased voltage"
@@ -5104,8 +5104,8 @@ msgstr "Montiranje"
 msgid "Move"
 msgstr "Premještanje"
 
-msgid "Move PIP"
-msgstr "Premjestite PIP"
+msgid "Move PiP"
+msgstr "Premjestite PiP"
 
 msgid "Move PiP to main picture"
 msgstr "Premjestite PiP na glavnu sliku"
@@ -6638,7 +6638,7 @@ msgid "Reloading bouquets and services..."
 msgstr "Ponovno učitati pakete i kanale..."
 
 msgid "Remember last service in PiP"
-msgstr "Zapamtite zadnji servis u PIP-u"
+msgstr "Zapamtite zadnji servis u PiP-u"
 
 msgid "Remember service PIN"
 msgstr "Zapamtite PIN usluge"
@@ -7810,7 +7810,7 @@ msgstr "Prikažite igre"
 msgid "Show InfoBar"
 msgstr "Prikažite info traku"
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr "Prikažite PiP"
 
 msgid "Show SNR percentage instead of dB value"
@@ -8601,7 +8601,7 @@ msgstr "Suriname"
 msgid "Svalbard and Jan Mayen"
 msgstr "Svalbard i Jan Mayen"
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr "PiP promjena"
 
 msgid "Swap PiP and main picture"
@@ -9310,7 +9310,7 @@ msgstr "Promjenite HDMI ulaz"
 msgid "Toggle LCD LiveTV"
 msgstr "Promijenite LCD LiveTV"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr "Promjenite PIPzap"
 
 msgid "Toggle TV/RADIO mode"
@@ -10118,7 +10118,7 @@ msgstr "Koju vrstu skeniranja usluga želite?"
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Kada je omogućeno enigma2 učitat će nepovezane korisničke pakete. To znači da će korisnički paketi koji su dostupni, ali nisu uključeni u bouquets.tv ili bouquets.radio datoteke, i dalje biti učitani. To vam omogućuje, primjerice, da zadržite vlastiti korisnički paket dok su instalirane postavke ažurirane."
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Kada je omogućeno, PiP se može zatvoriti pomoću gumba za izlaz."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10672,7 +10672,7 @@ msgid "Zap up"
 msgstr "Prebaci kanal prema gore"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr "Prebaci na uslugu tajmera %s каo PiP!"
 
 #, python-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -1369,7 +1369,7 @@ msgstr "Kezdési idő"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr "'Pause' és 'OK' viselkedése megállítás közben"
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Kép-a-Képben esetén a 0 gomb jelentése"
 
 msgid "Behavior when a movie is started"
@@ -1834,7 +1834,7 @@ msgstr "TV kijelző klónozása LCD módba"
 msgid "Close"
 msgstr "Bezárás"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Kép-a-Képben bezárása kilépéskor"
 
 msgid "Close title selection"
@@ -1962,7 +1962,7 @@ msgstr "A ventilátor működési módjának beállítása"
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "A kódolási ikonok megjelenítése a csatornalistában."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Beállíthatja, hogy a legutolsó Kép-a-Képben csatorna mennyi ideig maradjon meg."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2070,7 +2070,7 @@ msgstr "Többnyelvű csatornáknál ezt a hangsávot választja automatikusan, n
 msgid "Configure the fourth subtitle language."
 msgstr "Többnyelvű csatornáknál ezt a feliratot választja automatikusan, negyedik prioritással."
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr "A '0' gomb működése aktív Kép-a-Képben funkció mellett."
 
 msgid "Configure the gateway."
@@ -4366,7 +4366,7 @@ msgstr "Legyen ECM a HTTP jelfolyamban"
 msgid "Include EIT in http streams"
 msgstr "Legyen EIT a HTTP jelfolyamban"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Nem megfelelő csatorna a Kép-a-Képben módhoz!"
 
 msgid "Increased voltage"
@@ -5094,7 +5094,7 @@ msgstr "Csatlakozás"
 msgid "Move"
 msgstr "Áthelyezés"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr "Kép-A-Képben mozgatása"
 
 msgid "Move PiP to main picture"
@@ -7805,7 +7805,7 @@ msgstr "Játék/Show"
 msgid "Show InfoBar"
 msgstr "Infobar megjelenítése"
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr "Kép a képben megjelenítése"
 
 msgid "Show SNR percentage instead of dB value"
@@ -8597,7 +8597,7 @@ msgstr "Suriname"
 msgid "Svalbard and Jan Mayen"
 msgstr "Jan Mayen-sziget"
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr "Kép-a-Képben felcserélése"
 
 msgid "Swap PiP and main picture"
@@ -9313,7 +9313,7 @@ msgstr "HDMI bemenet be/ki"
 msgid "Toggle LCD LiveTV"
 msgstr "LCD élő TV be/ki"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr "Kép-a-Képben ugrás be/ki"
 
 msgid "Toggle TV/RADIO mode"
@@ -10116,7 +10116,7 @@ msgstr "Milyen típusú szolgáltatást szeretne keresni?"
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Ha engedélyezi, a leválasztott listák is betöltődnek. Ez azt jelenti, hogy az olyan felhasználói listák is betöltődnek, amelyek léteznek, de nincsnek benne a bouquets.tv vagy bouquets.radio fájlban. Ez lehetőséget ad arra, hogy a saját listáit megtartsa, ha a csatornák frissülnek."
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Kép-a-Képben bezárása a távírányító 'Exit' gomb megnyomásakor."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10674,7 +10674,7 @@ msgid "Zap up"
 msgstr "Ugrás felfelé"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr "Csatorna váltva az időzítésre %s Kép-a-Képben módban!"
 
 #, python-format

--- a/po/id.po
+++ b/po/id.po
@@ -1392,7 +1392,7 @@ msgstr "Waktu mulai"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr "Fungsi tombol 'pause dan ok' saat posisi jeda"
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Fungsi tombol 0 pada mode PiP"
 
 msgid "Behavior when a movie is started"
@@ -1854,7 +1854,7 @@ msgstr "Mode gandakan layar TV ke LCD"
 msgid "Close"
 msgstr "Tutup"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Tutup PiP saat keluar"
 
 msgid "Close title selection"
@@ -1989,7 +1989,7 @@ msgstr "Atur bagaimana kipas seharusnya berfungsi"
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Atur jika dan bagaimana ikon kripto akan ditampilkan pada daftar pemilihan kanal."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Atur jika dan berapa lama layanan terakhir pada PiP akan diingat."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2097,8 +2097,8 @@ msgstr "Atur bahasa audio keempat."
 msgid "Configure the fourth subtitle language."
 msgstr "Atur bahasa terjemahan keempat."
 
-msgid "Configure the function of the '0' button do when PIP is active."
-msgstr "Atur fungsi tombol '0' ketika PIP sedang aktif."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
+msgstr "Atur fungsi tombol '0' ketika PiP sedang aktif."
 
 msgid "Configure the gateway."
 msgstr "Atur gateway."
@@ -4467,7 +4467,7 @@ msgstr "Sertakan ECM pada streaming http"
 msgid "Include EIT in http streams"
 msgstr "Sertakan EIT pada streaming http"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Jenis layanan tidak benar pada PiP!"
 
 msgid "Increased voltage"
@@ -5214,8 +5214,8 @@ msgstr "Mount"
 msgid "Move"
 msgstr "Pindah"
 
-msgid "Move PIP"
-msgstr "Pindahkan PIP"
+msgid "Move PiP"
+msgstr "Pindahkan PiP"
 
 msgid "Move PiP to main picture"
 msgstr "Pindahkan PiP ke gambar utama"
@@ -7990,8 +7990,8 @@ msgstr "Tampilkan permainan"
 msgid "Show InfoBar"
 msgstr "Tampilkan Bilah info"
 
-msgid "Show PIP"
-msgstr "Tampilkan PIP"
+msgid "Show PiP"
+msgstr "Tampilkan PiP"
 
 msgid "Show SNR percentage instead of dB value"
 msgstr "Tampilkan persentase SNR ketimbang nilai dB"
@@ -8797,8 +8797,8 @@ msgstr "Nama kanal"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
-msgstr "Tukar PIP"
+msgid "Swap PiP"
+msgstr "Tukar PiP"
 
 msgid "Swap PiP and main picture"
 msgstr "Tukarkan PiP dan gambar utama"
@@ -9519,7 +9519,7 @@ msgstr "Alihkan In HDMI"
 msgid "Toggle LCD LiveTV"
 msgstr "Alihkan LiveTV LCD"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr "Alihkan PIPzap"
 
 msgid "Toggle TV/RADIO mode"
@@ -10349,7 +10349,7 @@ msgstr "Jenis pelacakan layanan apa yg anda inginkan?"
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Ketika diaktifkan enigma2 akan memuat buket pengguna yg tak terhubung. Ini berarti bahwa buket pengguna yg tersedia, tapi tidak disertakan dalam file bouquets.tv atau bouquets.radio, akan tetap dimuat. Ini memungkinkan anda misalnya untuk menyimpan buket pengguna anda sendiri sementara pengaturan yg terpasang sedang ditingkatkan"
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Ketika diaktifkan, PiP bisa ditutup dengan tombol keluar (exit)."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10915,7 +10915,7 @@ msgid "Zap up"
 msgstr "Zap atas"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr "Zap ke layanan pewaktu %s sebagai PiP!"
 
 #, fuzzy, python-format

--- a/po/is.po
+++ b/po/is.po
@@ -1503,7 +1503,7 @@ msgstr "Byrjunar tími"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr ""
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Virkun 0 hnapps í PiP-ham"
 
 msgid "Behavior when a movie is started"
@@ -1977,7 +1977,7 @@ msgstr ""
 msgid "Close"
 msgstr "Loka"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr ""
 
 msgid "Close title selection"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr ""
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr ""
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2233,7 +2233,7 @@ msgstr ""
 msgid "Configure the fourth subtitle language."
 msgstr "skipta á næsta undirtexta"
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr ""
 
 #, fuzzy
@@ -4805,7 +4805,7 @@ msgstr ""
 msgid "Include EIT in http streams"
 msgstr ""
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr ""
 
 #
@@ -5686,7 +5686,7 @@ msgstr ""
 msgid "Move"
 msgstr ""
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr ""
 
 #
@@ -8890,7 +8890,7 @@ msgstr ""
 msgid "Show InfoBar"
 msgstr ""
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr ""
 
 msgid "Show SNR percentage instead of dB value"
@@ -9823,7 +9823,7 @@ msgstr "Leita að rásum"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr ""
 
 #
@@ -10615,7 +10615,7 @@ msgstr ""
 msgid "Toggle LCD LiveTV"
 msgstr ""
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr ""
 
 msgid "Toggle TV/RADIO mode"
@@ -11548,7 +11548,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr ""
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -12111,7 +12111,7 @@ msgid "Zap up"
 msgstr ""
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #

--- a/po/it.po
+++ b/po/it.po
@@ -1377,7 +1377,7 @@ msgstr "Ora inizio"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr "Azione del tasto 'Pausa e OK' durante lo stato di pausa"
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Funzione del tasto 0 in modalità PIP"
 
 msgid "Behavior when a movie is started"
@@ -1827,7 +1827,7 @@ msgstr "Modalità di clonazione dello schermo TV sul display LCD"
 msgid "Close"
 msgstr "Chiudere"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Chiudere il PIP con tasto EXIT"
 
 msgid "Close title selection"
@@ -1955,7 +1955,7 @@ msgstr "Impostare il funzionamento della ventola"
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Impostare se e come visualizzare le icone di trasmissione codificata nella lista di selezione dei canali."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Impostare se e per quanto tempo deve essere ricordato l'ultimo canale del PIP."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2063,7 +2063,7 @@ msgstr "Impostare la quarta lingua audio."
 msgid "Configure the fourth subtitle language."
 msgstr "Impostare la quarta lingua sottotitoli."
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr "Impostare la funzione associata al tasto \"0\" quando il PIP è attivo."
 
 msgid "Configure the gateway."
@@ -4363,7 +4363,7 @@ msgstr "Includere ECM nei flussi http"
 msgid "Include EIT in http streams"
 msgstr "Includere EIT nei flussi http"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Canale di tipo non idoneo per il PIP!"
 
 msgid "Increased voltage"
@@ -5091,7 +5091,7 @@ msgstr "Montare"
 msgid "Move"
 msgstr "Spostare"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr "Spostare il PIP"
 
 msgid "Move PiP to main picture"
@@ -7801,7 +7801,7 @@ msgstr "Show/Telequiz"
 msgid "Show InfoBar"
 msgstr "Mostrare l'infobar"
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr "Mostrare il PIP"
 
 msgid "Show SNR percentage instead of dB value"
@@ -8593,7 +8593,7 @@ msgstr "Suriname"
 msgid "Svalbard and Jan Mayen"
 msgstr "Svalbard e Jan Mayen"
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr "Scambiare il canale PIP"
 
 msgid "Swap PiP and main picture"
@@ -9318,7 +9318,7 @@ msgstr "Attivare/disattivare l'ingresso HDMI"
 msgid "Toggle LCD LiveTV"
 msgstr "Attivare/disattivare la funzione LiveTV dell'LCD"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr "Attivare/disattivare il cambio canale nel PIP"
 
 msgid "Toggle TV/RADIO mode"
@@ -10129,7 +10129,7 @@ msgstr "Che tipo di scansione si desidera effettuare?"
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Se questa impostazione è attivata, Enigma2 caricherà anche tutti i bouquet disponibili ma non inclusi negli elenchi bouquet.tv o bouquet.radio. Questo consente ad esempio di conservare i propri bouquet personalizzati quando l'elenco canali viene aggiornato."
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Se questa impostazione è attivata, il PIP potrà essere chiuso tramite il tasto EXIT."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10684,7 +10684,7 @@ msgid "Zap up"
 msgstr "Passare al canale precedente"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr "Passato al canale del timer %s in modalità PiP!"
 
 #, python-format

--- a/po/ku.po
+++ b/po/ku.po
@@ -1380,8 +1380,8 @@ msgstr "zeman dest pédike"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr ""
 
-msgid "Behavior of 0 key in PiP-mode"
-msgstr "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
+msgstr "Behavior of '0' button in PiP mode"
 
 msgid "Behavior when a movie is started"
 msgstr "Behavior when a movie is started"
@@ -1838,7 +1838,7 @@ msgstr ""
 msgid "Close"
 msgstr "Veqeti"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr ""
 
 msgid "Close title selection"
@@ -1973,7 +1973,7 @@ msgstr ""
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr ""
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr ""
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2081,8 +2081,8 @@ msgstr "Configure the fourth audio language."
 msgid "Configure the fourth subtitle language."
 msgstr "Configure the fourth subtitle language."
 
-msgid "Configure the function of the '0' button do when PIP is active."
-msgstr "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
+msgstr "Configure the function of the '0' button when Picture in Picture is active."
 
 msgid "Configure the gateway."
 msgstr "Configure the gateway."
@@ -4404,7 +4404,7 @@ msgstr "Include ECM in http streams"
 msgid "Include EIT in http streams"
 msgstr "Include EIT in http streams"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr ""
 
 msgid "Increased voltage"
@@ -5145,7 +5145,7 @@ msgstr "Mount"
 msgid "Move"
 msgstr "Move"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr ""
 
 msgid "Move PiP to main picture"
@@ -7913,7 +7913,7 @@ msgstr "Show Games show"
 msgid "Show InfoBar"
 msgstr ""
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr ""
 
 msgid "Show SNR percentage instead of dB value"
@@ -8720,7 +8720,7 @@ msgstr "Service name"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr ""
 
 msgid "Swap PiP and main picture"
@@ -9418,7 +9418,7 @@ msgstr ""
 msgid "Toggle LCD LiveTV"
 msgstr ""
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr ""
 
 msgid "Toggle TV/RADIO mode"
@@ -10239,7 +10239,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr ""
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10789,7 +10789,7 @@ msgid "Zap up"
 msgstr ""
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #, fuzzy, python-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -1377,7 +1377,7 @@ msgstr "Pradžios laikas"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr "'Pause' ir 'Ok' mygtukų elgsena pauzės metu"
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "'0' mygtuko elgsena PiP režime"
 
 msgid "Behavior when a movie is started"
@@ -1841,7 +1841,7 @@ msgstr "Dubliuoti TV vaizdą LCD ekrane"
 msgid "Close"
 msgstr "Užverti"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Išeinant užverti PiP"
 
 msgid "Close title selection"
@@ -1968,7 +1968,7 @@ msgstr "Nustatykite, kaip turi veikti aušintuvas"
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Nustatykite, ar ir kaip kanalų pasirinkimo sąrašo lange turi būti rodomos kodavimo piktogramos."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Nustatykite, ar ir kiek laiko turi būti įsimenamas paskutinis PiP lange rodytas kanalas."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2076,8 +2076,8 @@ msgstr "Nustatykite ketvirtą garso kalbą."
 msgid "Configure the fourth subtitle language."
 msgstr "Nustatykite ketvirtą subtitrų kalbą."
 
-msgid "Configure the function of the '0' button do when PIP is active."
-msgstr "Nustatykite kas vyks paspaudus '0' mygtuką, kai PIP aktyvuotas."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
+msgstr "Nustatykite kas vyks paspaudus '0' mygtuką, kai PiP aktyvuotas."
 
 msgid "Configure the gateway."
 msgstr "Nustatykite tinklo šliuzą."
@@ -4373,7 +4373,7 @@ msgstr "Įtraukti ECM į http srautus"
 msgid "Include EIT in http streams"
 msgstr "Įtraukti EIT į http srautus"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Kanalas netinkamas PiP!"
 
 msgid "Increased voltage"
@@ -5103,7 +5103,7 @@ msgstr "Prijungti"
 msgid "Move"
 msgstr "Perkelti"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr "Perkelti PiP"
 
 msgid "Move PiP to main picture"
@@ -7811,7 +7811,7 @@ msgstr "Rodyti žaidimų šou"
 msgid "Show InfoBar"
 msgstr "Rodyti info juostą"
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr "Rodyti PiP"
 
 msgid "Show SNR percentage instead of dB value"
@@ -8602,7 +8602,7 @@ msgstr "Surinamas"
 msgid "Svalbard and Jan Mayen"
 msgstr "Svalbardas ir Jan Majenas"
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr "Sukeisti PiP"
 
 msgid "Swap PiP and main picture"
@@ -9313,7 +9313,7 @@ msgstr "Perjungti HDMI įėjimą"
 msgid "Toggle LCD LiveTV"
 msgstr "Perjungti transliaciją į LCD"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr "Perjungti PiP jungimą"
 
 msgid "Toggle TV/RADIO mode"
@@ -10121,7 +10121,7 @@ msgstr "Kokio tipo kanalų nuskaitymo norite?"
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Kai čia įjungta enigma2 bus įkelti atsieti vartotojo paketai. Tai reiškia, kad vartotojo paketai, kurie yra prieinami, tačiau nėra įtraukti į paketai.tv ar paketai.radijas failus, vis tiek bus įkelti. Tai leidžia jums pvz. saugoti savo vartotojo paketus, o įdiegti nustatymai bus atnaujinti"
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Kai įjungta, PiP gali būti užvertas su exit mygtuku."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10678,7 +10678,7 @@ msgid "Zap up"
 msgstr "Perjungti aukštyn"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr "Perjungta į laikmačio kanalą %s kaip PiP!"
 
 #, python-format

--- a/po/lv.po
+++ b/po/lv.po
@@ -390,7 +390,7 @@ msgid "(VU+ type)"
 msgstr "(VU+ tips)"
 
 msgid "(ZAP as PiP)"
-msgstr "(PĀRSLĒGT kā PIP)"
+msgstr "(PĀRSLĒGT kā PiP)"
 
 msgid "(ZAP)"
 msgstr "(PĀRSLĒGT)"
@@ -1388,7 +1388,7 @@ msgstr "Sākuma laiks"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr "Taustiņu 'pauze un ok' darbība pauzē"
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "0 taustiņa nozīme PiP režīmā"
 
 msgid "Behavior when a movie is started"
@@ -1840,7 +1840,7 @@ msgstr "Dublēt TV attēlu uz LCD"
 msgid "Close"
 msgstr "Aizvērt"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Izejot aizvērt PiP"
 
 msgid "Close title selection"
@@ -1968,7 +1968,7 @@ msgstr "Uzstāda kā vadīt ventilatoru"
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Uzstāda vai un kā crypto ikona tiks attēlota kanālu sarakstā."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Uzstāda vai un cik ilgi atcerēsies pēdējo attēls attēlā kanālu."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2076,7 +2076,7 @@ msgstr "Uzstāda nākamo audio valodu."
 msgid "Configure the fourth subtitle language."
 msgstr "Uzstāda nākamo subtitru valodu."
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr "Uzstāda kādu funkciju veic taustiņš '0' ja PiP ir aktīvs."
 
 msgid "Configure the gateway."
@@ -4389,7 +4389,7 @@ msgstr "Ietvert ECM http plūsmās"
 msgid "Include EIT in http streams"
 msgstr "Ietvert EIT http plūsmās"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Nepareizs PiP kanāla veids!"
 
 msgid "Increased voltage"
@@ -5117,8 +5117,8 @@ msgstr "Montēt"
 msgid "Move"
 msgstr "Pārvietot"
 
-msgid "Move PIP"
-msgstr "Pārvietot PIP"
+msgid "Move PiP"
+msgstr "Pārvietot PiP"
 
 msgid "Move PiP to main picture"
 msgstr "Pārvietot PiP uz galveno attēlu"
@@ -7838,8 +7838,8 @@ msgstr "Rādīt Games show"
 msgid "Show InfoBar"
 msgstr "Rādīt infojoslu"
 
-msgid "Show PIP"
-msgstr "Rādīt PIP"
+msgid "Show PiP"
+msgstr "Rādīt PiP"
 
 msgid "Show SNR percentage instead of dB value"
 msgstr "Rādīt SNR procentos dB vietā"
@@ -8631,7 +8631,7 @@ msgstr "Surinama"
 msgid "Svalbard and Jan Mayen"
 msgstr "Svalbāra un Jana Majena"
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr "Mainīt PiP"
 
 msgid "Swap PiP and main picture"
@@ -9342,8 +9342,8 @@ msgstr "HDMI In"
 msgid "Toggle LCD LiveTV"
 msgstr "Pārslēgties uz LCD LiveTV"
 
-msgid "Toggle PIPzap"
-msgstr "Pārslēgties uz PIP"
+msgid "Toggle PiPzap"
+msgstr "Pārslēgties uz PiP"
 
 msgid "Toggle TV/RADIO mode"
 msgstr "Pārslēgt TV/RADIO režīmu"
@@ -10152,7 +10152,7 @@ msgstr "Kāda veida kanālu meklēšanu vēlaties veikt?"
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Ja ieslēgts, enigma ielādēs neiekļautās buķetes. Tas nozīmē ka buķetes tiek izmantotas, bet nav iekļautas bouquets.tv vai bouquets.radio failos. Tas atļauj saglabāt jūsu individuālās buķetes ja tiek atjaunoti uzstādījumi."
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Ja ieslēgts attēls attēlā, var aizvērt ar exit taustiņu."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10707,7 +10707,7 @@ msgid "Zap up"
 msgstr "Pārslēgt uz augšu"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr "Pārslēdz kā PiP uz taimera kanālu %s!"
 
 #, python-format

--- a/po/nb.po
+++ b/po/nb.po
@@ -1514,7 +1514,7 @@ msgid "Behavior of 'pause and ok' when paused"
 msgstr "Funksjon for 'pause og ok' når satt i pause"
 
 #
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Funksjon for 0 tast i PiP modus"
 
 msgid "Behavior when a movie is started"
@@ -2032,7 +2032,7 @@ msgstr "Klone TV skjerm til LCD modus"
 msgid "Close"
 msgstr "Lukk"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Slå av PiP (bilde i bilde) med exit tast"
 
 #
@@ -2182,7 +2182,7 @@ msgstr "Still inn valg for kjølevifte"
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Velg hvis du ønsker at krypteringsindikator skal vises i kanallisten."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Velg hvis du ønsker å lagre det siste brukte PiP (bilde i bilde) i minnet."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2292,7 +2292,7 @@ msgstr "Still inn fjerdevalg på lyd språk."
 msgid "Configure the fourth subtitle language."
 msgstr "Still inn fjerdevalg på undertekst språk."
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr "Still inn funksjonen for '0' tasten når PiP (bilde i bilde) er aktiv."
 
 msgid "Configure the gateway."
@@ -4832,7 +4832,7 @@ msgstr "Inkluder ECM i http stream"
 msgid "Include EIT in http streams"
 msgstr "Inkluder EIT i http stream"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Feil bruk av bilde i bilde!"
 
 #
@@ -5668,7 +5668,7 @@ msgstr "Monter"
 msgid "Move"
 msgstr "Kjør"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr "Flytt bilde i bilde"
 
 #
@@ -8700,7 +8700,7 @@ msgid "Show InfoBar"
 msgstr "Vis infobar"
 
 #
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr "Vis bilde i bilde"
 
 msgid "Show SNR percentage instead of dB value"
@@ -9586,7 +9586,7 @@ msgid "Svalbard and Jan Mayen"
 msgstr "Svalbard og Jan Mayen"
 
 #
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr "Bytt om bilde i bilde"
 
 #
@@ -10376,7 +10376,7 @@ msgstr "Veksle HDMI inn"
 msgid "Toggle LCD LiveTV"
 msgstr "Vis/Skjul LCD-LiveTV"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr "Vis/Skjul Bilde i bilde"
 
 msgid "Toggle TV/RADIO mode"
@@ -11270,7 +11270,7 @@ msgstr "Hvilken type kanalsøk vil du bruke?"
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Når dette er på, vil enigma2 laste kanallister som ikke er tilknyttet mottakeren. Dette betyr at kanallister som er tilgjengelige, men som ikke er tilknyttet radio eller TV filer fortsatt vil bli lastet. Dette gjør at du kan holde egne favorittlister mens installerte innstillinger er oppdatert"
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Når dette er på, kan PiP (bilde i bilde) avsluttes med exit knapp."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -11849,7 +11849,7 @@ msgid "Zap up"
 msgstr "Gå opp"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr "Timer skiftet til valgt kanal %s som bilde i bilde!"
 
 #

--- a/po/nl.po
+++ b/po/nl.po
@@ -1370,7 +1370,7 @@ msgstr "Starttijd"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr "Het gedrag van de 'pauze en ok toets' indien gepauzeerd"
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Functie van de 0-toets in de PIP-modus"
 
 msgid "Behavior when a movie is started"
@@ -1846,7 +1846,7 @@ msgstr "TV beeld op het LCD display weergeven."
 msgid "Close"
 msgstr "Sluiten"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Sluit de PIP met de toets 'exit'"
 
 msgid "Close title selection"
@@ -1998,7 +1998,7 @@ msgstr ""
 "\n"
 "U kunt kiezen uit, links of rechts van de zendernaam, of geen weergave."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr ""
 "Hiermee stelt u in of en hoe lang het laatste kanaal in de PIP wordt onthouden.\n"
 "\n"
@@ -2151,7 +2151,7 @@ msgstr "Stel de vierde audio taal in."
 msgid "Configure the fourth subtitle language."
 msgstr "Bepaal de vierde ondertitel taalselectie."
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr ""
 "Met deze optie stelt u de functie in van de '0' toets indien PIP actief is.\n"
 "\n"
@@ -4569,7 +4569,7 @@ msgstr "Neem ECM op in http streams"
 msgid "Include EIT in http streams"
 msgstr "Neem EIT op in http streams"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Onjuist service type voor PIP!"
 
 msgid "Increased voltage"
@@ -5296,7 +5296,7 @@ msgstr "Mount"
 msgid "Move"
 msgstr "Verplaats"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr "Verplaats PIP"
 
 msgid "Move PiP to main picture"
@@ -8048,7 +8048,7 @@ msgstr "Show/Quiz"
 msgid "Show InfoBar"
 msgstr "Toon de informatiebalk"
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr "Toon de PIP"
 
 msgid "Show SNR percentage instead of dB value"
@@ -8843,7 +8843,7 @@ msgstr "Suriname"
 msgid "Svalbard and Jan Mayen"
 msgstr "Spitsbergen en Jan Mayen"
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr "Wijzig PIP"
 
 msgid "Swap PiP and main picture"
@@ -9574,7 +9574,7 @@ msgstr "Activeer HDMI in"
 msgid "Toggle LCD LiveTV"
 msgstr "Activeer Live TV op het LCD display"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr "Activeer PIPzap"
 
 msgid "Toggle TV/RADIO mode"
@@ -10398,7 +10398,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Indien geactiveerd, dan zal Enigma de niet gelinkte zenderbouquetten laden. Dit houdt in, dat aanwezige gebruikerslijsten die niet aanwezig zijn in bouquets.tv of bouquets.radio alsnog geladen worden. Hiermee kunt u uw eigen wijzigingen in de zenderlijst behouden ondanks een mogelijke update van deze lijst. "
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr ""
 "Met deze optie stelt u in op welke wijze de PiP beëindigd kan worden met de exit knop.\n"
 "\n"
@@ -10981,7 +10981,7 @@ msgid "Zap up"
 msgstr "Zap omhoog"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr "Schakelde naar het timer kanaal %s als PIP!"
 
 #, python-format

--- a/po/nn.po
+++ b/po/nn.po
@@ -1490,7 +1490,7 @@ msgid "Behavior of 'pause and ok' when paused"
 msgstr ""
 
 #
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Innstilling for 0 knapp i PiP (bilde i bilde modus)"
 
 msgid "Behavior when a movie is started"
@@ -1994,7 +1994,7 @@ msgstr ""
 msgid "Close"
 msgstr "Lukke"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Slå av PiP (bilde i bilde) med exit knapp"
 
 #
@@ -2149,7 +2149,7 @@ msgstr ""
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr ""
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr ""
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2260,7 +2260,7 @@ msgstr "Still inn fjerdevalg på lyd språk."
 msgid "Configure the fourth subtitle language."
 msgstr "Still inn fjerdevalg på undertekst språk."
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr "Still inn funksjonen for '0' knappen når PiP (bilde i bilde) er aktiv."
 
 msgid "Configure the gateway."
@@ -4787,7 +4787,7 @@ msgstr "Inkludere ECM i http dataprotokoll"
 msgid "Include EIT in http streams"
 msgstr "Inkludere EIT i http dataprotokoll"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr ""
 
 #
@@ -5625,7 +5625,7 @@ msgstr "Montere"
 msgid "Move"
 msgstr "Kjøre"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr ""
 
 #
@@ -8641,7 +8641,7 @@ msgstr "Vis Games show"
 msgid "Show InfoBar"
 msgstr ""
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr ""
 
 msgid "Show SNR percentage instead of dB value"
@@ -9522,7 +9522,7 @@ msgstr "Kanalnavn"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr ""
 
 #
@@ -10287,7 +10287,7 @@ msgstr ""
 msgid "Toggle LCD LiveTV"
 msgstr ""
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr ""
 
 msgid "Toggle TV/RADIO mode"
@@ -11183,7 +11183,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Når dette er valgt, kan PiP (bilde i bilde) bli avsluttet med exit knappen."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -11758,7 +11758,7 @@ msgid "Zap up"
 msgstr ""
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #

--- a/po/pl.po
+++ b/po/pl.po
@@ -1381,7 +1381,7 @@ msgstr "Czas rozpoczęcia"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr "Zachowanie 'pauzy' i 'OK' gdy spauzowane"
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Zachowanie przycisku 0 w trybie PiP"
 
 msgid "Behavior when a movie is started"
@@ -1846,7 +1846,7 @@ msgstr "Klonuj obraz z TV na LCD"
 msgid "Close"
 msgstr "Zamknij"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Wyłączaj PiP klawiszem exit"
 
 msgid "Close title selection"
@@ -1974,7 +1974,7 @@ msgstr "Skonfiguruj tryb pracy wentylatora"
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Skonfiguruj czy i jak wyświetlać w liście ikony informujące o tym, że kanał jest kodowany."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Skonfiguruj czy, i jak długo, ma być pamiętany ostatni kanał wyświetlony w PiP."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2082,7 +2082,7 @@ msgstr "Skonfiguruj język czwartej ścieżki audio,"
 msgid "Configure the fourth subtitle language."
 msgstr "Skonfiguruj czwarty język napisów"
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr "Skonfiguruj zachowanie przycisku '0' gdy PiP jest aktywny. "
 
 msgid "Configure the gateway."
@@ -4383,7 +4383,7 @@ msgstr "ECMy w streamie http"
 msgid "Include EIT in http streams"
 msgstr "EIT w streamie http"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Typ serwisu nieobsługiwany w PiP!"
 
 msgid "Increased voltage"
@@ -5112,7 +5112,7 @@ msgstr "Podmontuj"
 msgid "Move"
 msgstr "Przenieś"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr "Przesuń PiP"
 
 msgid "Move PiP to main picture"
@@ -7825,7 +7825,7 @@ msgstr "Rozrywka"
 msgid "Show InfoBar"
 msgstr "Pokaż InfoBar"
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr "Pokaż PiP"
 
 msgid "Show SNR percentage instead of dB value"
@@ -8617,7 +8617,7 @@ msgstr "Surinam"
 msgid "Svalbard and Jan Mayen"
 msgstr "Svalbard i Jan Mayen"
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr "Zamień PiP"
 
 msgid "Swap PiP and main picture"
@@ -9330,7 +9330,7 @@ msgstr "Włączaj HDMI In"
 msgid "Toggle LCD LiveTV"
 msgstr "Włączaj TV na LCD"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr "Włączaj PiPzap"
 
 msgid "Toggle TV/RADIO mode"
@@ -10138,7 +10138,7 @@ msgstr "Jaki typ skanowania kanałów wybierasz?"
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Gdy włączone, system będzie ładować także niepodlinkowane bukiety. To oznacza, że bukiety użytkownika nie uwzględnione w  plikach bouquets.tv lub bouquets.radio nadal będą dostępne. To pozwala np. zachować własne bukiety, gdy lista zainstalowana z feedu jest aktualizowana"
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Gdy włączone, PiP może być wyłączony klawiszem exit"
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10693,7 +10693,7 @@ msgid "Zap up"
 msgstr "Przełącz na kanał wyżej"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr "Przełączono na kanał timera %s jako PiP!"
 
 #, python-format

--- a/po/pt.po
+++ b/po/pt.po
@@ -797,7 +797,7 @@ msgstr ""
 
 #
 msgid "Activate Picture in Picture"
-msgstr "Activar Picture-in-picture (PIP)"
+msgstr "Activar Picture-in-picture (PiP)"
 
 #
 #, fuzzy
@@ -1561,7 +1561,7 @@ msgid "Behavior of 'pause and ok' when paused"
 msgstr "Comportamento da 'PAUSA e OK' quando em paus"
 
 #
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Comportamento do botão 0 no modo PiP"
 
 #
@@ -2075,7 +2075,7 @@ msgstr ""
 msgid "Close"
 msgstr "Fechar"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Fechar PiP ao sair"
 
 #
@@ -2238,7 +2238,7 @@ msgstr "Configurar como o ventilador deve operar"
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Configurar como os ícones de criptografia serão exibidos na lista de selecção de canais."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Configurar como os últimos canais em PiP devem ser relembrados."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2357,7 +2357,7 @@ msgstr "Configurar o quarto idioma para o áudio."
 msgid "Configure the fourth subtitle language."
 msgstr "Configurar 0 quarto idioma para as legendas."
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr "Configurar a função do botão '0' quando o PiP está activo."
 
 #
@@ -4994,7 +4994,7 @@ msgstr "Incluir ECM nos Streams HTTP"
 msgid "Include EIT in http streams"
 msgstr "Incluir EIT nos Streams HTTP"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Serviço incorrecto para o Picture in Picture!"
 
 #
@@ -5884,7 +5884,7 @@ msgstr "Montagem"
 msgid "Move"
 msgstr "Mover"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr ""
 
 #
@@ -9144,7 +9144,7 @@ msgstr "Mostrar jogos"
 msgid "Show InfoBar"
 msgstr ""
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr ""
 
 msgid "Show SNR percentage instead of dB value"
@@ -10083,7 +10083,7 @@ msgstr "Nome do canal"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr ""
 
 #
@@ -10886,7 +10886,7 @@ msgstr ""
 msgid "Toggle LCD LiveTV"
 msgstr ""
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr ""
 
 msgid "Toggle TV/RADIO mode"
@@ -11854,7 +11854,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Quando activo o PiP pode ser fechado pelo botão EXIT."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -12442,7 +12442,7 @@ msgid "Zap up"
 msgstr ""
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #, fuzzy, python-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1373,7 +1373,7 @@ msgstr "Hora de início"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr ""
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Comportamento do botão 0 no modo PiP"
 
 msgid "Behavior when a movie is started"
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Close"
 msgstr "Fechar"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Fechar PiP ao sair"
 
 msgid "Close title selection"
@@ -1965,7 +1965,7 @@ msgstr ""
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Configurar se e como os ícones encriptados serão mostrados na seleção da lista de canal"
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr ""
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2073,7 +2073,7 @@ msgstr "Configurar o quarto idioma de áudio."
 msgid "Configure the fourth subtitle language."
 msgstr "Configurar o quarto idioma da legenda."
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr "Configurar a função do botão 0 quando o PiP está ativo."
 
 msgid "Configure the gateway."
@@ -4396,7 +4396,7 @@ msgstr "Incluir ECM nos streams HTTP"
 msgid "Include EIT in http streams"
 msgstr "Incluir EIT nos streams HTTP"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr ""
 
 msgid "Increased voltage"
@@ -5136,7 +5136,7 @@ msgstr "Montagem"
 msgid "Move"
 msgstr "Mover"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr ""
 
 msgid "Move PiP to main picture"
@@ -7905,7 +7905,7 @@ msgstr "Exibir Games Show"
 msgid "Show InfoBar"
 msgstr ""
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr ""
 
 msgid "Show SNR percentage instead of dB value"
@@ -8712,7 +8712,7 @@ msgstr "Serviço"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr ""
 
 msgid "Swap PiP and main picture"
@@ -9409,7 +9409,7 @@ msgstr ""
 msgid "Toggle LCD LiveTV"
 msgstr ""
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr ""
 
 msgid "Toggle TV/RADIO mode"
@@ -10232,7 +10232,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Quando ativado, o PiP pode ser fechado com o botão Sair."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10783,7 +10783,7 @@ msgid "Zap up"
 msgstr ""
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #, fuzzy, python-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -726,7 +726,7 @@ msgid "Activate HbbTV (Redbutton)"
 msgstr ""
 
 msgid "Activate Picture in Picture"
-msgstr "Activeaza PIP"
+msgstr "Activeaza PiP"
 
 #, fuzzy
 msgid "Activate current configuration"
@@ -1386,7 +1386,7 @@ msgstr "Momentul inceperii"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr ""
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Efectul butonului 0 in modul PiP (imagine in imagine)"
 
 msgid "Behavior when a movie is started"
@@ -1849,7 +1849,7 @@ msgstr ""
 msgid "Close"
 msgstr "Inchide"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr ""
 
 msgid "Close title selection"
@@ -1989,7 +1989,7 @@ msgstr ""
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr ""
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr ""
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2101,7 +2101,7 @@ msgstr ""
 msgid "Configure the fourth subtitle language."
 msgstr "mergi la urmatoarea limba pentru subtitrari"
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr ""
 
 msgid "Configure the gateway."
@@ -4463,7 +4463,7 @@ msgstr ""
 msgid "Include EIT in http streams"
 msgstr ""
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr ""
 
 msgid "Increased voltage"
@@ -5239,7 +5239,7 @@ msgstr ""
 msgid "Move"
 msgstr ""
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr ""
 
 #, fuzzy
@@ -8068,7 +8068,7 @@ msgstr ""
 msgid "Show InfoBar"
 msgstr ""
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr ""
 
 msgid "Show SNR percentage instead of dB value"
@@ -8902,7 +8902,7 @@ msgstr "Scanare Serviciu"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr ""
 
 #, fuzzy
@@ -9607,7 +9607,7 @@ msgstr ""
 msgid "Toggle LCD LiveTV"
 msgstr ""
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr ""
 
 msgid "Toggle TV/RADIO mode"
@@ -10439,7 +10439,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr ""
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10965,7 +10965,7 @@ msgid "Zap up"
 msgstr ""
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #, fuzzy, python-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -1380,7 +1380,7 @@ msgstr "Время начала"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr "Поведение 'пауза и ок' во время паузы"
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Поведение кнопки 0 в режиме PiP"
 
 msgid "Behavior when a movie is started"
@@ -1845,7 +1845,7 @@ msgstr "Клон ТВ экрана на LCD режим"
 msgid "Close"
 msgstr "Закрыть"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Закрывать PiP кнопкой exit"
 
 msgid "Close title selection"
@@ -1973,7 +1973,7 @@ msgstr "Настройка режимов работы вентилятора."
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Настройка иконок для кодированных сервисов в списке выбора каналов."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Настройка - запомнить и на какой период времени последний сервис PiP."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2081,7 +2081,7 @@ msgstr "Настройка четвертого языка аудио."
 msgid "Configure the fourth subtitle language."
 msgstr "Настройка четвертого языка субтитров."
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr "Настройка функции кнопки '0' , если  PiP активирован."
 
 msgid "Configure the gateway."
@@ -4384,7 +4384,7 @@ msgstr "Включать ECM в http стрим потоки"
 msgid "Include EIT in http streams"
 msgstr "Включать EIT в http стрим потоки"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Некорректный тип сервиса для PiP!"
 
 msgid "Increased voltage"
@@ -5111,7 +5111,7 @@ msgstr "Монтирование"
 msgid "Move"
 msgstr "Перемещение"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr "Изменить PiP"
 
 msgid "Move PiP to main picture"
@@ -7828,7 +7828,7 @@ msgstr "Показ игровых шоу"
 msgid "Show InfoBar"
 msgstr "Показать инфобар"
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr "Показать PiP"
 
 msgid "Show SNR percentage instead of dB value"
@@ -8620,7 +8620,7 @@ msgstr "Suriname"
 msgid "Svalbard and Jan Mayen"
 msgstr "Svalbard and Jan Mayen"
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr "Поменять PiP"
 
 msgid "Swap PiP and main picture"
@@ -9328,7 +9328,7 @@ msgstr "Смена HDMI In"
 msgid "Toggle LCD LiveTV"
 msgstr "Смена LCD LiveTV"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr "Смена Pipzap"
 
 msgid "Toggle TV/RADIO mode"
@@ -10136,7 +10136,7 @@ msgstr "Какой тип сканирования Вы хотите выбра�
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Если это включено, то при старте энигма2 будут загружены доступные букеты, которые не включены в списки bouquets.tv или bouquets.radio."
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Если включено, то можно закрыть экран PiP с помощью кнопки выход."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10690,7 +10690,7 @@ msgid "Zap up"
 msgstr "Переключить канал вверх"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr "Таймер - переключено на сервис %s как PiP!"
 
 #, python-format

--- a/po/sk.po
+++ b/po/sk.po
@@ -1381,7 +1381,7 @@ msgstr "Čas začiatku"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr "Funkcia tlačidiel Pauza a OK počas pauzy"
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Funkcia tlačidla 0 v režime Obraz v obraze (PiP)"
 
 msgid "Behavior when a movie is started"
@@ -1846,7 +1846,7 @@ msgstr "Klonovať TV obraz na režim LCD"
 msgid "Close"
 msgstr "Zatvoriť"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Zatvoriť PiP pri stlačení Exit"
 
 msgid "Close title selection"
@@ -1974,7 +1974,7 @@ msgstr "Nastaviť režim ventilátora"
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Nastaviť či a ako sa majú zobrazovať icony kódovania v zozname staníc."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Nastaviť či a ako dlho bude posledná stanica zapamätaná v PiP."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2082,7 +2082,7 @@ msgstr "Štvrtý jazyk audio stopy."
 msgid "Configure the fourth subtitle language."
 msgstr "Štvrtý jazyk titulkov."
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr "Vyberte funkciu tlačidla \"0\" , pri aktívnom PiP."
 
 msgid "Configure the gateway."
@@ -4383,7 +4383,7 @@ msgstr "Zahrnúť ECM do http streamov"
 msgid "Include EIT in http streams"
 msgstr "Zahrnúť EIT (EPG) do http streamov"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Nesprávny typ služby pre PiP!"
 
 msgid "Increased voltage"
@@ -5112,7 +5112,7 @@ msgstr "Prípojný bod"
 msgid "Move"
 msgstr "Premiestniť"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr "Premiestniť PiP"
 
 msgid "Move PiP to main picture"
@@ -7823,7 +7823,7 @@ msgstr "Zobraziť prehliadku hier"
 msgid "Show InfoBar"
 msgstr "Zobraziť informačný panel"
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr "Zobraziť PiP"
 
 msgid "Show SNR percentage instead of dB value"
@@ -8615,7 +8615,7 @@ msgstr "Surinam"
 msgid "Svalbard and Jan Mayen"
 msgstr "Svalbard a Jan Mayen"
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr "Prehodiť PiP"
 
 msgid "Swap PiP and main picture"
@@ -9328,7 +9328,7 @@ msgstr "Prepnúť HDMI vstup"
 msgid "Toggle LCD LiveTV"
 msgstr "Prepnúť LCD LiveTV"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr "Prepnúť PiP prepínanie"
 
 msgid "Toggle TV/RADIO mode"
@@ -10134,7 +10134,7 @@ msgstr "Aký typ staníc chcete prehľadať?"
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Ak je povolené, enigma2 načíta neprepojené užívateľské prehľady. To znamená, že užívateľské prehľady, ktoré sú k dispozícii, ale nie sú zahrnuté v bouquets.tv alebo bouquets.radio súboroch sa aj napriek tomu načítajú. To Vám umožňuje napríklad zachovať Vaše vlastné užívateľské prehľady po inštalácii a inovácii nastavení. "
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Ak povolené, PiP môže byť ukončený tlačidlom EXIT."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10689,7 +10689,7 @@ msgid "Zap up"
 msgstr "Prepnút dopredu"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr "Program %s prepnutý časovačom do PiP!"
 
 #, python-format

--- a/po/sl.po
+++ b/po/sl.po
@@ -1592,7 +1592,7 @@ msgid "Behavior of 'pause and ok' when paused"
 msgstr "Obnašanje tipk \"premor\" in \"premor\" ob pavzi"
 
 #
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Odziv tipke \"0\" v načinu \"Slika v sliki\""
 
 #
@@ -2109,7 +2109,7 @@ msgid "Close"
 msgstr "Izhod"
 
 #
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Zaprtje načina \"Slika v sliki\" s pritiskom tipke \"izhod\""
 
 #
@@ -2266,7 +2266,7 @@ msgstr "Nastavitev načina delovanja ventilatorja"
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Določitev morebitnega prikaza in na kakšen način naj se prikazujejo kripto ikone v seznamu kanalov."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Določitev vklopa nastavitve in kako dolgo naj si sprejemnik zapomni zadnji gledani kanal v načinu \"Slika v sliki\"."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2380,7 +2380,7 @@ msgstr "Določitev četrte zvočne sledi."
 msgid "Configure the fourth subtitle language."
 msgstr "Nastavitev četrtega jezika podnapisov."
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr "Določitev funkcije tipke \"0\", ko je aktivna funkcija \"Slika v sliki\"."
 
 #
@@ -5036,7 +5036,7 @@ msgstr "Prisotnost ECM paketkov v HTTP toku"
 msgid "Include EIT in http streams"
 msgstr "Prisotnost EIT podatkov v HTTP toku"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Napačna vrsta kanala za način \"Slika v sliki\"!"
 
 #
@@ -5897,7 +5897,7 @@ msgstr "Pripenjanje"
 msgid "Move"
 msgstr "Premik"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr ""
 
 #
@@ -9124,7 +9124,7 @@ msgstr ""
 msgid "Show InfoBar"
 msgstr "Prikaz info. vrstice"
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr "Prikaži Sliko v sliki"
 
 msgid "Show SNR percentage instead of dB value"
@@ -10066,7 +10066,7 @@ msgstr "Ime kanala"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr ""
 
 #
@@ -10846,7 +10846,7 @@ msgstr ""
 msgid "Toggle LCD LiveTV"
 msgstr ""
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr ""
 
 msgid "Toggle TV/RADIO mode"
@@ -11790,7 +11790,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Če je nastavitev vključena, potem se funkcija \"Slika v sliki\" izklopi s pritiskom na tipko \"izhod\"."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -12376,7 +12376,7 @@ msgid "Zap up"
 msgstr "Preklop gor"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #

--- a/po/sr.po
+++ b/po/sr.po
@@ -1584,7 +1584,7 @@ msgid "Behavior of 'pause and ok' when paused"
 msgstr ""
 
 #
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Uloga tipke 0 u SuS-modu"
 
 #
@@ -2102,7 +2102,7 @@ msgstr ""
 msgid "Close"
 msgstr "Zatvori"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr ""
 
 #
@@ -2265,7 +2265,7 @@ msgstr ""
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr ""
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr ""
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2385,7 +2385,7 @@ msgstr ""
 msgid "Configure the fourth subtitle language."
 msgstr "Prebaci na sledeći jezik titla"
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr ""
 
 #
@@ -5039,7 +5039,7 @@ msgstr ""
 msgid "Include EIT in http streams"
 msgstr ""
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr ""
 
 #
@@ -5934,7 +5934,7 @@ msgstr ""
 msgid "Move"
 msgstr ""
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr ""
 
 #
@@ -9189,7 +9189,7 @@ msgstr ""
 msgid "Show InfoBar"
 msgstr ""
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr ""
 
 msgid "Show SNR percentage instead of dB value"
@@ -10132,7 +10132,7 @@ msgstr "Skeniranje Kanala"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr ""
 
 #
@@ -10931,7 +10931,7 @@ msgstr ""
 msgid "Toggle LCD LiveTV"
 msgstr ""
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr ""
 
 msgid "Toggle TV/RADIO mode"
@@ -11879,7 +11879,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr ""
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -12451,7 +12451,7 @@ msgid "Zap up"
 msgstr ""
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #

--- a/po/sv.po
+++ b/po/sv.po
@@ -1545,7 +1545,7 @@ msgid "Behavior of 'pause and ok' when paused"
 msgstr "Beteende av 'paus och OK' vid pausad"
 
 #
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Beteende av '0' knappen i BiB-läge"
 
 #
@@ -2057,7 +2057,7 @@ msgstr "Klona TV skärm till LCD"
 msgid "Close"
 msgstr "Stäng"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Avsluta BiB med exitknappen"
 
 #
@@ -2213,7 +2213,7 @@ msgstr "Konfigurera hur fläkten skall fungera."
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Konfigurera om och hur krypteringsikoner skall visas i kanallistan."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Konfigurera om och hur länge den senaste kanalen i BiB skall kommas ihåg."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2327,7 +2327,7 @@ msgstr "Konfigurera det fjärde ljudspråket."
 msgid "Configure the fourth subtitle language."
 msgstr "Konfigurera det fjärde undertextspråket."
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr "Konfigurera beteendet på '0' knappen när BiB är aktiv."
 
 #
@@ -4929,7 +4929,7 @@ msgstr "Inkludera ECM i http strömmar"
 msgid "Include EIT in http streams"
 msgstr "Inkludera EIT i http strömmar"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Felaktig kanal för BiB!"
 
 #
@@ -5781,7 +5781,7 @@ msgstr "Montera"
 msgid "Move"
 msgstr "Flytta"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr "Flytta BiB"
 
 #
@@ -8931,7 +8931,7 @@ msgstr "Visa Spel show"
 msgid "Show InfoBar"
 msgstr "Visa infobalk"
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr "Visa BiB"
 
 msgid "Show SNR percentage instead of dB value"
@@ -9834,7 +9834,7 @@ msgstr "Kanalnamn"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr "Skifta BiB"
 
 #
@@ -10651,7 +10651,7 @@ msgstr "Växla HDMI In"
 msgid "Toggle LCD LiveTV"
 msgstr "Växla LCD direktsänd TV"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr "Växla BiBzapp"
 
 msgid "Toggle TV/RADIO mode"
@@ -11590,7 +11590,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Vid aktiverad laddar enigma2 olänkade favoritlistor. Detta innebär att favoritlistor som är tillgängliga men som inte ingår i bouquet.tv eller bouquet.radio filer kommer fortfarande laddas. Detta gör att du till exempel kan behålla dina egna favoritlistor medan installerade inställningar uppdateras."
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Vid aktiverad kan BiB stängas med exitknappen."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -12188,7 +12188,7 @@ msgid "Zap up"
 msgstr "Zappa upp"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #, fuzzy, python-format

--- a/po/th.po
+++ b/po/th.po
@@ -1395,7 +1395,7 @@ msgstr "เวลาเริ่ม"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr ""
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "เมื่อกด 0 ใน PiP ให้"
 
 msgid "Behavior when a movie is started"
@@ -1860,7 +1860,7 @@ msgstr ""
 msgid "Close"
 msgstr "ปิด"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr ""
 
 msgid "Close title selection"
@@ -2000,7 +2000,7 @@ msgstr ""
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr ""
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr ""
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2113,7 +2113,7 @@ msgstr ""
 msgid "Configure the fourth subtitle language."
 msgstr "เลือกซับไตเติ้ลต่อไป"
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr ""
 
 #, fuzzy
@@ -4486,7 +4486,7 @@ msgstr ""
 msgid "Include EIT in http streams"
 msgstr ""
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr ""
 
 msgid "Increased voltage"
@@ -5265,12 +5265,12 @@ msgstr ""
 msgid "Move"
 msgstr ""
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr ""
 
 #, fuzzy
 msgid "Move PiP to main picture"
-msgstr "สลับให้ PIP เต็มจอ"
+msgstr "สลับให้ PiP เต็มจอ"
 
 msgid "Move Picture in Picture"
 msgstr "ย้ายภาพซ้อนภาพ"
@@ -6062,7 +6062,7 @@ msgstr ""
 
 #, fuzzy
 msgid "PiP setup"
-msgstr "ตั้งค่า PIP"
+msgstr "ตั้งค่า PiP"
 
 msgid "Picon"
 msgstr ""
@@ -8107,7 +8107,7 @@ msgstr ""
 msgid "Show InfoBar"
 msgstr ""
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr ""
 
 msgid "Show SNR percentage instead of dB value"
@@ -8945,7 +8945,7 @@ msgstr "ค้นหาบริการ"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr ""
 
 #, fuzzy
@@ -9653,7 +9653,7 @@ msgstr ""
 msgid "Toggle LCD LiveTV"
 msgstr ""
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr ""
 
 msgid "Toggle TV/RADIO mode"
@@ -10485,7 +10485,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr ""
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -11019,7 +11019,7 @@ msgid "Zap up"
 msgstr ""
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #, fuzzy, python-format

--- a/po/tr.po
+++ b/po/tr.po
@@ -1376,7 +1376,7 @@ msgstr "Başlama zamanı"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr "Durdurulduğunda 'Dur ve OK' davranışı"
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "RiR kipinde 0 tuşu görevi"
 
 msgid "Behavior when a movie is started"
@@ -1835,7 +1835,7 @@ msgstr "TV ekranını LCD ye yansıt"
 msgid "Close"
 msgstr "Kapat"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "RiR Kapat ve Çık"
 
 msgid "Close title selection"
@@ -1970,7 +1970,7 @@ msgstr "Fanın nasıl çalışması gerektiğini yapılandırın"
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Şİfreli Kanal simgesinin kanal listesinde görünme şekli"
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "En son uzun süre bakılan RiR servisini hatırlama ayarı. "
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2078,7 +2078,7 @@ msgstr "Dördüncü ses dilini yapılandırın."
 msgid "Configure the fourth subtitle language."
 msgstr "Dördüncü altyazı dili yapılandırın."
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr "RiR aktif olduğunda '0 'düğmesinin işlevini yapılandırın."
 
 msgid "Configure the gateway."
@@ -4427,7 +4427,7 @@ msgstr "http akışlarında ECM dahil"
 msgid "Include EIT in http streams"
 msgstr "http akışlarında EIT dahil"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "RiR için geçersiz servis!"
 
 msgid "Increased voltage"
@@ -5166,7 +5166,7 @@ msgstr "Bağla"
 msgid "Move"
 msgstr "Taşı"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr "RiR Taşı"
 
 msgid "Move PiP to main picture"
@@ -7941,7 +7941,7 @@ msgstr "Gösteri Oyunlarını göster"
 msgid "Show InfoBar"
 msgstr "Bilgi Çubuğunu Göster"
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr "RiR Göster"
 
 msgid "Show SNR percentage instead of dB value"
@@ -8747,7 +8747,7 @@ msgstr "Kanal adı"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr "RiR Değiştir"
 
 msgid "Swap PiP and main picture"
@@ -9464,7 +9464,7 @@ msgstr "HDMI girişini değiştir"
 msgid "Toggle LCD LiveTV"
 msgstr "LCD LiveTV"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr "RiRzap"
 
 msgid "Toggle TV/RADIO mode"
@@ -10291,7 +10291,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Ne zaman enigma2 etkin bağlantısız buket yükleyecektir. Bu, mevcut değil, fakat bouquets.tv ya bouquets.radio dosyaları dahil değildir userbouquets zaten yüklü olacağı anlamına gelir. Yüklü ayarlar yükseltilmiş ise bu kendi kullanıcı buket tutmak için örneğin yapmanızı sağlar"
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Etkin olduğunda RiR çıkış düğmesi ile kapatılabilir."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10842,7 +10842,7 @@ msgid "Zap up"
 msgstr "Zap Yukarı"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #, fuzzy, python-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -1397,7 +1397,7 @@ msgstr "Час початку"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr "Поведінка \" паузи і OK ' під час паузи"
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Поведінка кнопки 0 в режимі PiP"
 
 msgid "Behavior when a movie is started"
@@ -1859,7 +1859,7 @@ msgstr "Клон телевізор з плоским екраном на LCD"
 msgid "Close"
 msgstr "Закрити"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Закрити PiP кнопкою вихід"
 
 msgid "Close title selection"
@@ -1994,7 +1994,7 @@ msgstr "Налаштування вентилятора "
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Налаштувати , де і як крипто іконки будуть відображатися в списку каналів"
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Налаштування, коли і як довго останній канал в PiP пам'ятатимуть"
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2104,8 +2104,8 @@ msgstr "Налаштування четвертої мови Аудіо."
 msgid "Configure the fourth subtitle language."
 msgstr "Налаштування четвертої мови субтитрів."
 
-msgid "Configure the function of the '0' button do when PIP is active."
-msgstr "Налаштуйте функцію кнопки '0 'коли вікно PIP активно."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
+msgstr "Налаштуйте функцію кнопки '0 'коли вікно PiP активно."
 
 msgid "Configure the gateway."
 msgstr "Ви можете налаштувати шлюз."
@@ -4461,7 +4461,7 @@ msgstr "Вмикати ECM в http стрім"
 msgid "Include EIT in http streams"
 msgstr "Вмикати EIT в http стрім"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Неправильне обслуговування типу для PiP!"
 
 msgid "Increased voltage"
@@ -5211,8 +5211,8 @@ msgstr "Перегляд підключень"
 msgid "Move"
 msgstr "Переміщення"
 
-msgid "Move PIP"
-msgstr "Перемістити PIP"
+msgid "Move PiP"
+msgstr "Перемістити PiP"
 
 msgid "Move PiP to main picture"
 msgstr "Перемістити PiP на основний екран"
@@ -7974,7 +7974,7 @@ msgstr "Коротка назва"
 
 #, fuzzy
 msgid "Show"
-msgstr "Показати PIP"
+msgstr "Показати PiP"
 
 msgid "Show Audioselection"
 msgstr "Показувати вибір Аудіо"
@@ -7997,8 +7997,8 @@ msgstr "Показ ігрових шоу"
 msgid "Show InfoBar"
 msgstr "Показати Інфобар"
 
-msgid "Show PIP"
-msgstr "Показати PIP"
+msgid "Show PiP"
+msgstr "Показати PiP"
 
 msgid "Show SNR percentage instead of dB value"
 msgstr "Показати відсотки SNR замість значення dB в інфобарі"
@@ -8806,7 +8806,7 @@ msgstr "Назва сервісу"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr "Підкачка PiP"
 
 msgid "Swap PiP and main picture"
@@ -9547,7 +9547,7 @@ msgstr "Перемикання HDMI В"
 msgid "Toggle LCD LiveTV"
 msgstr "Перемкнути LCD LiveTV"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr "Переключити PIPzap"
 
 msgid "Toggle TV/RADIO mode"
@@ -10380,7 +10380,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Якщо включено, то будуть загружатися невибрані букети користувача. Це означає, букети існують, но не були включені в файли bouquets.tv або bouquets.radio. Це дасть Вам застосувати свій власний букет в існуючий список букетів"
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Якщо увімкнено, то можна закрити екран PiP за допомогою кнопки вихід."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10958,7 +10958,7 @@ msgid "Zap up"
 msgstr "Перемкнути канал вгору"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #, fuzzy, python-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -1366,7 +1366,7 @@ msgstr "Thời gian bắt đầu"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr "Hành vi của 'tạm dừng và ok' khi tạm dừng"
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "Hành vi của phím 0 trong chế độ PiP"
 
 msgid "Behavior when a movie is started"
@@ -1831,7 +1831,7 @@ msgstr "Sao chép màn hình TV sang chế độ LCD"
 msgid "Close"
 msgstr "Đóng"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "Đóng PiP khi thoát"
 
 msgid "Close title selection"
@@ -1959,7 +1959,7 @@ msgstr "Cấu hình cách quạt hoạt động"
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr "Định cấu hình nếu và cách các biểu tượng tiền điện tử sẽ được hiển thị trong danh sách chọn kênh."
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr "Định cấu hình nếu và bao lâu dịch vụ mới nhất trong PiP sẽ được ghi nhớ."
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2067,8 +2067,8 @@ msgstr "Cấu hình ngôn ngữ âm thanh thứ tư."
 msgid "Configure the fourth subtitle language."
 msgstr "Cấu hình ngôn ngữ phụ đề thứ tư."
 
-msgid "Configure the function of the '0' button do when PIP is active."
-msgstr "Định cấu hình chức năng của nút '0' khi PIP hoạt động."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
+msgstr "Định cấu hình chức năng của nút '0' khi PiP hoạt động."
 
 msgid "Configure the gateway."
 msgstr "Cấu hình cổng."
@@ -4367,7 +4367,7 @@ msgstr "Bao gồm ECM trong luồng http"
 msgid "Include EIT in http streams"
 msgstr "Bao gồm thuế TNDN trong các luồng http"
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr "Loại dịch vụ không chính xác cho PiP!"
 
 msgid "Increased voltage"
@@ -5094,8 +5094,8 @@ msgstr "Núi"
 msgid "Move"
 msgstr "Di chuyển"
 
-msgid "Move PIP"
-msgstr "Di chuyển PIP"
+msgid "Move PiP"
+msgstr "Di chuyển PiP"
 
 msgid "Move PiP to main picture"
 msgstr "Di chuyển PiP sang hình ảnh chính"
@@ -7804,8 +7804,8 @@ msgstr "Chương trình trò chơi"
 msgid "Show InfoBar"
 msgstr "Hiển thị thông tin"
 
-msgid "Show PIP"
-msgstr "Hiển thị PIP"
+msgid "Show PiP"
+msgstr "Hiển thị PiP"
 
 msgid "Show SNR percentage instead of dB value"
 msgstr "Hiển thị phần trăm SNR thay vì giá trị dB"
@@ -8596,8 +8596,8 @@ msgstr "Xuameame"
 msgid "Svalbard and Jan Mayen"
 msgstr "Svalbard và Jan Mayen"
 
-msgid "Swap PIP"
-msgstr "Hoán đổi PIP"
+msgid "Swap PiP"
+msgstr "Hoán đổi PiP"
 
 msgid "Swap PiP and main picture"
 msgstr "Hoán đổi PiP và hình ảnh chính"
@@ -9306,7 +9306,7 @@ msgstr "Chuyển đổi HDMI trong"
 msgid "Toggle LCD LiveTV"
 msgstr "Chuyển đổi LCD LiveTV"
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr "Chuyển đổi PIPzap"
 
 msgid "Toggle TV/RADIO mode"
@@ -10113,7 +10113,7 @@ msgstr "Bạn muốn loại dịch vụ quét nào?"
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr "Khi được bật enigma2 sẽ tải các tập tin người dùng không liên kết. Điều này có nghĩa là các userbouquets có sẵn, nhưng không được bao gồm trong các tập tin bouquets.tv hoặc bouquets.radio, vẫn sẽ được tải. Điều này cho phép bạn lấy ví dụ để giữ bó hoa người dùng của riêng bạn trong khi cài đặt được cài đặt được nâng cấp"
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr "Khi được bật, PiP có thể được đóng bằng nút thoát."
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10666,7 +10666,7 @@ msgid "Zap up"
 msgstr "Chuyển lên"
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr "Được chuyển sang dịch vụ hẹn giờ%s dưới dạng PiP!"
 
 #, python-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1354,7 +1354,7 @@ msgstr "开始时间"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr ""
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "按 0 键启用画中画模式"
 
 msgid "Behavior when a movie is started"
@@ -1812,7 +1812,7 @@ msgstr ""
 msgid "Close"
 msgstr "关闭"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr "结束时关闭画中画"
 
 msgid "Close title selection"
@@ -1946,7 +1946,7 @@ msgstr ""
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr ""
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr ""
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2054,7 +2054,7 @@ msgstr ""
 msgid "Configure the fourth subtitle language."
 msgstr ""
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr ""
 
 msgid "Configure the gateway."
@@ -4362,7 +4362,7 @@ msgstr ""
 msgid "Include EIT in http streams"
 msgstr ""
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr ""
 
 msgid "Increased voltage"
@@ -5102,7 +5102,7 @@ msgstr "挂载"
 msgid "Move"
 msgstr "移动"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr ""
 
 msgid "Move PiP to main picture"
@@ -7862,7 +7862,7 @@ msgstr ""
 msgid "Show InfoBar"
 msgstr ""
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr ""
 
 msgid "Show SNR percentage instead of dB value"
@@ -8661,7 +8661,7 @@ msgstr "文件名"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr ""
 
 msgid "Swap PiP and main picture"
@@ -9329,7 +9329,7 @@ msgstr ""
 msgid "Toggle LCD LiveTV"
 msgstr ""
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr ""
 
 msgid "Toggle TV/RADIO mode"
@@ -10130,7 +10130,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr ""
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10659,7 +10659,7 @@ msgid "Zap up"
 msgstr ""
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #, python-format

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -1352,7 +1352,7 @@ msgstr "開始時間"
 msgid "Behavior of 'pause and ok' when paused"
 msgstr ""
 
-msgid "Behavior of 0 key in PiP-mode"
+msgid "Behavior of '0' button in PiP mode"
 msgstr "按 0 鍵啟用畫中畫模式"
 
 msgid "Behavior when a movie is started"
@@ -1812,7 +1812,7 @@ msgstr "螢幕左移"
 msgid "Close"
 msgstr "關閉"
 
-msgid "Close PiP on exit"
+msgid "Close PiP with 'exit' button"
 msgstr ""
 
 msgid "Close title selection"
@@ -1946,7 +1946,7 @@ msgstr ""
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
 msgstr ""
 
-msgid "Configure if and how long the latest service in the PiP will be remembered."
+msgid "Configure if and how long the latest service in Picture in Picture mode will be remembered."
 msgstr ""
 
 msgid "Configure if and how service type icons will be shown in the channel selection list."
@@ -2054,7 +2054,7 @@ msgstr ""
 msgid "Configure the fourth subtitle language."
 msgstr ""
 
-msgid "Configure the function of the '0' button do when PIP is active."
+msgid "Configure the function of the '0' button when Picture in Picture is active."
 msgstr ""
 
 msgid "Configure the gateway."
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Include EIT in http streams"
 msgstr ""
 
-msgid "Incorrect type service for PiP!"
+msgid "Incorrect service type for Picture in Picture!"
 msgstr ""
 
 msgid "Increased voltage"
@@ -5100,7 +5100,7 @@ msgstr "安裝(Mount)"
 msgid "Move"
 msgstr "移動"
 
-msgid "Move PIP"
+msgid "Move PiP"
 msgstr ""
 
 msgid "Move PiP to main picture"
@@ -7864,7 +7864,7 @@ msgstr ""
 msgid "Show InfoBar"
 msgstr ""
 
-msgid "Show PIP"
+msgid "Show PiP"
 msgstr ""
 
 msgid "Show SNR percentage instead of dB value"
@@ -8667,7 +8667,7 @@ msgstr "重命名"
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-msgid "Swap PIP"
+msgid "Swap PiP"
 msgstr ""
 
 msgid "Swap PiP and main picture"
@@ -9338,7 +9338,7 @@ msgstr ""
 msgid "Toggle LCD LiveTV"
 msgstr ""
 
-msgid "Toggle PIPzap"
+msgid "Toggle PiPzap"
 msgstr ""
 
 msgid "Toggle TV/RADIO mode"
@@ -10137,7 +10137,7 @@ msgstr ""
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are updated"
 msgstr ""
 
-msgid "When enabled the PiP can be closed by the exit button."
+msgid "When enabled the Picture in Picture window can be closed with 'exit' button."
 msgstr ""
 
 msgid "When enabled the arrow buttons around the OK button will follow the 'neutrino' style zap controls instead of the enigma2 style."
@@ -10665,7 +10665,7 @@ msgid "Zap up"
 msgstr ""
 
 #, python-format
-msgid "Zapped to timer service %s as PiP!"
+msgid "Zapped to timer service %s as Picture in Picture!"
 msgstr ""
 
 #, fuzzy, python-format


### PR DESCRIPTION
Strings containing "PIP" were renamed to "PiP" and some of the strings containing "PiP" were renamed to "Picture in Picture" as discussed in https://github.com/OpenPLi/enigma2/issues/2380
All existing translations were kept intact or were updated.

Also some goofed English were corrected.