### PR TITLE
[Geolocation] Do not return Lat/Long and IP details

### DIFF
--- a/lib/python/Tools/Geolocation.py
+++ b/lib/python/Tools/Geolocation.py
@@ -47,7 +47,7 @@ def InitGeolocation():
 	if config.misc.enableGeolocation.value:
 		if len(geolocation) == 0:
 			try:
-				response = urlopen("http://ip-api.com/json/?fields=33288191", data=None, timeout=10).read()
+				response = urlopen("http://ip-api.com/json/?fields=33279807", data=None, timeout=10).read()
 				# print "[Geolocation] DEBUG:", response
 				if response:
 					geolocation = loads(response)


### PR DESCRIPTION
Timezone lookup will still work.

Returned data will be:

```
status	"success"
continent	"Europe"
continentCode	"EU"
country	"United Kingdom"
countryCode	"GB"
region	"ENG"
regionName	"England"
city	"xxxxx"
district	""
zip	"xxxxx"
timezone	"Europe/London"
currency	"GBP"
isp	"xxxxx"
org	""
as	"xxxxx"
asname	"xxxxx"
mobile	false
proxy	false
hosting	false
```

Querying with 29016351 returns following

```
status	"success"
continent	"Europe"
continentCode	"EU"
country	"United Kingdom"
countryCode	"GB"
region	"ENG"
regionName	"England"
city	"xxxxx"
district	""
timezone	"Europe/London"
currency	"GBP"
proxy	false
hosting	false
```
