### PR TITLE
[listboxservice] force set default color progress bar as celServiceInfo

### DIFF
--- a/lib/service/listboxservice.cpp
+++ b/lib/service/listboxservice.cpp
@@ -707,6 +707,7 @@ void eListboxServiceContent::paint(gPainter &painter, eWindowStyle &style, const
 		bool serviceAvail = true;
 		bool serviceFallback = false;
 		int isplayable_value;
+		gRGB EventProgressbarColor = 0xe7b53f;
 
 		if (!marked && isPlayable && service_info && m_is_playable_ignore.valid())
 		{
@@ -809,16 +810,28 @@ void eListboxServiceContent::paint(gPainter &painter, eWindowStyle &style, const
 						if (serviceAvail)
 						{
 							if (!selected && m_color_set[eventForeground])
+							{
 								painter.setForegroundColor(m_color[eventForeground]);
+								EventProgressbarColor = m_color[eventForeground];
+							}
 							else if (selected && m_color_set[eventForegroundSelected])
+							{
 								painter.setForegroundColor(m_color[eventForegroundSelected]);
+								EventProgressbarColor = m_color[eventForegroundSelected];
+							}
 							else
 								painter.setForegroundColor(gRGB(0xe7b53f));
 
 							if (serviceFallback && !selected && m_color_set[eventForegroundFallback]) // fallback receiver
+							{
 								painter.setForegroundColor(m_color[eventForegroundFallback]);
+								EventProgressbarColor = m_color[eventForegroundFallback];
+							}
 							else if (serviceFallback && selected && m_color_set[eventForegroundSelectedFallback])
+							{
 								painter.setForegroundColor(m_color[eventForegroundSelectedFallback]);
+								EventProgressbarColor = m_color[eventForegroundSelectedFallback];
+							}
 						}
 						break;
 					}
@@ -1121,6 +1134,8 @@ void eListboxServiceContent::paint(gPainter &painter, eWindowStyle &style, const
 					painter.setForegroundColor(m_color[serviceEventProgressbarColor]);
 				else if (selected && m_color_set[serviceEventProgressbarColorSelected])
 					painter.setForegroundColor(m_color[serviceEventProgressbarColorSelected]);
+				else if (m_show_two_lines == 2)
+					painter.setForegroundColor(EventProgressbarColor);
 				painter.fill(tmp);
 			}
 


### PR DESCRIPTION
For next event.
Because this is probably a feature(?) such that the default color of the
progress bar is taken from the color celServiceInfo.