### PR TITLE
Include CI assignment - support two modules

### DIFF
--- a/Navigation.py
+++ b/Navigation.py
@@ -5,6 +5,7 @@ from Components.SystemInfo import SystemInfo
 from Components.config import config, configfile
 from Tools.BoundFunction import boundFunction
 from Tools.StbHardware import getFPWasTimerWakeup
+from Tools.Alternatives import ResolveCiAlternative
 from Tools import Notifications
 from time import time
 import RecordTimer
@@ -91,17 +92,11 @@ class Navigation:
 		if not checkParentalControl or parentalControl.isServicePlayable(ref, boundFunction(self.playService, checkParentalControl=False, forceRestart=forceRestart, adjust=adjust)):
 			if ref.flags & eServiceReference.isGroup:
 				oldref = self.currentlyPlayingServiceReference or eServiceReference()
-				if config.misc.use_ci_assignment.value:
-					def ResolveCiAlternative(ref):
-						serviceList = self.ServiceHandler and self.ServiceHandler.list(ref)
-						if serviceList:
-							for service in serviceList.getContent("R"):
-								if isPlayableForCur(service):
-									return service
-						return None
-					playref = ResolveCiAlternative(ref)
-				else:
-					playref = getBestPlayableServiceReference(ref, oldref)
+				playref = getBestPlayableServiceReference(ref, oldref)
+				if playref and config.misc.use_ci_assignment.value and not isPlayableForCur(playref):
+					alternative_ci_ref = ResolveCiAlternative(ref, playref)
+					if alternative_ci_ref:
+						playref = alternative_ci_ref
 				print "[Navigation] alternative ref: ", playref and playref.toString()
 				if playref and oldref and playref == oldref and not forceRestart:
 					print "[Navigation] ignore request to play already running service(2)"

--- a/RecordTimer.py
+++ b/RecordTimer.py
@@ -13,11 +13,13 @@ import Screens.InfoBar
 import Components.ParentalControl
 from Tools import Directories, Notifications, ASCIItranslit, Trashcan
 from Tools.XMLTools import stringToXML
+from Tools.Alternatives import ResolveCiAlternative
+from Tools.CIHelper import cihelper
 
 import timer
 import xml.etree.cElementTree
 import NavigationInstance
-from ServiceReference import ServiceReference
+from ServiceReference import ServiceReference, isPlayableForCur
 
 from time import localtime, strftime, ctime, time
 from bisect import insort
@@ -165,6 +167,7 @@ class RecordTimerEntry(timer.TimerEntry, object):
 		self.disabled = disabled
 		self.timer = None
 		self.__record_service = None
+		self.rec_ref = None
 		self.start_prepare = 0
 		self.justplay = justplay
 		self.always_zap = always_zap
@@ -264,6 +267,37 @@ class RecordTimerEntry(timer.TimerEntry, object):
 				if not rec_ref:
 					self.log(1, "'get best playable service for group... record' failed")
 					return False
+			if rec_ref and config.misc.use_ci_assignment.value and not (self.record_ecm and not self.descramble):
+				current_ref = NavigationInstance.instance.getCurrentlyPlayingServiceReference()
+				is_playable = isPlayableForCur(rec_ref)
+				if current_ref and current_ref != rec_ref:
+					cur_assignment = cihelper.ServiceIsAssigned(current_ref.toString())
+					rec_assignment = cihelper.ServiceIsAssigned(rec_ref.toString())
+					live_ci_ref = (cur_assignment and rec_assignment and cur_assignment[0] == rec_assignment[0]) and cur_assignment
+				else:
+					live_ci_ref = False
+				if live_ci_ref or not is_playable:
+					start_zap = record_ecm_notdescramble = False
+					if self.service_ref.ref.flags & eServiceReference.isGroup:
+						alternative_ci_ref = ResolveCiAlternative(self.service_ref.ref, ignore_ref = not is_playable and rec_ref, record_mode = live_ci_ref)
+						if alternative_ci_ref:
+							rec_ref = alternative_ci_ref
+						elif live_ci_ref and is_playable:
+							start_zap = True
+						elif not is_playable:
+							record_ecm_notdescramble = True
+					elif live_ci_ref and is_playable:
+						start_zap = True
+					elif not is_playable:
+						record_ecm_notdescramble = True
+					if record_ecm_notdescramble:
+						self.record_ecm = True
+						self.descramble = False
+					if start_zap:
+						self.log(1, "zapping in CI+ use")
+						NavigationInstance.instance.playService(rec_ref)
+						Notifications.AddNotification(MessageBox, _("In order to record a timer, the TV was switched to the recording service!\n"), type=MessageBox.TYPE_INFO, timeout=20)
+			self.log(1, "'record ref' %s" % rec_ref and rec_ref.toString())
 			self.setRecordingPreferredTuner()
 			self.record_service = rec_ref and NavigationInstance.instance.recordService(rec_ref)
 
