### PR TITLE
[Satconfig] show entry "Externally powered" when this not FBC tuner

### DIFF
--- a/lib/python/Screens/Satconfig.py
+++ b/lib/python/Screens/Satconfig.py
@@ -403,7 +403,7 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 					self.list.append(getConfigListEntry(self.indent % "LOF/L", currLnb.lofl, _("Consult your SCR device spec sheet for this information.")))
 					self.list.append(getConfigListEntry(self.indent % "LOF/H", currLnb.lofh, _("Consult your SCR device spec sheet for this information.")))
 					self.list.append(getConfigListEntry(self.indent % _("Threshold"), currLnb.threshold, _("Consult your SCR device spec sheet for this information.")))
-					if not SystemInfo["LnbPowerAlwaysOn"]:
+					if not SystemInfo["LnbPowerAlwaysOn"] or not self.nim.isFBCTuner():
 						self.list.append(self.externallyPowered)
 					if not currLnb.powerinserter.value:
 						self.list.append(getConfigListEntry(self.indent % _("Bootup time"), currLnb.bootuptime, _("Consult your SCR device spec sheet for this information.")))
@@ -417,7 +417,7 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 					if currLnb.positions.value > 1:
 						self.list.append(self.advancedPosition)
 					self.list.append(self.advancedSCR)
-					if not SystemInfo["LnbPowerAlwaysOn"]:
+					if not SystemInfo["LnbPowerAlwaysOn"] or not self.nim.isFBCTuner():
 						self.list.append(self.externallyPowered)
 				choices = []
 				connectable = nimmanager.canConnectTo(self.slotid)


### PR DESCRIPTION
SystemInfo["LnbPowerAlwaysOn"] = HardwareInfo().get_device_model() in
("vusolo4k", "vuduo4k", "vuultimo4k", "vuuno4k", "vuuno4kse")

I checked my solo4k.
In standby:
FBC tuner(A, B ) voltage 13.68v is tuner not use.
Dual DVB-S2 tuner(I,J) voltage 0v is tuner not use.