### PR TITLE
Rework summary screen titles

### DIFF
--- a/data/display/skin_display_gbue4k.xml
+++ b/data/display/skin_display_gbue4k.xml
@@ -99,7 +99,7 @@
 	</screen>
 
 	<screen name="MenuSummary" position="0,0" size="220,176">
-		<widget source="parent.SummaryTitle" render="Label" position="5,0" size="210,60" font="GBLcd;26" valign="center"/>
+		<widget source="Title" render="Label" position="5,0" size="210,60" font="GBLcd;26" valign="center"/>
 		<widget source="parent.menu" render="Label" position="5,60" size="215,49" font="GBLcd;20" valign="bottom" foregroundColor="GBLcdGrey">
 			<convert type="StringListSelection"/>
 		</widget>
@@ -118,21 +118,21 @@
 	</screen>
 
 	<screen name="MovieContextMenuSummary" position="0,0" size="220,176">
-		<widget source="parent.SummaryTitle" render="Label" position="5,0" size="210,60" font="GBLcd;26" valign="center"/>
+		<widget source="Title" render="Label" position="5,0" size="210,60" font="GBLcd;26" valign="center"/>
 		<widget source="selected" render="Label" position="5,60" size="215,49" font="GBLcd;20" valign="bottom" foregroundColor="GBLcdGrey"/>
 		<eLabel position="5,109" size="210,6" backgroundColor="GBLcdWhite"/>
 		<panel name="GBLcdClockTemplate"/>
 	</screen>
 
 	<screen name="MovieSelectionSummary" position="0,0" size="220,176">
-		<widget source="parent.SummaryTitle" render="Label" position="5,0" size="210,60" font="GBLcd;26" valign="center"/>
+		<widget source="Title" render="Label" position="5,0" size="210,60" font="GBLcd;26" valign="center"/>
 		<widget source="name" render="Label" position="5,60" size="215,49" font="GBLcd;20" valign="bottom" foregroundColor="GBLcdGrey"/>
 		<eLabel position="5,109" size="210,6" backgroundColor="GBLcdWhite"/>
 		<panel name="GBLcdClockTemplate"/>
 	</screen>
 
 	<screen name="PluginBrowserSummary" position="0,0" size="220,176">
-		<widget source="parent.SummaryTitle" render="Label" position="5,0" size="210,60" font="GBLcd;26" valign="center"/>
+		<widget source="Title" render="Label" position="5,0" size="210,60" font="GBLcd;26" valign="center"/>
 		<widget source="entry" render="Label" position="5,60" size="215,49" font="GBLcd;20" foregroundColor="GBLcdGrey" valign="center"/>
 		<widget source="desc" render="Label" position="5,109" size="215,67" font="GBLcd;20"/>
 	</screen>
@@ -155,7 +155,7 @@
 	</screen>
 
 	<screen name="SimpleSummary" position="0,0" size="220,176">
-		<widget source="parent.SummaryTitle" render="Label" position="5,0" size="210,109" font="GBLcd;26"/>
+		<widget source="Title" render="Label" position="5,0" size="210,109" font="GBLcd;26"/>
 		<eLabel position="5,109" size="210,6" backgroundColor="GBLcdWhite"/>
 		<panel name="GBLcdClockTemplate"/>
 	</screen>

--- a/lib/python/Screens/Menu.py
+++ b/lib/python/Screens/Menu.py
@@ -41,8 +41,12 @@ class MenuUpdater:
 
 menuupdater = MenuUpdater()
 
+
 class MenuSummary(Screen):
-	pass
+	def __init__(self, session, parent):
+		Screen.__init__(self, session, parent=parent)
+		self["Title"] = StaticText(parent.getTitle())
+
 
 class Menu(Screen, ProtectedScreen):
 	ALLOW_SUSPEND = True

--- a/lib/python/Screens/Screen.py
+++ b/lib/python/Screens/Screen.py
@@ -45,7 +45,6 @@ class Screen(dict):
 		self.instance = None
 		self.summaries = CList()
 		self["Title"] = StaticText()
-		self["SummaryTitle"] = StaticText()
 		self["ScreenPath"] = StaticText()
 		self["screen_path"] = StaticText()  # Support legacy screen history skins.
 		self.screenPath = ""  # This is the current screen path without the title.
@@ -169,7 +168,6 @@ class Screen(dict):
 		self["ScreenPath"].text = screenPath
 		self["screen_path"].text = screenPath  # Support legacy screen history skins.
 		self["Title"].text = screenTitle
-		self["SummaryTitle"].text = self.screenTitle
 
 	def getTitle(self):
 		return self.screenTitle

--- a/lib/python/Screens/SimpleSummary.py
+++ b/lib/python/Screens/SimpleSummary.py
@@ -1,3 +1,4 @@
+from Components.Sources.StaticText import StaticText
 from Screens.Screen import Screen
 
 
@@ -7,11 +8,12 @@ class SimpleSummary(Screen):
 		<widget source="global.CurrentTime" render="Label" position="56,46" size="82,18" font="Regular;16">
 			<convert type="ClockToText">WithSeconds</convert>
 		</widget>
-		<widget source="parent.SummaryTitle" render="Label" position="6,4" size="120,42" font="Regular;18" />
+		<widget source="Title" render="Label" position="6,4" size="120,42" font="Regular;18" />
 	</screen>"""
 
 	def __init__(self, session, parent):
 		Screen.__init__(self, session, parent=parent)
+		self["Title"] = StaticText(parent.getTitle())
 		names = parent.skinName
 		if not isinstance(names, list):
 			names = [names]


### PR DESCRIPTION
This change is a slight rework of the summary screen titles to use the standard and preferred name of Title.

This change still requires changes in the display skins but this time it is to use the current screen's "Title" widget rather than using the parent screen's "Title" widget.

This change was made in response to a request from Littlesat.
