### PR TITLE
Clean up screen path code

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -9,7 +9,7 @@
 	<setup key="usage" title="Customize">
 		<item level="1" text="Sort order for menu entries" description="This option allows you to hide and sort menu entries. When selecting user you can change order and hide menu items via the blue button. With the user defined hidden the blue button is not shown in the menus">config.usage.menu_sort_mode</item>
 		<item level="1" text="Sort order for setup entries" description="This option allows you to alphabetically sort setup menu entries.">config.usage.sort_settings</item>
-		<item level="1" text="Show menu paths" description="This option allows you to show menu paths.">config.usage.menu_path</item>
+		<item level="1" text="Show screen path" description="This option allows you to show the full screen path leading to the current screen.">config.usage.showScreenPath</item>
 		<item level="0" text="Show menu or plugin numbers" description="This option allows you to show menu and/or plugin number quick links.">config.usage.menu_show_numbers</item>
 		<item level="2" text="Show softcam setup in extensions menu" description="This option allows you to add the softcam setup in the extensions menu." requires="HasSoftcamInstalled">config.misc.softcam_setup.extension_menu</item>
 		<item level="1" text="Zap mode" requires="ZapMode" description="Configure the way in which the receiver changes channels.">config.misc.zapmode</item>

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -82,18 +82,6 @@ def InitUsageConfig():
 	config.usage.menu_sort_mode = ConfigSelection(default = "default", choices = [("a_z", _("alphabetical")), ("default", _("Default")), ("user", _("user defined")), ("user_hidden", _("user defined hidden"))])
 	config.usage.menu_show_numbers = ConfigSelection(default = "no", choices = [("no", _("no")), ("menu&plugins", _("in menu and plugins")), ("menu", _("in menu only")), ("plugins", _("in plugins only"))])
 	config.usage.showScreenPath = ConfigSelection(default="small", choices=[("off", _("Disabled")), ("small", _("Small")), ("large", _("Large"))])
-	# The following code is to be short lived and exists to transition
-	# settings from the old config.usage.menu_path to the new
-	# config.usage.showScreenPath as this is the value to now shared
-	# by all images.  Thise code will transition the setting and then
-	# remove the old entry from user's settings files.
-	config.usage.menu_path = ConfigSelection(default="small", choices=[("off", _("Disabled")), ("small", _("Small")), ("large", _("Large"))])
-	if config.usage.menu_path.value != config.usage.menu_path.default:
-		config.usage.showScreenPath.value = config.usage.menu_path.value
-		config.usage.menu_path.value = config.usage.menu_path.default
-		config.usage.save()
-		print("[UserConfig] DEBUG: The 'menu_path' setting of '%s' has been transferred to 'showScreenPath'." % config.usage.showScreenPath.value)
-	# End of temporary code.
 	config.usage.enable_tt_caching = ConfigYesNo(default = True)
 	config.usage.sort_settings = ConfigYesNo(default=False)
 	choicelist = []

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -81,10 +81,19 @@ def InitUsageConfig():
 	config.usage.menu_sort_weight = ConfigDictionarySet(default = { "mainmenu" : {"submenu" : {} }})
 	config.usage.menu_sort_mode = ConfigSelection(default = "default", choices = [("a_z", _("alphabetical")), ("default", _("Default")), ("user", _("user defined")), ("user_hidden", _("user defined hidden"))])
 	config.usage.menu_show_numbers = ConfigSelection(default = "no", choices = [("no", _("no")), ("menu&plugins", _("in menu and plugins")), ("menu", _("in menu only")), ("plugins", _("in plugins only"))])