@@ -272,11 +306,13 @@ class RecordTimerEntry(timer.TimerEntry, object):
 				self.setRecordingPreferredTuner(setdefault=True)
 				return False
 
+			self.rec_ref = rec_ref
+
 			name = self.name
 			description = self.description
 			if self.repeated:
 				epgcache = eEPGCache.getInstance()
-				queryTime=self.begin+(self.end-self.begin)/2
+				queryTime = self.begin+(self.end-self.begin)/2
 				evt = epgcache.lookupEventTime(rec_ref, queryTime)
 				if evt:
 					if self.rename_repeat:
@@ -300,7 +336,7 @@ class RecordTimerEntry(timer.TimerEntry, object):
 				if event_id is None:
 					event_id = -1
 
-			prep_res=self.record_service.prepare(self.Filename + self.record_service.getFilenameExtension(), self.begin, self.end, event_id, name.replace("\n", ""), description.replace("\n", ""), ' '.join(self.tags), bool(self.descramble), bool(self.record_ecm))
+			prep_res = self.record_service.prepare(self.Filename + self.record_service.getFilenameExtension(), self.begin, self.end, event_id, name.replace("\n", ""), description.replace("\n", ""), ' '.join(self.tags), bool(self.descramble), bool(self.record_ecm))
 			if prep_res:
 				if prep_res == -255:
 					self.log(4, "failed to write meta information")
@@ -314,6 +350,7 @@ class RecordTimerEntry(timer.TimerEntry, object):
 
 				NavigationInstance.instance.stopRecordService(self.record_service)
 				self.record_service = None
+				self.rec_ref = None
 				self.setRecordingPreferredTuner(setdefault=True)
 				return False
 			return True
@@ -337,7 +374,7 @@ class RecordTimerEntry(timer.TimerEntry, object):
 		next_state = self.state + 1
 		self.log(5, "activating state %d" % next_state)
 
-		if next_state == 1:
+		if next_state == self.StatePrepared:
 			if self.always_zap:
 				if Screens.Standby.inStandby:
 					self.log(5, "wakeup and zap to recording service")
@@ -362,7 +399,6 @@ class RecordTimerEntry(timer.TimerEntry, object):
 							self.failureCB(True)
 							self.log(5, "zap to recording service")
 
-		if next_state == self.StatePrepared:
 			if self.tryPrepare():
 				self.log(6, "prepare ok, waiting for begin")
 				# create file to "reserve" the filename
@@ -492,6 +528,7 @@ class RecordTimerEntry(timer.TimerEntry, object):
 			if not self.justplay:
 				NavigationInstance.instance.stopRecordService(self.record_service)
 				self.record_service = None
+				self.rec_ref = None
 			if not checkForRecordings():
 				if self.afterEvent == AFTEREVENT.DEEPSTANDBY or self.afterEvent == AFTEREVENT.AUTO and (Screens.Standby.inStandby or RecordTimerEntry.wasInStandby) and not config.misc.standbyCounter.value:
 					if not Screens.Standby.inTryQuitMainloop:

--- a/lib/python/Components/TimerSanityCheck.py
+++ b/lib/python/Components/TimerSanityCheck.py
@@ -178,19 +178,18 @@ class TimerSanityCheck:
 		cnt = 0
 		idx = 0
 		overlaplist = []
-		is_ci_use = 0
-		is_ci_timer_conflict = 0
-
+		is_ci_timer_conflict = False
 		ci_timer = False
