### PR TITLE
[Screen.py] Protect against screens with no self or session

### DIFF
--- a/lib/python/Screens/Screen.py
+++ b/lib/python/Screens/Screen.py
@@ -145,7 +145,9 @@ class Screen(dict):
 		return self.screenPath
 
 	def setTitle(self, title):
-		if self.session and len(self.session.dialog_stack) > 2:
+		if not self or not self.session:  # Catch plugins that start without a self or session.
+			return
+		if len(self.session.dialog_stack) > 2:
 			self.screenPath = " > ".join(ds[0].getTitle() for ds in self.session.dialog_stack[2:])
 		self.screenTitle = title
 		if self.instance:


### PR DESCRIPTION
This change protects the code from tasks started at system startup that don't have a self or session.
