### PR TITLE
[ScrollLabel.py] fix "scrollbarSliderPicture" and "scrollbarBackgroun…

### DIFF
--- a/lib/python/Components/ScrollLabel.py
+++ b/lib/python/Components/ScrollLabel.py
@@ -25,10 +25,16 @@ class ScrollLabel(GUIComponent):
 		if self.skinAttributes:
 			widget_attribs = []
 			scrollbar_attribs = []
-			scrollbarAttrib = ["borderColor", "borderWidth", "scrollbarSliderForegroundColor", "scrollbarSliderBorderColor", "scrollbarSliderPicture", "scrollbarBackgroundPicture"]
-			for (attrib, value) in self.skinAttributes:
+			scrollbarAttrib = ["borderColor", "borderWidth", "scrollbarSliderForegroundColor", "scrollbarSliderBorderColor"]
+			for (attrib, value) in self.skinAttributes[:]:
 				if attrib in scrollbarAttrib:
 					scrollbar_attribs.append((attrib, value))
+					self.skinAttributes.remove((attrib, value))
+				elif attrib in ("scrollbarSliderPicture", "sliderPixmap"):
+					self.scrollbar.setPixmap(skin.loadPixmap(value, desktop))
+					self.skinAttributes.remove((attrib, value))
+				elif attrib in ("scrollbarBackgroundPicture", "scrollbarbackgroundPixmap"):
+					self.scrollbar.setBackgroundPixmap(skin.loadPixmap(value, desktop))
 					self.skinAttributes.remove((attrib, value))
 				elif "transparent" in attrib or "backgroundColor" in attrib:
 					widget_attribs.append((attrib, value))


### PR DESCRIPTION
…dPicture"

Previously these attributes did not work and raised an AttributeError.

Switch "self.skinAttributes" to "self.skinAttributes[:]" so we are iterating a copy of the list while modifying the original.

Previously the loop which was iterating "self.skinAttributes" was removing items from the same list (a Python no-no). This means that if the current (or a previous) item is deleted from the sequence, the next item will be skipped (since it gets the index of the current item which has already been treated).