-		if config.misc.use_ci_assignment.value and cihelper.ServiceIsAssigned(self.newtimer.service_ref.ref, self.newtimer.state) and not (self.newtimer.record_ecm and not self.newtimer.descramble):
-			ci_timer = self.newtimer
-			ci_timer_begin = ci_timer.begin
-			ci_timer_end = ci_timer.end
-			ci_timer_dur = ci_timer_end - ci_timer_begin
-			ci_timer_events = []
-			for ev in self.nrep_eventlist:
-				if ev[2] == -1:
-					ci_timer_events.append((ev[0], ev[0] + ci_timer_dur))
+
+		if config.misc.use_ci_assignment.value and not (self.newtimer.record_ecm and not self.newtimer.descramble):
+			new_assignment = cihelper.ServiceIsAssigned(self.newtimer.service_ref.ref.toString(), self.newtimer)
+			if new_assignment:
+				ci_timer = self.newtimer
+				ci_timer_dur = ci_timer.end - ci_timer.begin
+				ci_timer_events = []
+				for ev in self.nrep_eventlist:
+					if ev[2] == -1:
+						ci_timer_events.append((ev[0], ev[0] + ci_timer_dur))
 
 		for event in self.nrep_eventlist:
 			cnt += event[1]
@@ -203,7 +202,13 @@ class TimerSanityCheck:
 				ref = timer.service_ref and timer.service_ref.ref
 				timer_ref = timer.service_ref
 				if ref and ref.flags & eServiceReference.isGroup and timer.isRunning():
-					timer_ref = getBestPlayableServiceReference(timer.service_ref.ref, eServiceReference())
+					alternativeref = None
+					if not timer.justplay:
+						alternativeref = hasattr(timer, "rec_ref") and timer.rec_ref
+						if alternativeref:
+							timer_ref = alternativeref
+					if not alternativeref:
+						timer_ref = getBestPlayableServiceReference(timer.service_ref.ref, eServiceReference())
 				fakeRecService = NavigationInstance.instance.recordService(timer_ref, True)
 				if fakeRecService:
 					fakeRecResult = fakeRecService.start(True)
@@ -256,28 +261,35 @@ class TimerSanityCheck:
 			else:
 				print "[TimerSanityCheck] bug: unknown flag!"
 
-			if ci_timer and timer != ci_timer and not is_ci_timer_conflict and cihelper.ServiceIsAssigned(timer.service_ref.ref, timer.state) and not (timer.record_ecm and not timer.descramble):
-				if event[1] == self.bflag:
-					timer_begin = event[0]
-					timer_end = event[0] + (timer.end - timer.begin)
-				else:
-					timer_end = event[0]
-					timer_begin = event[0] - (timer.end - timer.begin)
-				for ci_ev in ci_timer_events:
-					if (ci_ev[0] >= timer_begin and ci_ev[0] <= timer_end) or (ci_ev[1] >= timer_begin and ci_ev[1] <= timer_end):
-						if ci_timer.service_ref.ref != timer.service_ref.ref:
-							if cihelper.canMultiDescramble(timer.service_ref.ref, timer.state):
-								getUnsignedDataRef1 = ci_timer.service_ref.ref.getUnsignedData
-								getUnsignedDataRef2 = timer.service_ref.ref.getUnsignedData
-								for x in (4, 2, 3):
-									if getUnsignedDataRef1.getUnsignedData(x) != getUnsignedDataRef2.getUnsignedData(x):
-										is_ci_timer_conflict = 1
-							else:
-								is_ci_timer_conflict = 1
-							if is_ci_timer_conflict:
+			if ci_timer and timer != ci_timer and not is_ci_timer_conflict and not (timer.record_ecm and not timer.descramble):
+				is_assignment = cihelper.ServiceIsAssigned(timer.service_ref.ref.toString(), timer)
+				if is_assignment and new_assignment[0] == is_assignment[0]:
+					if event[1] == self.bflag:
+						timer_begin = event[0]
+						timer_end = event[0] + (timer.end - timer.begin)
+					else:
+						timer_end = event[0]
+						timer_begin = event[0] - (timer.end - timer.begin)
+					for ci_ev in ci_timer_events:
+						if (ci_ev[0] >= timer_begin and ci_ev[0] <= timer_end) or (ci_ev[1] >= timer_begin and ci_ev[1] <= timer_end):
+							timerstr = is_assignment[1] or timer.service_ref.ref.toString()
+							ci_timerstr = ci_timer.service_ref.ref.toString()
+							if ci_timerstr != timerstr:
+								is_ci_timer_conflict = True
 								break
