### PR TITLE
[skin] allow scaling of skin elements and fonts based on the current …

### DIFF
--- a/lib/python/Components/Converter/TemplatedMultiContent.py
+++ b/lib/python/Components/Converter/TemplatedMultiContent.py
@@ -6,8 +6,9 @@ class TemplatedMultiContent(StringList):
 	def __init__(self, args):
 		StringList.__init__(self, args)
 		from enigma import BT_SCALE, RT_HALIGN_CENTER, RT_HALIGN_LEFT, RT_HALIGN_RIGHT, RT_VALIGN_BOTTOM, RT_VALIGN_CENTER, RT_VALIGN_TOP, RT_WRAP, eListboxPythonMultiContent, gFont
-		from skin import parseFont
+		from skin import parseFont, getSkinFactor
 		from Components.MultiContent import MultiContentEntryPixmap, MultiContentEntryPixmapAlphaBlend, MultiContentEntryPixmapAlphaTest, MultiContentEntryProgress, MultiContentEntryProgressPixmap, MultiContentEntryText, MultiContentTemplateColor
+		f = getSkinFactor()
 		loc = locals()
 		del loc["self"]  # Cleanup locals a bit.
 		del loc["args"]

--- a/skin.py
+++ b/skin.py
@@ -227,7 +227,8 @@ class SkinError(Exception):
 #         c      : Take the center point of parent size/width.
 #         %      : Take given percentage of parent size/width.
 #         w      : Multiply by current font width. (Only to be used in elements where the font attribute is available, i.e. not "None")
-#         h      : Multiply by current font width. (Only to be used in elements where the font attribute is available, i.e. not "None")
+#         h      : Multiply by current font height. (Only to be used in elements where the font attribute is available, i.e. not "None")
+#         f      : Replace with getSkinFactor().
 #
 def parseCoordinate(s, e, size=0, font=None):
 	orig = s = s.strip()
@@ -254,6 +255,8 @@ def parseCoordinate(s, e, size=0, font=None):
 				s = s.replace("h", "*%s" % str(fonts[font][2]))
 			if "%" in s:
 				s = s.replace("%", "*%s" % str(e / 100.0))
+			if "f" in s:
+				s = s.replace("f", str(getSkinFactor()))
 			try:
 				val = int(s)  # For speed try a simple number first.
 			except ValueError:
@@ -303,6 +306,16 @@ def parseSize(s, scale, object=None, desktop=None):
 def parseFont(s, scale=((1, 1), (1, 1))):
 	if ";" in s:
 		name, size = s.split(";")
+		orig = size
+		try:
+			size = int(size)
+		except ValueError:
+			try:
+				size = size.replace("f", str(getSkinFactor()))
+				size = int(eval(size))
+			except Exception as err:
+				print("[Skin] %s '%s': font size formula '%s', processed to '%s', cannot be evaluated!" % (type(err).__name__, err, orig, s))
+				size = None
 	else:
 		name = s
 		size = None


### PR DESCRIPTION
…screen resolution

This will allow screens from the default skin to be used at all resolutions.

"f" is used to represent skinFactor in formulas.

Example use:
<ePixmap position="0,0" size="974*f,148*f" pixmap="infobar/1stinfobar.png" alphatest="on" zPosition="-1" scale="1"/>

Note 1: in the example above the scale flag is used so images correctly fill their respective cell.

Note 2: In TemplatedMultiContent all formulas must evaluate to int.