### PR TITLE
[Timezones.py] More changes for legacy support

### DIFF
--- a/lib/python/Components/Timezones.py
+++ b/lib/python/Components/Timezones.py
@@ -45,7 +45,8 @@ from Tools.StbHardware import setRTCoffset
 # DEFAULT_AREA = "Classic"  # Use the classic timezone based list of timezones.
 # DEFAULT_AREA = "Australia"  # Beyonwiz
 DEFAULT_AREA = "Europe"  # OpenATV, OpenPLi, OpenViX
-DEFAULT_ZONE = "Berlin"  # OpenATV, OpenPLi
+DEFAULT_ZONE = "Amsterdam"  # OpenPLi
+# DEFAULT_ZONE = "Berlin"  # OpenATV
 # DEFAULT_ZONE = "London"  # OpenViX
 TIMEZONE_FILE = "/etc/timezone.xml"  # This should be SCOPE_TIMEZONES_FILE!  This file moves arond the filesystem!!!  :(
 TIMEZONE_DATA = "/usr/share/zoneinfo/"  # This should be SCOPE_TIMEZONES_DATA!
@@ -64,13 +65,35 @@ def InitTimeZones():
 	elif DEFAULT_AREA == "Classic":
 		area = "Classic"
 		zone = tz
-		print "[Timezones] Classic mode with geolocation tz='%s', area='%s', zone='%s'." % (tz, area, zone)
+		print "[Timezones] Classic mode with geolocation tz='%s'.  (area='%s', zone='%s')" % (tz, area, zone)
 	else:
 		area, zone = tz.split("/", 1)
-		print "[Timezones] Modern mode with geolocation tz='%s', area='%s', zone='%s'." % (tz, area, zone)
+		print "[Timezones] Modern mode with geolocation tz='%s'.  (area='%s', zone='%s')" % (tz, area, zone)
 	config.timezone = ConfigSubsection()
 	config.timezone.area = ConfigSelection(default=area, choices=timezones.getTimezoneAreaList())
 	config.timezone.val = ConfigSelection(default=timezones.getTimezoneDefault(), choices=timezones.getTimezoneList())
+	if not config.timezone.area.value and config.timezone.val.value.find("/") == -1:
+		config.timezone.area.value = "Generic"
+	try:
+		tzLink = path.realpath("/etc/localtime")[20:]
+		tzSplit = tzLink.find("/")
+		if tzSplit == -1:
+			tzArea = "Generic"
+			tzVal = tzLink
+		else:
+			tzArea = tzLink[:tzSplit]
+			tzVal = tzLink[tzSplit + 1:]
+		msgs = []
+		if config.timezone.area.value != tzArea:
+			msgs.append("area '%s' != '%s'" % (tzArea, config.timezone.area.value))
+			config.timezone.area.value = tzArea
+		if config.timezone.val.value != tzVal:
+			msgs.append("zone '%s' != '%s'" % (tzVal, config.timezone.val.value))
+			config.timezone.val.value = tzVal
+		if len(msgs):
+			print "[Timezones] Warning: System timezone does not match Enigma2 timezone (%s), setting Enigma2 to system timezone!" % ",".join(msgs)
+	except (IOError, OSError):
+		pass
 
 	def timezoneAreaChoices(configElement):
 		choices = timezones.getTimezoneList(area=configElement.value)


### PR DESCRIPTION
- Add a new DEFAULT_ZONE = "Amsterdam" for OpenPLi.
- Load and use the timezone in "/etc/localtime" if it differs from the timezone defined in Enigma2.  A warning is logged if the timezones differ.
- Improve some of the logging messages.