-				if is_ci_timer_conflict == 1:
-					if ConflictTimer is None:
+								# "AlphaCrypt" multi descramble is exist?
+								#if not ci_timerstr.startswith('1:134:') and not timerstr.startswith('1:134:') and self.canMultiDescramble(timerstr):
+								#	eService = eServiceReference(timerstr)
+								#	eService1 = ci_timer.service_ref.ref
+								#	for x in (4, 2, 3):
+								#		if eService.getUnsignedData(x) != eService1.getUnsignedData(x):
+								#			is_ci_timer_conflict = True
+								#			break
+								#else:
+								#	is_ci_timer_conflict = True
+								#if is_ci_timer_conflict:
+								#	break
+					if is_ci_timer_conflict and ConflictTimer is None:
 						ConflictTimer = timer
 						ConflictTunerType = tunerType
 

--- a/lib/python/Tools/Alternatives.py
+++ b/lib/python/Tools/Alternatives.py
@@ -1,4 +1,7 @@
 from enigma import eServiceCenter, eServiceReference
+from Components.config import config
+from ServiceReference import isPlayableForCur
+from Tools.CIHelper import cihelper
 
 def getAlternativeChannels(service):
 	alternativeServices = eServiceCenter.getInstance().list(eServiceReference(service))
@@ -16,3 +19,69 @@ def GetWithAlternative(service):
 		if channels:
 			return channels[0]
 	return service
+
+def ResolveCiAlternative(ref, ignore_ref=None, record_mode=False):
+	if ref and isinstance(ref, eServiceReference):
+		if ref.flags & eServiceReference.isGroup:
+			serviceList = eServiceCenter.getInstance() and eServiceCenter.getInstance().list(ref)
+			prio_list = []
+			prio_val = int(config.usage.alternatives_priority.value)
+			if serviceList:
+				for service in serviceList.getContent("R"):
+					if not ignore_ref or service != ignore_ref:
+						refstr = service.toString()
+						def resolveRecordLiveMode():
+							if record_mode:
+								is_assignment = cihelper.ServiceIsAssigned(refstr)
+								if is_assignment and is_assignment[0] == record_mode[0]: 
+									return False
+							#	"AlphaCrypt" multi descramble is exist?
+							#	if not is_assignment or is_assignment[0] != record_mode[0]:
+							#		return True
+							#	elif is_assignment:
+							#		if cihelper.canMultiDescramble(refstr):
+							#			eService = eServiceReference(record_mode[1])
+							#			for x in (4, 2, 3):
+							#				if service.getUnsignedData(x) != eService.getUnsignedData(x):
+							#					return False
+							#		else:
+							#			return False
+							return True
+						if resolveRecordLiveMode() and (service.getPath() or isPlayableForCur(service)):
+							if prio_val == 127:
+								return service
+							else:
+								type = ("%3a//" in refstr and 4) or ('EEEE0000' in refstr and 2) or ('FFFF0000' in refstr and 3) or 1
+								prio_list.append((service, type))
+			num = len(prio_list)
+			if num == 1:
+				return prio_list[0][0]
+			elif num > 1:
+				prio_map = [(3, 2, 1),# -S -C -T
+							(3, 1, 2),# -S -T -C
+							(2, 3, 1),# -C -S -T
+							(1, 3, 2),# -C -T -S
+							(1, 2, 3),# -T -C -S
+							(2, 1, 3) # -T -S -C
+							]
+				cur = tmp = 0
+				stream_service = service = None
+				for x in prio_list:
+					if x[1] == 2:
+						tmp = prio_map[prio_val][2]
+					elif x[1] == 3:
+						tmp = prio_map[prio_val][1]
+					elif x[1] == 1:
+						tmp = prio_map[prio_val][0]
+					if tmp > cur:
+						cur = tmp
+						service = x[0]
+					if x[1] == 4 and not stream_service:
+						stream_service = x[0]
+				if cur > 0:
+					return service
+				if stream_service:
+					return stream_service
+		elif ref.getPath() or isPlayableForCur(ref):
+			return ref
+	return None

