### PR TITLE
Start fixing Summary screens.

### DIFF
--- a/data/display/skin_display_gbue4k.xml
+++ b/data/display/skin_display_gbue4k.xml
@@ -99,7 +99,7 @@
 	</screen>
 
 	<screen name="MenuSummary" position="0,0" size="220,176">
-		<widget source="parent.title" render="Label" position="5,0" size="210,60" font="GBLcd;26" valign="center"/>
+		<widget source="parent.SummaryTitle" render="Label" position="5,0" size="210,60" font="GBLcd;26" valign="center"/>
 		<widget source="parent.menu" render="Label" position="5,60" size="215,49" font="GBLcd;20" valign="bottom" foregroundColor="GBLcdGrey">
 			<convert type="StringListSelection"/>
 		</widget>
@@ -118,21 +118,21 @@
 	</screen>
 
 	<screen name="MovieContextMenuSummary" position="0,0" size="220,176">
-		<widget source="parent.Title" render="Label" position="5,0" size="210,60" font="GBLcd;26" valign="center"/>
+		<widget source="parent.SummaryTitle" render="Label" position="5,0" size="210,60" font="GBLcd;26" valign="center"/>
 		<widget source="selected" render="Label" position="5,60" size="215,49" font="GBLcd;20" valign="bottom" foregroundColor="GBLcdGrey"/>
 		<eLabel position="5,109" size="210,6" backgroundColor="GBLcdWhite"/>
 		<panel name="GBLcdClockTemplate"/>
 	</screen>
 
 	<screen name="MovieSelectionSummary" position="0,0" size="220,176">
-		<widget source="parent.Title" render="Label" position="5,0" size="210,60" font="GBLcd;26" valign="center"/>
+		<widget source="parent.SummaryTitle" render="Label" position="5,0" size="210,60" font="GBLcd;26" valign="center"/>
 		<widget source="name" render="Label" position="5,60" size="215,49" font="GBLcd;20" valign="bottom" foregroundColor="GBLcdGrey"/>
 		<eLabel position="5,109" size="210,6" backgroundColor="GBLcdWhite"/>
 		<panel name="GBLcdClockTemplate"/>
 	</screen>
 
 	<screen name="PluginBrowserSummary" position="0,0" size="220,176">
-		<widget source="parent.Title" render="Label" position="5,0" size="210,60" font="GBLcd;26" valign="center"/>
+		<widget source="parent.SummaryTitle" render="Label" position="5,0" size="210,60" font="GBLcd;26" valign="center"/>
 		<widget source="entry" render="Label" position="5,60" size="215,49" font="GBLcd;20" foregroundColor="GBLcdGrey" valign="center"/>
 		<widget source="desc" render="Label" position="5,109" size="215,67" font="GBLcd;20"/>
 	</screen>
@@ -155,7 +155,7 @@
 	</screen>
 
 	<screen name="SimpleSummary" position="0,0" size="220,176">
-		<widget source="parent.Title" render="Label" position="5,0" size="210,109" font="GBLcd;26"/>
+		<widget source="parent.SummaryTitle" render="Label" position="5,0" size="210,109" font="GBLcd;26"/>
 		<eLabel position="5,109" size="210,6" backgroundColor="GBLcdWhite"/>
 		<panel name="GBLcdClockTemplate"/>
 	</screen>

--- a/lib/python/Screens/Screen.py
+++ b/lib/python/Screens/Screen.py
@@ -45,6 +45,7 @@ class Screen(dict):
 		self.instance = None
 		self.summaries = CList()
 		self["Title"] = StaticText()
+		self["SummaryTitle"] = StaticText()
 		self["ScreenPath"] = StaticText()
 		self["screen_path"] = StaticText()  # Support legacy screen history skins.
 		self.screenPath = ""  # This is the current screen path without the title.
@@ -168,6 +169,7 @@ class Screen(dict):
 		self["ScreenPath"].text = screenPath
 		self["screen_path"].text = screenPath  # Support legacy screen history skins.
 		self["Title"].text = screenTitle
+		self["SummaryTitle"].text = self.screenTitle
 
 	def getTitle(self):
 		return self.screenTitle
@@ -216,30 +218,23 @@ class Screen(dict):
 		self.__callLaterTimer.start(0, True)
 
 	def applySkin(self):
-		z = 0
 		# DEBUG: baseRes = (getDesktop(GUI_SKIN_ID).size().width(), getDesktop(GUI_SKIN_ID).size().height())
 		baseRes = (720, 576)  # FIXME: A skin might have set another resolution, which should be the base res.
