### PR TITLE
Add/Restore ability to suppress ScreenPath

### DIFF
--- a/lib/python/Screens/InputBox.py
+++ b/lib/python/Screens/InputBox.py
@@ -15,7 +15,7 @@ class InputBox(Screen):
 		self["input"] = Input(**kwargs)
 		if windowTitle is None:
 			windowTitle = _("Input")
-		self.onShown.append(boundFunction(self.setTitle, windowTitle))
+		self.setTitle(windowTitle, showPath=False)
 		if useableChars is not None:
 			self["input"].setUseableChars(useableChars)
 

--- a/lib/python/Screens/MessageBox.py
+++ b/lib/python/Screens/MessageBox.py
@@ -78,7 +78,7 @@ class MessageBox(Screen):
 					"leftRepeated": self.left,
 					"rightRepeated": self.right
 				}, -1)
-		self.setTitle(self.title)
+		self.setTitle(self.title, showPath=False)
 
 	def initTimeout(self, timeout):
 		self.timeout = timeout
@@ -106,7 +106,7 @@ class MessageBox(Screen):
 		if self.timerRunning:
 			del self.timer
 			self.onExecBegin.remove(self.startTimer)
-			self.setTitle(self.origTitle)
+			self.setTitle(self.origTitle, showPath=False)
 			self.timerRunning = False
 
 	def timerTick(self):
@@ -114,7 +114,7 @@ class MessageBox(Screen):
 			self.timeout -= 1
 			if self.origTitle is None:
 				self.origTitle = self.instance.getTitle()
-			self.setTitle(self.origTitle + " (" + str(self.timeout) + ")")
+			self.setTitle(self.origTitle + " (" + str(self.timeout) + ")", showPath=False)
 			if self.timeout == 0:
 				self.timer.stop()
 				self.timerRunning = False

--- a/lib/python/Screens/Screen.py
+++ b/lib/python/Screens/Screen.py
@@ -144,7 +144,7 @@ class Screen(dict):
 	def getScreenPath(self):
 		return self.screenPath
 
-	def setTitle(self, title):
+	def setTitle(self, title, showPath=True):
 		try:  # This protects against calls to setTitle() before being fully initialised like self.session is accessed *before* being defined.
 			if self.session and len(self.session.dialog_stack) > 2:
 				self.screenPath = " > ".join(ds[0].getTitle() for ds in self.session.dialog_stack[2:])
@@ -156,10 +156,10 @@ class Screen(dict):
 		except AttributeError:
 			pass
 		self.screenTitle = title
-		if config.usage.menu_path.value == "large":
+		if showPath and config.usage.menu_path.value == "large":
 			screenPath = ""
 			screenTitle = "%s > %s" % (self.screenPath, title) if self.screenPath else title
-		elif config.usage.menu_path.value == "small":
+		elif showPath and config.usage.menu_path.value == "small":
 			screenPath = "%s >" % self.screenPath if self.screenPath else ""
 			screenTitle = title
 		else:


### PR DESCRIPTION
[Screen.py] Add/Restore ability to suppress ScreenPath
- Add a new argument to the setTitle() method to allow any screens / plugins suppress the ScreenPath history option for that screen / plugin.

[MessageBox.py] Suppress title ScreenPath
- Use the new setTitle() method argument "showPath" to suppress the ScreenPath display for MessageBox.

[InputBox.py] Suppress title ScreenPath
- Use the new setTitle() method argument "showPath" to suppress the ScreenPath display for MessageBox.

This has been done to address a user request.  This should match the changes made to implement the new Screen.py code in [Pull Request #2657](https://github.com/OpenPLi/enigma2/pull/2657).