--- a/lib/python/Tools/CIHelper.py
+++ b/lib/python/Tools/CIHelper.py
@@ -1,8 +1,7 @@
 from xml.etree.cElementTree import parse
-from enigma import eDVBCIInterfaces, eDVBCI_UI, eEnv, eServiceCenter, eServiceReference, getBestPlayableServiceReference
-import NavigationInstance 
+from enigma import eDVBCIInterfaces, eDVBCI_UI, eEnv, eServiceCenter, eServiceReference, getBestPlayableServiceReference, iRecordableService 
 from Components.SystemInfo import SystemInfo
-from Tools.Alternatives import GetWithAlternative
+import NavigationInstance
 import os
 
 class CIHelper:
@@ -10,7 +9,8 @@ class CIHelper:
 	CI_ASSIGNMENT_LIST = None
 	CI_ASSIGNMENT_SERVICES_LIST = None
 	CI_MULTIDESCRAMBLE = None
-	CI_MULTIDESCRAMBLE_MODULES = ("AlphaCrypt", )
+	CI_RECORDS_LIST = None
+	CI_MULTIDESCRAMBLE_MODULES = ("AlphaCrypt",)
 
 	def parse_ci_assignment(self):
 		NUM_CI = SystemInfo["CommonInterface"]
@@ -33,48 +33,66 @@ class CIHelper:
 					usingcaid = []
 					for slot in tree.findall("slot"):
 						read_slot = getValue(slot.findall("id"), False).encode("UTF-8")
+						if read_slot is not False and self.CI_ASSIGNMENT_SERVICES_LIST is None:
+							self.CI_ASSIGNMENT_SERVICES_LIST = {}
 
 						for caid in slot.findall("caid"):
 							read_caid = caid.get("id").encode("UTF-8")
-							usingcaid.append(long(read_caid,16))
+							usingcaid.append(long(read_caid, 16))
 
 						for service in slot.findall("service"):
 							read_service_ref = service.get("ref").encode("UTF-8")
-							read_services.append (read_service_ref)
+							read_services.append(read_service_ref)
+							if read_slot is not False and not self.CI_ASSIGNMENT_SERVICES_LIST.get(read_service_ref, False):
+								self.CI_ASSIGNMENT_SERVICES_LIST[read_service_ref] = read_slot
 
 						for provider in slot.findall("provider"):
 							read_provider_name = provider.get("name").encode("UTF-8")
 							read_provider_dvbname = provider.get("dvbnamespace").encode("UTF-8")
-							read_providers.append((read_provider_name,long(read_provider_dvbname,16)))
+							read_providers.append((read_provider_name, long(read_provider_dvbname, 16)))
+							if read_slot is not False:
+								provider_services_refs = self.getProivderServices([read_provider_name])
+								if provider_services_refs:
+									for ref in provider_services_refs:
+										if not self.CI_ASSIGNMENT_SERVICES_LIST.get(ref, False):
+											self.CI_ASSIGNMENT_SERVICES_LIST[ref] = read_slot
+
 						if read_slot is not False and (read_services or read_providers or usingcaid):
 							self.CI_ASSIGNMENT_LIST.append((int(read_slot), (read_services, read_providers, usingcaid)))
 				except:
-					print "[CI_ASSIGNMENT %d] error parsing xml..." % ci
+					print "[CI_ASSIGNMENT %d] ERROR parsing xml..." % ci
 					try:
 						os.remove(filename)
 					except:
-						print "[CI_ASSIGNMENT %d] error remove damaged xml..." % ci
+						print "[CI_ASSIGNMENT %d] ERROR remove damaged xml..." % ci
+			if self.CI_ASSIGNMENT_LIST:
+				for item in self.CI_ASSIGNMENT_LIST:
+					try:
+						eDVBCIInterfaces.getInstance().setDescrambleRules(item[0],item[1])
+						print "[CI_ASSIGNMENT %d] activate with following settings" % item[0]
+					except:
+						print "[CI_ASSIGNMENT %d] ERROR setting DescrambleRules" % item[0]
 
