### PR TITLE
force checks option 'Additional cable of motorized LNB'

### DIFF
--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -295,9 +295,17 @@ class SecConfigure:
 		lnb = int(config.Nims[slotid].advanced.sat[3607].lnb.value)
 		if lnb != 0:
 			root_id = int(config.Nims[slotid].connectedTo.value)
-			for x in self.NimManager.getRotorSatListForNim(root_id):
-				print "[SecConfigure] add", x[0], "to", lnb
-				lnbSat[lnb].append(x[0])
+			rotor_sat_list = self.NimManager.getRotorSatListForNim(root_id)
+			if rotor_sat_list:
+				for x in rotor_sat_list:
+					print "[SecConfigure] add", x[0], "to", lnb
+					lnbSat[lnb].append(x[0])
+			else:
+				config.Nims[slotid].advanced.sat[3607].lnb.value = "0"
+				config.Nims[slotid].advanced.sat[3607].lnb.save()
+				if len(self.NimManager.getSatListForNim(slotid)) < 1:
+					config.Nims[slotid].configMode.value = "nothing"
+					config.Nims[slotid].configMode.save()
 
 		for x in range(1, 72):
 			if len(lnbSat[x]) > 0:

--- a/lib/python/Screens/Satconfig.py
+++ b/lib/python/Screens/Satconfig.py
@@ -149,12 +149,21 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 				elif self.nimConfig.configMode.value == "advanced":
 					advanced_satposdepends_satlist_choices = (3607, _('Additional cable of motorized LNB'), 1)
 					advanced_satlist_choices = self.nimConfig.advanced.sats.choices.choices
+					advanced_setchoices = False
 					if nimmanager.canDependOn(self.slotid, True):
 						if advanced_satposdepends_satlist_choices not in advanced_satlist_choices:
 							advanced_satlist_choices.append(advanced_satposdepends_satlist_choices)
+							advanced_setchoices = True
 					elif advanced_satposdepends_satlist_choices in advanced_satlist_choices:
 						advanced_satlist_choices.remove(advanced_satposdepends_satlist_choices)
-					self.nimConfig.advanced.sats.setChoices(advanced_satlist_choices, 192)
+						advanced_setchoices = True
+					if advanced_setchoices:
+						default_orbpos = None
+						for x in self.nimConfig.advanced.sat.keys():
+							if x == 192:
+								default_orbpos = "192"
+								break
+						self.nimConfig.advanced.sats.setChoices(advanced_satlist_choices, default=default_orbpos)
 					self.advancedSatsEntry = getConfigListEntry(self.indent % _("Satellite"), self.nimConfig.advanced.sats, _("Select the satellite you want to configure. Once that satellite is configured you can select and configure other satellites that will be accessed using this same tuner."))
 					self.list.append(self.advancedSatsEntry)
 					current_config_sats = self.nimConfig.advanced.sats.value


### PR DESCRIPTION
-[Satconfig] update sat choices only if necessary
-[NimManager] set advanced.sat[3607].lnb.value as "0" when no tuners
available using rotor and set configMode.value as "nothing" when sat
list for current tuner empty