### PR TITLE
[listboxservice] set celServiceNextInfo priority higher than celServi…

### DIFF
--- a/lib/service/listboxservice.h
+++ b/lib/service/listboxservice.h
@@ -55,8 +55,8 @@ public:
 		celFolderPixmap,
 		celServiceEventProgressbar,
 		celServiceName,
-		celServiceInfo, // "now" event
 		celServiceNextInfo, // "next" event
+		celServiceInfo, // "now" event
 		celServiceTypePixmap,
 		celElements
 	};


### PR DESCRIPTION
…ceInfo

Because this is probably a feature(?) such that the default color of the
progress bar is taken from the color celServiceInfo.