### PR TITLE
Auto detect region for DVB-T/T2 tuners

### DIFF
--- a/lib/dvb/dvb.cpp
+++ b/lib/dvb/dvb.cpp
@@ -840,7 +840,7 @@ RESULT eDVBResourceManager::allocateFrontend(ePtr<eDVBAllocatedFrontend> &fe, eP
 {
 	eSmartPtrList<eDVBRegisteredFrontend> &frontends = simulate ? m_simulate_frontend : m_frontend;
 	eDVBRegisteredFrontend *best, *fbc_fe, *best_fbc_fe;
-	int bestval, foundone, current_fbc_setid, c, system;
+	int bestval, foundone, current_fbc_setid, c, tuner_type;
 	bool check_fbc_leaf_linkable, is_configured_sat;
 	long link;
 
@@ -896,8 +896,8 @@ RESULT eDVBResourceManager::allocateFrontend(ePtr<eDVBAllocatedFrontend> &fe, eP
 			}
 			else
 			{
-				feparm->getSystem(system);
-				if (system == eDVBFrontend::feTerrestrial)
+				feparm->getSystem(tuner_type);
+				if (tuner_type == eDVBFrontend::feTerrestrial)
 					is_configured_sat = true;
 			}
 			c = i->m_frontend->isCompatibleWith(feparm, is_configured_sat);

--- a/lib/dvb/dvb.cpp
+++ b/lib/dvb/dvb.cpp
@@ -840,7 +840,7 @@ RESULT eDVBResourceManager::allocateFrontend(ePtr<eDVBAllocatedFrontend> &fe, eP
 {
 	eSmartPtrList<eDVBRegisteredFrontend> &frontends = simulate ? m_simulate_frontend : m_frontend;
 	eDVBRegisteredFrontend *best, *fbc_fe, *best_fbc_fe;
-	int bestval, foundone, current_fbc_setid, c;
+	int bestval, foundone, current_fbc_setid, c, system;
 	bool check_fbc_leaf_linkable, is_configured_sat;
 	long link;
 
@@ -893,6 +893,12 @@ RESULT eDVBResourceManager::allocateFrontend(ePtr<eDVBAllocatedFrontend> &fe, eP
 							is_configured_sat = true;
 					}
 				}
+			}
+			else
+			{
+				feparm->getSystem(system);
+				if (system == eDVBFrontend::feTerrestrial)
+					is_configured_sat = true;
 			}
 			c = i->m_frontend->isCompatibleWith(feparm, is_configured_sat);
 		}

--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -2871,6 +2871,22 @@ int eDVBFrontend::isCompatibleWith(ePtr<iDVBFrontendParameters> &feparm, bool is
 			/* prefer to use a T tuner, try to keep T2 free for T2 transponders */
 			score--;
 		}
+		/* auto detect region - check if this frequency is in the frontend list */
+		if (is_configured_sat)
+		{
+			char configStr[255];
+			snprintf(configStr, 255, "config.Nims.%d.smart_region_list", m_slotid);
+			std::string smart_region_list = eConfigManager::getConfigValue(configStr);
+			if (!smart_region_list.empty())
+			{
+				std::stringstream ss;
+				ss << parm.frequency;
+				std::string freq;
+				freq = ss.str();
+				if (smart_region_list.find(freq) == std::string::npos)
+					return 0;
+			}
+		}
 	}
 	else if (type == eDVBFrontend::feATSC)
 	{

--- a/lib/python/Screens/Satconfig.py
+++ b/lib/python/Screens/Satconfig.py
@@ -289,6 +289,15 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 				self.terrestrialRegionsEntry = getConfigListEntry(self.indent % _("Region"), self.terrestrialRegions, _("Select your region. If not available change 'Country' to 'all' and select one of the default alternatives."))
 				self.list.append(self.terrestrialCountriesEntry)
 				self.list.append(self.terrestrialRegionsEntry)
+				nimcount = 0
+				for slot in nimmanager.nim_slots:
+					if slot.isCompatible("DVB-T") and slot.config.configMode.value != "nothing":
+						nimcount += 1
+				if nimcount > 1:
+					self.list.append(getConfigListEntry(self.indent % _("Auto detect region"), self.nimConfig.smart_region, _("If you use more than one DVB-T tuner with different regions, you can enable this option to select the correct tuner when zap in service.")))
+				elif self.nimConfig.smart_region.value:
+					self.nimConfig.smart_region.value = False
+					self.nimConfig.smart_region.save()
 				self.list.append(getConfigListEntry(self.indent % _("Enable 5V for active antenna"), self.nimConfig.terrestrial_5V, _("Enable this setting if your aerial system needs power")))
 		if self.nim.isCompatible("ATSC") or (self.nim.isCombined() and self.nim.canBeCompatible("ATSC")):
 			if self.nim.isCombined():


### PR DESCRIPTION
Attention!
This check will only work when zap to the service.
Availability in the channel list is not checked to reduce the load on
the system.