### PR TITLE
[Satfinder] assign a variable self.timer before onShow

### DIFF
--- a/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
@@ -40,6 +40,8 @@ class Satfinder(ScanSetup, ServiceScan):
 		self.frontend = None
 		self.is_id_boolEntry = None
 		self.t2mi_plp_id_boolEntry = None
+		self.timer = eTimer()
+		self.timer.callback.append(self.updateFrontendStatus)
 
 		ScanSetup.__init__(self, session)
 		self.setTitle(_("Signal finder"))
@@ -56,8 +58,6 @@ class Satfinder(ScanSetup, ServiceScan):
 		self.session.postScanService = self.session.nav.getCurrentlyPlayingServiceOrGroup()
 		self.onClose.append(self.__onClose)
 		self.onShow.append(self.prepareFrontend)
-		self.timer = eTimer()
-		self.timer.callback.append(self.updateFrontendStatus)
 
 	def openFrontend(self):
 		res_mgr = eDVBResourceManager.getInstance()


### PR DESCRIPTION
<File
"/usr/lib/enigma2/python/Plugins/SystemPlugins/Satfinder/plugin.py",
line 44, in __init__
File "/usr/lib/enigma2/python/Screens/ScanSetup.py", line 612, in
__init__
File
"/usr/lib/enigma2/python/Plugins/SystemPlugins/Satfinder/plugin.py",
line 252, in createSetup
File "/usr/lib/enigma2/python/Components/config.py", line 831, in
setValue
File "/usr/lib/enigma2/python/Components/config.py", line 109, in
changed
File
"/usr/lib/enigma2/python/Plugins/SystemPlugins/Satfinder/plugin.py",
line 491, in retune
AttributeError: 'Satfinder' object has no attribute 'timer'>