### PR TITLE
[sec] correct ret/satcount for advanced satposdepends lnbs

### DIFF
--- a/lib/dvb/sec.cpp
+++ b/lib/dvb/sec.cpp
@@ -188,7 +188,9 @@ int eDVBSatelliteEquipmentControl::canTune(const eDVBFrontendParametersSatellite
 					}
 					else
 					{
-						ret -= abs(rotor_orbital_position - sat.orbital_position) + 10;
+						// set low priory
+						ret = 10000 - lnb_param.m_satellites.size();
+						satcount = old_satcount + 1;
 					}
 					eSecDebugNoSimulate("[eDVBSatelliteEquipmentControl] ret1 %d", ret);
 				}


### PR DESCRIPTION
-satcount add only current(one) sat

This is necessary to set the lowest auto priority for advanced
satposdepends lnbs.