### PR TITLE
[Screen.py] Improve the previous stability fix

### DIFF
--- a/lib/python/Screens/Screen.py
+++ b/lib/python/Screens/Screen.py
@@ -145,14 +145,15 @@ class Screen(dict):
 		return self.screenPath
 
 	def setTitle(self, title):
-		if not self or not self.session:  # Catch plugins that start without a self or session.
-			return
-		if len(self.session.dialog_stack) > 2:
-			self.screenPath = " > ".join(ds[0].getTitle() for ds in self.session.dialog_stack[2:])
+		try:
+			if self.session and len(self.session.dialog_stack) > 2:
+				self.screenPath = " > ".join(ds[0].getTitle() for ds in self.session.dialog_stack[2:])
+			if self.instance:
+				self.instance.setTitle(title)
+			self.summaries.setTitle(title)
+		except AttributeError:
+			pass
 		self.screenTitle = title
-		if self.instance:
-			self.instance.setTitle(title)
-		self.summaries.setTitle(title)
 		if config.usage.menu_path.value == "large":
 			screenPath = ""
 			screenTitle = "%s > %s" % (self.screenPath, title) if self.screenPath else title


### PR DESCRIPTION
This change improves on the previous fix to protect the code from tasks started at system startup that don't have a self or session.
