### PR TITLE
GigaBlue PiP

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -926,6 +926,7 @@
 	<translate>
 		<device name="gigablue remote control">
 			<key from="KEY_OPTION" to="KEY_HELP" />
+			<key from="KEY_F2" to="KEY_SCREEN" />
 		</device>
 	</translate>
 </keymap>


### PR DESCRIPTION
Translate remote code so PiP works on GigaBlue remote.
Key translation while we await  a remote that sends the correct code.