-			services = []
-			providers = []
-			for item in self.CI_ASSIGNMENT_LIST:
-				print "[CI_Activate] activate CI%d with following settings:" % item[0]
-				try:
-					eDVBCIInterfaces.getInstance().setDescrambleRules(item[0],item[1])
-				except:
-					print "[CI_Activate_Config_CI%d] error setting DescrambleRules..." %item[0]
-				for x in item[1][0]:
-					services.append(x)
-				for x in item[1][1]:
-					providers.append(x[0])
-			service_refs = []
-			if len(services):
-				for x in services:
-					service_refs.append(eServiceReference(x))
-			provider_services_refs = []
-			if len(providers):
-				provider_services_refs = self.getProivderServices(providers)
-			self.CI_ASSIGNMENT_SERVICES_LIST = [service_refs, provider_services_refs]
+	def ciRecordEvent(self, service, event):
+		if event in (iRecordableService.evEnd, iRecordableService.evStart, None):
+			self.CI_RECORDS_LIST = []
+			if NavigationInstance.instance.getRecordings():
+				for timer in NavigationInstance.instance.RecordTimer.timer_list:
+					if not timer.justplay and timer.state in (1, 2) and timer.record_service and not (timer.record_ecm and not timer.descramble):
+						if timer.service_ref.ref.flags & eServiceReference.isGroup:
+							timerservice = hasattr(timer, "rec_ref") and timer.rec_ref
+							if not timerservice:
+								timerservice = getBestPlayableServiceReference(timer.service_ref.ref, eServiceReference())
+						else:
+							timerservice = timer.service_ref.ref
+						if timerservice:
+							timerstr = timerservice.toString()
+							is_assignment = self.ServiceIsAssigned(timerstr)
+							if is_assignment:
+								if is_assignment[0] not in self.CI_RECORDS_LIST:
+									self.CI_RECORDS_LIST.insert(0, is_assignment[0])
+								if is_assignment not in self.CI_RECORDS_LIST:
+									self.CI_RECORDS_LIST.append(is_assignment)
 
 	def load_ci_assignment(self, force=False):
 		if self.CI_ASSIGNMENT_LIST is None or force:
@@ -85,7 +103,7 @@ class CIHelper:
 		if len(providers):
 			serviceHandler = eServiceCenter.getInstance()
 			for x in providers:
-				refstr = '1:7:0:0:0:0:0:0:0:0:(provider == "%s") && (type == 1) || (type == 17) || (type == 22) || (type == 25) || (type == 31) || (type == 134) || (type == 195) ORDER BY name:%s' % (x,x)
+				refstr = '1:7:0:0:0:0:0:0:0:0:(provider == "%s") && (type == 1) || (type == 17) || (type == 22) || (type == 25) || (type == 31) || (type == 134) || (type == 195) ORDER BY name:%s' % (x, x)
 				myref = eServiceReference(refstr)
 				servicelist = serviceHandler.list(myref)
 				if not servicelist is None:
@@ -93,41 +111,57 @@ class CIHelper:
 						service = servicelist.getNext()
 						if not service.valid():
 							break
-						provider_services_refs.append(service)
+						provider_services_refs.append(service.toString())
 		return provider_services_refs
 
-	def ServiceIsAssigned(self, ref, timer_state=None):
-		self.load_ci_assignment()
-		ref = self.resolveAlternate(ref, timer_state)
-		if ref and self.CI_ASSIGNMENT_SERVICES_LIST:
-			for x in self.CI_ASSIGNMENT_SERVICES_LIST:
-				if len(x) and ref in x:
-					return True
+	def ServiceIsAssigned(self, ref, timer=None): 
+		if self.CI_ASSIGNMENT_SERVICES_LIST is not None:
+			if self.CI_RECORDS_LIST is None and NavigationInstance.instance:
+				NavigationInstance.instance.record_event.append(self.ciRecordEvent)
+				self.ciRecordEvent(None, None)
+			if ref and ref.startswith('1:134:'):
+				if timer:
+					if timer.state == 2 and not timer.justplay:
+						ref = hasattr(timer, "rec_ref") and timer.rec_ref and timer.rec_ref.toString()
+					else:
+						alternativeServices = eServiceCenter.getInstance().list(eServiceReference(ref))
+						if alternativeServices:
+							count = 0
+							is_ci_service = 0
+							ci_slot = []
+							for service in alternativeServices.getContent("S", True):
+								count += 1
+								is_assignment = self.CI_ASSIGNMENT_SERVICES_LIST.get(service, False)
+								if is_assignment:
+									is_ci_service += 1
+									if is_assignment not in ci_slot:
+										ci_slot.append(is_assignment)
+										if len(ci_slot) > 1:
+											return False
+							if ci_slot and count == is_ci_service:
+								return (ci_slot[0], "")
+						return False
+				else:
+					return False
+			if ref:
+				is_assignment = self.CI_ASSIGNMENT_SERVICES_LIST.get(ref, False)
+				return is_assignment and (is_assignment, ref) or False
 		return False
 
