### PR TITLE
[estring/event]  removing character ';'/ add items field

### DIFF
--- a/lib/base/estring.cpp
+++ b/lib/base/estring.cpp
@@ -763,17 +763,20 @@ int isUTF8(const std::string &string)
 
 unsigned int truncateUTF8(std::string &s, unsigned int newsize)
 {
-        unsigned int len = s.size();
-
-        // Assume s is a real UTF8 string!!!
-        while (len > newsize) {
-                while (len-- > 0  && (s[len] & 0xC0) == 0x80)
-                        ; // remove UTF data bytes,  e.g. range 0x80 - 0xBF
-                if (len > 0)   // remove the UTF startbyte, or normal ascii character
-                         --len;
-        }
-        s.resize(len);
-        return len;
+	unsigned int len = s.size();
+	unsigned int slen = len;
+	// Assume s is a real UTF8 string!!!
+	while (len > newsize) {
+		while (len-- > 0 && (s[len] & 0xC0) == 0x80)
+			if (len > 0) // remove the UTF startbyte, or normal ascii character
+				--len;
+	}
+	s.resize(len);
+	if (slen > newsize) {
+		s.insert (s.end(),3,'.'); //Indicate what string been truncated
+		len += 3;
+	}
+	return len;
 }
 
 

--- a/lib/service/event.cpp
+++ b/lib/service/event.cpp
@@ -89,6 +89,20 @@ bool eServiceEvent::loadLanguage(Event *evt, const std::string &lang, int tsidon
 					{
 						m_extended_description += convertDVBUTF8(eed->getText(), table, tsidonid);
 					}
+					const ExtendedEventList *itemlist = eed->getItems();
+					for (ExtendedEventConstIterator it = itemlist->begin(); it != itemlist->end(); ++it)
+					{
+						int cnt = 0;
+						for(int i=0; m_extended_description[i]; i++)
+							if ('\n' == m_extended_description[i]) cnt++;
+						if (cnt < 3) //limit to 3 entry
+						{
+							m_extended_description += convertDVBUTF8((*it)->getItemDescription());
+							m_extended_description += ": ";
+							m_extended_description += convertDVBUTF8((*it)->getItem());
+							m_extended_description += '\n';
+						}
+					}
 					retval=1;
 				}
 #if 0


### PR DESCRIPTION
- [estring.cpp] removing character ';' , a string is truncated without
an invalid character at the end of line.
more info:
https://github.com/openatv/enigma2/issues/1681
-- [event.cpp] If you look at "ETSI EN 300 468 V1.16.1 (2019-08)" in the
"6.2.15 Extended event descriptor" section, there are two types of text
fields - items and text. The items field consists of one or more
item_description and item pairs. Tricolor transmits information about
the country, year. actors, etc. in the items field, and the description
of the event in the text field, which is displayed in enigma2, while the
items field is ignored by the enigma. This is easy to see if you install
dvbsnoop and capture several Event Information Table fields.
To do this, you need:
1. Install dvbsnoop
opkg update
opkg install dvbsnoop

2. Capture 10 EIT fields
dvbsnoop -N 10 0x12> /tmp/info.txt