### PR TITLE
Zap timer - update when watching a video

### DIFF
--- a/lib/python/Plugins/Extensions/MediaPlayer/plugin.py
+++ b/lib/python/Plugins/Extensions/MediaPlayer/plugin.py
@@ -100,6 +100,7 @@ class MediaPlayer(Screen, InfoBarBase, InfoBarScreenSaver, InfoBarSeek, InfoBarA
 	ALLOW_SUSPEND = True
 	ENABLE_RESUME_SUPPORT = True
 	FLAG_CENTER_DVB_SUBS = 2048
+	media_instance =None
 
 	def __init__(self, session, args = None):
 		Screen.__init__(self, session)
@@ -113,6 +114,8 @@ class MediaPlayer(Screen, InfoBarBase, InfoBarScreenSaver, InfoBarSeek, InfoBarA
 		self.summary = None
 		self.oldService = self.session.nav.getCurrentlyPlayingServiceOrGroup()
 		self.session.nav.stopService()
+
+		MediaPlayer.media_instance = self
 
 		self.setTitle(_("Media player"))
 

--- a/lib/python/Screens/InfoBar.py
+++ b/lib/python/Screens/InfoBar.py
@@ -73,7 +73,7 @@ class InfoBar(InfoBarBase, InfoBarShowHide,
 				enigma.iPlayableService.evUpdatedEventInfo: self.__eventInfoChanged
 			})
 
-		self.current_begin_time=0
+		self.current_begin_time = 0
 		assert InfoBar.instance is None, "class InfoBar is a singleton class and just one instance of this class is allowed!"
 		InfoBar.instance = self
 
@@ -155,6 +155,7 @@ class MoviePlayer(InfoBarBase, InfoBarShowHide, InfoBarMenu, InfoBarSeek, InfoBa
 
 	ENABLE_RESUME_SUPPORT = True
 	ALLOW_SUSPEND = True
+	movie_instance = None
 
 	def __init__(self, session, service, slist=None, lastservice=None, infobar=None):
 		Screen.__init__(self, session)
@@ -192,6 +193,8 @@ class MoviePlayer(InfoBarBase, InfoBarShowHide, InfoBarMenu, InfoBarSeek, InfoBa
 		self.returning = False
 		self.onClose.append(self.__onClose)
 		config.misc.standbyCounter.addNotifier(self.standbyCountChanged, initial_call=False)
+		self.movieselection_dlg = None
+		MoviePlayer.movie_instance = self
 
 	def __onClose(self):
 		config.misc.standbyCounter.removeNotifier(self.standbyCountChanged)
@@ -502,7 +505,7 @@ class MoviePlayer(InfoBarBase, InfoBarShowHide, InfoBarMenu, InfoBarSeek, InfoBa
 	def showMovies(self):
 		ref = self.session.nav.getCurrentlyPlayingServiceOrGroup()
 		self.playingservice = ref # movie list may change the currently playing
-		self.session.openWithCallback(self.movieSelected, Screens.MovieSelection.MovieSelection, ref)
+		self.movieselection_dlg = self.session.openWithCallback(self.movieSelected, Screens.MovieSelection.MovieSelection, ref)
 
 	def movieSelected(self, service):
 		if service is not None:
@@ -519,6 +522,7 @@ class MoviePlayer(InfoBarBase, InfoBarShowHide, InfoBarMenu, InfoBarSeek, InfoBa
 			# no selection? Continue where we left off
 			if ref and not self.session.nav.getCurrentlyPlayingServiceOrGroup():
 				self.session.nav.playService(ref)
+		self.movieselection_dlg = None
 
 	def getPlaylistServiceInfo(self, service):
 		from MovieSelection import playlist


### PR DESCRIPTION
1)When current getCurrentlyPlayingServiceReference is getPath()  and PiP
available --> zap as PiP
2)When not PiP:
a)if running --> close Movieplayer(add movie_instance)
B)if running --> close plugin Mediaplayer(add media_instance)