### PR TITLE
[Converter/ConditionalShowHide] Allow ConditionalShowHide to work in …

### DIFF
--- a/lib/python/Components/Converter/ConditionalShowHide.py
+++ b/lib/python/Components/Converter/ConditionalShowHide.py
@@ -14,6 +14,10 @@ class ConditionalShowHide(Converter, object):
 		else:
 			self.timer = None
 
+	# Make ConditionalShowHide transparent to upstream attribute requests
+	def __getattr__(self, name):
+		return getattr(self.source, name)
+
 	def blinkFunc(self):
 		if self.blinking:
 			for x in self.downstream_elements:
@@ -47,6 +51,7 @@ class ConditionalShowHide(Converter, object):
 		else:
 			for x in self.downstream_elements:
 				x.visible = vis
+		super(Converter, self).changed(what)
 
 	def connectDownstream(self, downstream):
 		Converter.connectDownstream(self, downstream)


### PR DESCRIPTION
…renderers that currently don't support it

e.g. render=Label".

This means we can now super-impose a text over a background colour and have the colour disappear if no text is present in the text field.

<widget source="key_yellow" render="Label" objectTypes="key_yellow,StaticText" position="710,686" size="240,25" zPosition="1" font="Regular;20" halign="left" transparent="0" valign="center" noWrap="1" foregroundColor="menu-buttons-frgrnd" backgroundColor="green">
	<convert type="ConditionalShowHide"/>
</widget>

Before this commit ConditionalShowHide didn't work. If screen was drawn with no text in the field the screen failed to display any widgets after that point.

Author: @prl001