### PR TITLE
[font.cpp] stop enigma crash in case of font reading errors

### DIFF
--- a/lib/gdi/font.cpp
+++ b/lib/gdi/font.cpp
@@ -645,12 +645,19 @@ int eTextPara::renderString(const char *string, int rflags, int border)
 	singleLock s(ftlock);
 
 	if (!current_font)
+	{
+		eWarning("[eTextPara] renderString: No current_font!");
 		return -1;
-
+	}
 	if (!current_face)
-		eFatal("[eTextPara] renderString: No current_face!");
+	{
+		eWarning("[eTextPara] renderString: No current_face!");
+		return -1;
+	}
 	if (!current_face->size)
-		eFatal("[eTextPara] renderString: No current_face->size!");
+		eWarning("[eTextPara] renderString: No current_face->size!");
+		return -1;
+	}
 
 	if (cursor.y()==-1)
 	{

--- a/lib/gdi/font.cpp
+++ b/lib/gdi/font.cpp
@@ -655,6 +655,7 @@ int eTextPara::renderString(const char *string, int rflags, int border)
 		return -1;
 	}
 	if (!current_face->size)
+	{
 		eWarning("[eTextPara] renderString: No current_face->size!");
 		return -1;
 	}


### PR DESCRIPTION
Log:
[eListboxPythonConfigContent] second value of tuple is not a
tuple.
[eTextPara] renderString: No current_face->size!

dmesg

<6>[    1.368418] ehci-brcm f0480300.ehci: EHCI Host Controller
<6>[
1.373997] ehci-brcm f0480300.ehci: new USB bus registered, assigned bus
number 3

restart enigma2

This happens very rarely, but openATV also had a solution for this error

https://github.com/openatv/enigma2/commit/e8a14ed031c225353a77a168aa05beca339355df#diff-dedda219c4527313d2191fb406791b753dfd0f245b787f571ba2e71df5f4371a