### PR TITLE
ScrollLabel.py: "split" attribute

### DIFF
--- a/lib/python/Components/ScrollLabel.py
+++ b/lib/python/Components/ScrollLabel.py
@@ -39,7 +39,7 @@ class ScrollLabel(GUIComponent):
 					scrollbarBorderWidth = int(value)
 					self.skinAttributes.remove((attrib, value))
 				elif "split" in attrib:
-					self.split = int(value)
+					self.split = 1 if value.lower() in ("1", "enabled", "on", "split", "true", "yes") else 0
 					if self.split:
 						self.right_text = eLabel(self.instance)
 					self.skinAttributes.remove((attrib, value))	


### PR DESCRIPTION
Bring ScrollLabel "split" attribute in line with other boolean type attributes in skins.

e.g. from skin.py:

	def scale(self, value):
		value = 1 if value.lower() in ("1", "enabled", "on", "scale", "true", "yes") else 0
		self.guiObject.setScale(value)

https://github.com/OpenPLi/enigma2/blob/develop/skin.py#L501-L503