### PR TITLE
[skin.py] add 'colposition', 'dividechar' and 'split'

### DIFF
--- a/skin.py
+++ b/skin.py
@@ -643,6 +643,16 @@ class AttributeParser:
 		value = 1 if value.lower() in ("1", "enabled", "nowrap", "on", "true", "yes") else 0
 		self.guiObject.setNoWrap(value)
 
+	def split(self, value):
+		pass
+
+	def colposition(self, value):
+		pass
+
+	def dividechar(self, value):
+		pass
+
+
 def applySingleAttribute(guiObject, desktop, attrib, value, scale=((1, 1), (1, 1))):
 	# Is anyone still using applySingleAttribute?
 	AttributeParser(guiObject, desktop, scale).applyOne(attrib, value)


### PR DESCRIPTION
Add 'colposition', 'dividechar' and 'split' to 'AttributeParser' to suppress false warnings in the debug log.

These are valid ScrollLabel attributes. See here: https://github.com/OpenPLi/enigma2/blob/develop/lib/python/Components/ScrollLabel.py#L41-L49