### PR TITLE
Wakeup timer - change logic when powered on from deep standby

### DIFF
--- a/Navigation.py
+++ b/Navigation.py
@@ -40,10 +40,13 @@ class Navigation:
 		self.__isRestartUI = config.misc.RestartUI.value
 		startup_to_standby = config.usage.startup_to_standby.value
 		wakeup_time_type = config.misc.prev_wakeup_time_type.value
+		wakeup_timer_enabled = False
 		if config.usage.remote_fallback_import_restart.value:
 			ImportChannels()
 		if self.__wasTimerWakeup:
-			RecordTimer.RecordTimerEntry.setWasInDeepStandby()
+			wakeup_timer_enabled = wakeup_time_type == 3 and config.misc.prev_wakeup_time.value
+			if not wakeup_timer_enabled:
+				RecordTimer.RecordTimerEntry.setWasInDeepStandby()
 		if config.misc.RestartUI.value:
 			config.misc.RestartUI.value = False
 			config.misc.RestartUI.save()
@@ -51,9 +54,9 @@ class Navigation:
 		else:
 			if config.usage.remote_fallback_import.value and not config.usage.remote_fallback_import_restart.value:
 				ImportChannels()
-			if startup_to_standby == "yes" or self.__wasTimerWakeup and config.misc.prev_wakeup_time.value and ((wakeup_time_type == 0 or wakeup_time_type == 1) or ( wakeup_time_type == 3 and startup_to_standby == "except")):
+			if startup_to_standby == "yes" or self.__wasTimerWakeup and config.misc.prev_wakeup_time.value and (wakeup_time_type == 0 or wakeup_time_type == 1 or (wakeup_time_type == 3 and startup_to_standby == "except")):
 				if not Screens.Standby.inTryQuitMainloop:
-					Notifications.AddNotification(Screens.Standby.Standby)
+					Notifications.AddNotification(Screens.Standby.Standby, wakeup_timer_enabled and 1 or True)
 		if config.misc.prev_wakeup_time.value:
 			config.misc.prev_wakeup_time.value = 0
 			config.misc.prev_wakeup_time.save()

--- a/lib/python/Screens/Standby.py
+++ b/lib/python/Screens/Standby.py
@@ -110,13 +110,14 @@ class StandbyScreen(Screen):
 		if gotoShutdownTime:
 			self.standbyTimeoutTimer.startLongTimer(gotoShutdownTime)
 
-		gotoWakeupTime = isNextWakeupTime(True)
-		if gotoWakeupTime != -1:
-			curtime = localtime(time())
-			if curtime.tm_year > 1970:
-				wakeup_time = int(gotoWakeupTime - time())
-				if wakeup_time > 0:
-					self.standbyWakeupTimer.startLongTimer(wakeup_time)
+		if self.StandbyCounterIncrease is not 1:
+			gotoWakeupTime = isNextWakeupTime(True)
+			if gotoWakeupTime != -1:
+				curtime = localtime(time())
+				if curtime.tm_year > 1970:
+					wakeup_time = int(gotoWakeupTime - time())
+					if wakeup_time > 0:
+						self.standbyWakeupTimer.startLongTimer(wakeup_time)
 
 		self.onFirstExecBegin.append(self.__onFirstExecBegin)
 		self.onClose.append(self.__onClose)


### PR DESCRIPTION
[Standby] do not switch on from standby if used "Startup to Standby" and
"Wakeup timer"
[Navigation] do not consider the wakeup timer to be automatic
More info:
https://forums.openpli.org/topic/79649-timer-after-event-automatic/