-	config.usage.menu_path = ConfigSelection(default = "off", choices = [
-		("off", _("Disabled")),
-		("small", _("Small")),
-		("large", _("Large")),])
+	config.usage.showScreenPath = ConfigSelection(default="small", choices=[("off", _("Disabled")), ("small", _("Small")), ("large", _("Large"))])
+	# The following code is to be short lived and exists to transition
+	# settings from the old config.usage.menu_path to the new
+	# config.usage.showScreenPath as this is the value to now shared
+	# by all images.  Thise code will transition the setting and then
+	# remove the old entry from user's settings files.
+	config.usage.menu_path = ConfigSelection(default="small", choices=[("off", _("Disabled")), ("small", _("Small")), ("large", _("Large"))])
+	if config.usage.menu_path.value != config.usage.menu_path.default:
+		config.usage.showScreenPath.value = config.usage.menu_path.value
+		config.usage.menu_path.value = config.usage.menu_path.default
+		config.usage.save()
+		print("[UserConfig] DEBUG: The 'menu_path' setting of '%s' has been transferred to 'showScreenPath'." % config.usage.showScreenPath.value)
+	# End of temporary code.
 	config.usage.enable_tt_caching = ConfigYesNo(default = True)
 	config.usage.sort_settings = ConfigYesNo(default=False)
 	choicelist = []

--- a/lib/python/Screens/Screen.py
+++ b/lib/python/Screens/Screen.py
@@ -47,7 +47,6 @@ class Screen(dict):
 		self.summaries = CList()
 		self["Title"] = StaticText()
 		self["ScreenPath"] = StaticText()
-		self["screen_path"] = StaticText()  # Support legacy screen history skins.
 		self.screenPath = ""  # This is the current screen path without the title.
 		self.screenTitle = ""  # This is the current screen title without the path.
 
@@ -167,7 +166,6 @@ class Screen(dict):
 			screenPath = ""
 			screenTitle = title
 		self["ScreenPath"].text = screenPath
-		self["screen_path"].text = screenPath  # Support legacy screen history skins.
 		self["Title"].text = screenTitle
 
 	def getTitle(self):

--- a/lib/python/Screens/Screen.py
+++ b/lib/python/Screens/Screen.py
@@ -156,10 +156,10 @@ class Screen(dict):
 		except AttributeError:
 			pass
 		self.screenTitle = title
-		if showPath and config.usage.menu_path.value == "large":
+		if showPath and config.usage.showScreenPath.value == "large":
 			screenPath = ""
 			screenTitle = "%s > %s" % (self.screenPath, title) if self.screenPath else title
-		elif showPath and config.usage.menu_path.value == "small":
+		elif showPath and config.usage.showScreenPath.value == "small":
 			screenPath = "%s >" % self.screenPath if self.screenPath else ""
 			screenTitle = title
 		else:


### PR DESCRIPTION
[Screen.py] Remove defunct "screen_path"
- All official OpenPLi skins have now been updated to use the newer "ScreenPath" widget so the defunct "screen_path" widget can now be removed.

[UsageConfig.py] Transition screen path settings
- This temporary code will find the user's current value for the old "config.usage.menu_path" setting and move it to the new "config.usage.showScreenPath".  The code will then remove the old "config.usage.menu_path" entry from the settings file.

- This code is only run once such that when the setting is transferred the old setting is no longer used.  It is intended to remove this code after one or two production releases of OpenPLi when it will be assumed that most users have had the setting transferred.  When this code is removed the only implication for users will be that the setting will not be migrated and the "config.usage.showScreenPath" default value will be used.  Also the old "config.usage.menu_path" setting, if not at default, will not be removed.

[setup.xml] Use the new showScreenPath setting
- This change uses the new "config.usage.showScreenPath" setting and improves the label and description text to better reflect the functionality.

[Screen.py] Use new "config.usage.showScreenPath"
- This change replaces the old "config.usage.menu_path" setting with the new and proposed common "config.usage.showScreenPath" setting.

[UsageConfig.py] Remove transition code
- This change was requested by Littlesat and Persian Prince as OpenPLi production releases are too far apart such that this code could hang around for a very long time.  It is not considered an issue for this setting to be reset to default and the old value to be left in the setting file.
