### PR TITLE
[event.cpp] revert add items field

### DIFF
--- a/lib/service/event.cpp
+++ b/lib/service/event.cpp
@@ -89,20 +89,6 @@ bool eServiceEvent::loadLanguage(Event *evt, const std::string &lang, int tsidon
 					{
 						m_extended_description += convertDVBUTF8(eed->getText(), table, tsidonid);
 					}
-					const ExtendedEventList *itemlist = eed->getItems();
-					for (ExtendedEventConstIterator it = itemlist->begin(); it != itemlist->end(); ++it)
-					{
-						int cnt = 0;
-						for(int i=0; m_extended_description[i]; i++)
-							if ('\n' == m_extended_description[i]) cnt++;
-						if (cnt < 3) //limit to 3 entry
-						{
-							m_extended_description += convertDVBUTF8((*it)->getItemDescription());
-							m_extended_description += ": ";
-							m_extended_description += convertDVBUTF8((*it)->getItem());
-							m_extended_description += '\n';
-						}
-					}
 					retval=1;
 				}
 #if 0


### PR DESCRIPTION
1 ) it is not converted - detection for type is on start of each
broadcasted section => if is info taked in 1/2 of this section, then
convertDVBUTF8 cannot detect it

2) there is same or very similar info which is used as "Genre:" and
"Age". Added event "Reprise" for few events only.

3 ) when provider divide EPG info to short + extended descriptions (text
starts in short_description and continue in extended_description), is
nonsence, when this 'info' is added between this text.

more info:

https://forums.openpli.org/topic/33634-enigma2-patches-proposal/?view=findpost&p=1219954