-		idx = 0
-		skinTitleIndex = -1
-		title = self.title
+		zPosition = 0
 		for (key, value) in self.skinAttributes:
-			if key == "zPosition":
-				z = int(value)
-			elif key == "title":
-				skinTitleIndex = idx
-				if title:
-					self.skinAttributes[skinTitleIndex] = ("title", title)
-				else:
-					self["Title"].text = value
-					self.summaries.setTitle(value)
-			elif key == "baseResolution":
+			if key == "baseResolution":
 				baseRes = tuple([int(x) for x in value.split(",")])
-			idx += 1
+			elif key == "zPosition":
+				zPosition = int(value)
 		self.scale = ((baseRes[0], baseRes[0]), (baseRes[1], baseRes[1]))
 		if not self.instance:
-			self.instance = eWindow(self.desktop, z)
-		if skinTitleIndex == -1 and title:
-			self.skinAttributes.append(("title", title))
+			self.instance = eWindow(self.desktop, zPosition)
+		if "title" not in self.skinAttributes and self.screenTitle:
+			self.skinAttributes.append(("title", self.screenTitle))
+		else:
+			for attribute in self.skinAttributes:
+				if attribute[0] == "title":
+					self.setTitle(_(attribute[1]))
 		self.skinAttributes.sort(key=lambda a: {"position": 1}.get(a[0], 0))  # We need to make sure that certain attributes come last.
 		applyAllAttributes(self.instance, self.desktop, self.skinAttributes, self.scale)
 		self.createGUIScreen(self.instance, self.desktop)

--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -39,7 +39,7 @@ class SetupSummary(Screen):
 
 	def __init__(self, session, parent):
 		Screen.__init__(self, session, parent = parent)
-		self["SetupTitle"] = StaticText(_(parent.setup_title))
+		self["SetupTitle"] = StaticText(parent.getTitle())
 		self["SetupEntry"] = StaticText("")
 		self["SetupValue"] = StaticText("")
 		self.onShow.append(self.addWatcher)

--- a/lib/python/Screens/SimpleSummary.py
+++ b/lib/python/Screens/SimpleSummary.py
@@ -1,23 +1,21 @@
 from Screens.Screen import Screen
 
+
 class SimpleSummary(Screen):
 	skin = """
 	<screen position="0,0" size="132,64">
 		<widget source="global.CurrentTime" render="Label" position="56,46" size="82,18" font="Regular;16">
 			<convert type="ClockToText">WithSeconds</convert>
 		</widget>
-		<widget source="parent.Title" render="Label" position="6,4" size="120,42" font="Regular;18" />
+		<widget source="parent.SummaryTitle" render="Label" position="6,4" size="120,42" font="Regular;18" />
 	</screen>"""
+
 	def __init__(self, session, parent):
-
-		Screen.__init__(self, session, parent = parent)
-
+		Screen.__init__(self, session, parent=parent)
 		names = parent.skinName
 		if not isinstance(names, list):
 			names = [names]
-
-		self.skinName = [ x + "_summary" for x in names ]
+		self.skinName = ["%s_summary" % x for x in names]
 		self.skinName.append("SimpleSummary")
-
-		# if parent has a "skin_summary" defined, use that as default
+		# If parent has a "skin_summary" defined, use that as default.
 		self.skin = parent.__dict__.get("skin_summary", self.skin)


### PR DESCRIPTION
This pull request is a first pass ad addressing the many issues reported against Summary screens on device front panels.  More changes or adjustments may be required as testing progresses.

***NOTE: All display skins, other than the GigaBlue UE 4K that is provided here as an example, will need to be updated to use the new "parent.ScreenSummary" widget rather than the current "parent.Title" widget.***

[skin_display_gbue4k.xml] Use new SummaryTitle widget
- The new SummaryTitle widget was created to supply the current window title *without* the screen path history.  This is particularly required when the user chooses to use the screen path mode of "Large".

[Screen.py] Improve code for titles
- Add a new widget "SummaryTitle" intended to be used by Summary screens on the front panel to only display the current screen title without the screen path history.  This is particularly important when the user chooses to use the menu path history option "Large".
- Rework the "applySkin" method to correctly and more efficiently extract titles from the skin and apply them to the title code.

[SimpleSummary.py] Use the new SummaryTitle widget
- Adjust the embedded skin to use the new SummaryTitle skin widget.
- Optimise the calculation of self.skinName.

[Setup.py] Adjust SetupSummary to use getTitle() method
- This change forces Setup to use the established getTitle() method rather than relying on shared variables.

Please report any issues with the code so that problems can be investigated and corrected.
