### PR TITLE
Translate title and text when collect attributes from skin

### DIFF
--- a/skin.py
+++ b/skin.py
@@ -370,6 +370,8 @@ def collectAttributes(skinAttributes, node, context, skinPath=None, ignore=(), f
 			elif attrib == "font":
 				font = value.encode("utf-8")
 				skinAttributes.append((attrib, font))
+			elif attrib in ("title", "text"):
+				skinAttributes.append((attrib, _(value.encode("utf-8"))))
 			else:
 				skinAttributes.append((attrib, value.encode("utf-8")))
 	if pos is not None:
@@ -438,10 +440,10 @@ class AttributeParser:
 #			print("[Skin] Error: Invalid animationMode '%s'!  Must be one of 'disable', 'off', 'offshow', 'offhide', 'onshow' or 'onhide'." % value)
 
 	def title(self, value):
-		self.guiObject.setTitle(_(value))
+		self.guiObject.setTitle(value)
 
 	def text(self, value):
-		self.guiObject.setText(_(value))
+		self.guiObject.setText(value)
 
 	def font(self, value):
 		self.guiObject.setFont(parseFont(value, self.scaleTuple))


### PR DESCRIPTION
Title is used not only in AttributeParser but also in applySkin() to use for summaries.
This will fix the translation when the title is obtained from the skin instead of using setTitle().
It will also fix double translation in AttributeParser when you're using already translated text from setTitle() in applySkin() add it to the skin attributes and translate again in AttributeParser.