### PR TITLE
scan.cpp: update 28.2E

### DIFF
--- a/lib/dvb/scan.cpp
+++ b/lib/dvb/scan.cpp
@@ -74,8 +74,7 @@ int eDVBScan::isValidONIDTSID(int orbital_position, eOriginalNetworkID onid, eTr
 		ret = tsid != 0x4321;
 		break;
 	case 0x0002:
-		ret = absdiff(orbital_position, 282) < 6 && tsid != 2019;
-		// 12070H and 10936V have same tsid/onid.. but even the same services are provided
+		ret = absdiff(orbital_position, 282) < 6;
 		break;
 	case 0x2000:
 		ret = tsid != 0x1000;


### PR DESCRIPTION
 This removes an entry that was added 10 years ago to cover a dual illumination that lasted less than a week.
https://github.com/OpenPLi/enigma2/commit/397d12141b628fb0557daf8e0efc52070d888bad#diff-0745b6c402dc73ba260d2a203317df44

Most of the rest of this section just contains rubbish that should also go in the dustbin.