### PR TITLE
[keymap.xml] Allow VKB OK and ENTER buttons to repeat

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -64,7 +64,7 @@
 		<key id="KEY_YELLOW" mapto="shift" flags="m" />
 		<key id="KEY_BLUE" mapto="capsLock" flags="m" />
 		<key id="KEY_EXIT" mapto="cancel" flags="m" />
-		<key id="KEY_OK" mapto="select" flags="m" />
+		<key id="KEY_OK" mapto="select" flags="mr" />
 		<key id="KEY_TEXT" mapto="locale" flags="m" />
 		<key id="KEY_UP" mapto="up" flags="mr" />
 		<key id="KEY_PREVIOUS" mapto="backspace" flags="mr" />
@@ -99,7 +99,7 @@
 		<key id="KEY_F3" mapto="locale" flags="m" />
 		<key id="KEY_F4" mapto="shift" flags="m" />
 		<key id="KEY_ESC" mapto="cancel" flags="m" />
-		<key id="KEY_ENTER" mapto="select" flags="m" />
+		<key id="KEY_ENTER" mapto="select" flags="mr" />
 		<key id="KEY_PREVIOUSSONG" mapto="first" flags="m" />
 		<key id="KEY_F9" mapto="first" flags="m" />
 		<key id="KEY_F11" mapto="prev" flags="m" />


### PR DESCRIPTION
This update addresses a user request to allow the VirtualKeyBoard OK (and ENTER) buttons to repeat.