-	def resolveAlternate(self, ref, timer_state=None):
-		if ref and timer_state is not None and ref.flags & eServiceReference.isGroup:
-			if timer_state == 2:
-				ref = getBestPlayableServiceReference(ref, eServiceReference())
-			else:
-				ref = eServiceReference(GetWithAlternative(ref.toString()))
-		return ref
-
-	def canMultiDescramble(self, ref, timer_state=None):
+	def canMultiDescramble(self, ref):
 		if self.CI_MULTIDESCRAMBLE is None:
-			no_ci = SystemInfo["CommonInterface"]
-			if no_ci > 0:
+			num_ci = SystemInfo["CommonInterface"]
+			if num_ci > 0:
 				self.CI_MULTIDESCRAMBLE = False
-				for ci in range(no_ci):
+				for ci in range(num_ci):
 					appname = eDVBCI_UI.getInstance().getAppName(ci)
 					if appname in self.CI_MULTIDESCRAMBLE_MODULES:
 						self.CI_MULTIDESCRAMBLE = True
 		elif self.CI_MULTIDESCRAMBLE == False:
 			return False
-		ref = self.resolveAlternate(ref, timer_state)
 		if ref and self.CI_ASSIGNMENT_LIST is not None and len(self.CI_ASSIGNMENT_LIST):
 			for x in self.CI_ASSIGNMENT_LIST:
-				if ref.toString() in x[1][0]:
+				if ref in x[1][0]:
 					appname = eDVBCI_UI.getInstance().getAppName(x[0])
 					if appname in self.CI_MULTIDESCRAMBLE_MODULES:
 						return True
@@ -145,20 +179,21 @@ class CIHelper:
 		return False
 
 	def isPlayable(self, service):
-		service = eServiceReference(service)
-		if NavigationInstance.instance.getRecordings():
-			if self.ServiceIsAssigned(service):
-				for timer in NavigationInstance.instance.RecordTimer.timer_list:
-					if not timer.justplay and timer.isRunning() and not (timer.record_ecm and not timer.descramble):
-						timerservice = self.resolveAlternate(timer.service_ref.ref, timer.isRunning())
-						if timerservice and timerservice != service:
-							if self.ServiceIsAssigned(timerservice):
-								if self.canMultiDescramble(service):
-									for x in (4, 2, 3):
-										if timerservice.getUnsignedData(x) != service.getUnsignedData(x):
-											return 0
-								else:
-									return 0
+		is_assignment = self.ServiceIsAssigned(service)
+		if is_assignment and self.CI_RECORDS_LIST and is_assignment[0] in self.CI_RECORDS_LIST and is_assignment not in self.CI_RECORDS_LIST:
+			return 0
+			# "AlphaCrypt" multi descramble is exist?
+			#if self.canMultiDescramble(service):
+			#	for timerservice in self.CI_RECORDS_LIST:
+			#		if len(timerservice) > 1:
+			#			if timerservice[0] == is_assignment[0]:
+			#				eService = eServiceReference(timerservice[1])
+			#				eService1 = eServiceReference(service)
+			#				for x in (4, 2, 3):
+			#					if eService.getUnsignedData(x) != eService1.getUnsignedData(x):
+			#						return 0
+			#else:
+			#	return 0
 		return 1
 
 cihelper = CIHelper()


### PR DESCRIPTION
-[CIHelper] support more modules,optimized check for assigned service
-[Alternatives] added function to search for a free tuner for
alternative services with a setting "Alternative services tuner
priority"
-[RecordTimer] automatic search for a recording tuner when using CI
modules
-[Navigation] update play service for new  'Alternatives' function
-[TimerSanityCheck] update for new 'CIHelper' tools

Attention!
Checking multi-decoding modules is now disabled.At the moment, it’s only
"AlphaCrypt".
If this is still necessary, then several lines must be uncommented.