### PR TITLE
[Tools/CIHelper] dynamic change CI_MULTIDESCRAMBLE_MODULES

### DIFF
--- a/lib/python/Tools/CIHelper.py
+++ b/lib/python/Tools/CIHelper.py
@@ -1,6 +1,7 @@
 from xml.etree.cElementTree import parse
 from enigma import eDVBCIInterfaces, eDVBCI_UI, eEnv, eServiceCenter, eServiceReference, getBestPlayableServiceReference, iRecordableService 
 from Components.SystemInfo import SystemInfo
+from Components.config import config
 import NavigationInstance
 import os
 
@@ -10,6 +11,7 @@ class CIHelper:
 	CI_ASSIGNMENT_SERVICES_LIST = None
 	CI_MULTIDESCRAMBLE = None
 	CI_RECORDS_LIST = None
+	CI_INIT_NOTIFIER = None
 	CI_MULTIDESCRAMBLE_MODULES = ("AlphaCrypt", "M7 CAM701 Multi-2")
 
 	def parse_ci_assignment(self):
@@ -148,15 +150,22 @@ class CIHelper:
 				return is_assignment and (is_assignment, ref) or False
 		return False
 
+	def forceUpdateMultiDescramble(self, configElement):
+		self.CI_MULTIDESCRAMBLE = None
+
 	def canMultiDescramble(self, ci):
 		if self.CI_MULTIDESCRAMBLE is None:
 			NUM_CI = SystemInfo["CommonInterface"]
 			if NUM_CI and NUM_CI > 0:
 				self.CI_MULTIDESCRAMBLE = []
-				for ci in range(NUM_CI):
-					appname = eDVBCI_UI.getInstance().getAppName(ci)
-					if appname in self.CI_MULTIDESCRAMBLE_MODULES:
-						self.CI_MULTIDESCRAMBLE.append(str(ci))
+				for slot in range(NUM_CI):
+					appname = eDVBCI_UI.getInstance().getAppName(slot)
+					multipleServices = config.ci[slot].canDescrambleMultipleServices.value
+					if self.CI_INIT_NOTIFIER is None:
+						config.ci[slot].canDescrambleMultipleServices.addNotifier(self.forceUpdateMultiDescramble, initial_call=False, immediate_feedback=False)
+					if multipleServices == "yes" or (appname in self.CI_MULTIDESCRAMBLE_MODULES and multipleServices == "auto"):
+						self.CI_MULTIDESCRAMBLE.append(str(slot))
+				self.CI_INIT_NOTIFIER = True
 		else:
 			return self.CI_MULTIDESCRAMBLE and ci in self.CI_MULTIDESCRAMBLE
 


### PR DESCRIPTION
CI_MULTIDESCRAMBLE_MODULES = ("AlphaCrypt", "M7 CAM701 Multi-2")
When use "Multiple service support" yes'  or module name in
CI_MULTIDESCRAMBLE_MODULES and 'auto'  it  is compatible with multi
descramble module in the channel selector.