### PR TITLE
[Tools.Directories] SCOPE_FONT: Check the "fonts" folder

### DIFF
--- a/lib/python/Tools/Directories.py
+++ b/lib/python/Tools/Directories.py
@@ -127,11 +127,11 @@ def resolveFilename(scope, base="", path_prefix=None):
 		resolveList = [
 			os.path.join(defaultPaths[SCOPE_CONFIG][0], skin),
 			os.path.join(defaultPaths[SCOPE_CONFIG][0], "skin_common"),
-			defaultPaths[SCOPE_CONFIG][0],  # Can we deprecate top level of SCOPE_CONFIG directory to allow a clean up?
+			defaultPaths[SCOPE_CONFIG][0],
 			os.path.join(defaultPaths[SCOPE_SKIN][0], skin),
 			os.path.join(defaultPaths[SCOPE_SKIN][0], "skin_fallback_%d" % getDesktop(0).size().height()),
 			os.path.join(defaultPaths[SCOPE_SKIN][0], "skin_default"),
-			defaultPaths[SCOPE_SKIN][0]  # Can we deprecate top level of SCOPE_SKIN directory to allow a clean up?
+			defaultPaths[SCOPE_SKIN][0]
 		]
 		for item in resolveList:
 			file = os.path.join(item, base)
@@ -148,11 +148,11 @@ def resolveFilename(scope, base="", path_prefix=None):
 		resolveList = [
 			os.path.join(defaultPaths[SCOPE_CONFIG][0], "display", skin),
 			os.path.join(defaultPaths[SCOPE_CONFIG][0], "display", "skin_common"),
-			defaultPaths[SCOPE_CONFIG][0],  # Can we deprecate top level of SCOPE_CONFIG directory to allow a clean up?
+			defaultPaths[SCOPE_CONFIG][0],
 			os.path.join(defaultPaths[SCOPE_LCDSKIN][0], skin),
 			os.path.join(defaultPaths[SCOPE_LCDSKIN][0], "skin_fallback_%s" % getDesktop(1).size().height()),
 			os.path.join(defaultPaths[SCOPE_LCDSKIN][0], "skin_default"),
-			defaultPaths[SCOPE_LCDSKIN][0]  # Can we deprecate top level of SCOPE_LCDSKIN directory to allow a clean up?
+			defaultPaths[SCOPE_LCDSKIN][0]
 		]
 		for item in resolveList:
 			file = os.path.join(item, base)
@@ -166,13 +166,16 @@ def resolveFilename(scope, base="", path_prefix=None):
 		display = os.path.dirname(config.skin.display_skin.value) if hasattr(config.skin, "display_skin") else None
 		resolveList = [
 			os.path.join(defaultPaths[SCOPE_CONFIG][0], "fonts"),
+			os.path.join(defaultPaths[SCOPE_CONFIG][0], skin, "fonts"),
 			os.path.join(defaultPaths[SCOPE_CONFIG][0], skin)
 		]
 		if display:
 			resolveList.append(os.path.join(defaultPaths[SCOPE_CONFIG][0], "display", display))
 		resolveList.append(os.path.join(defaultPaths[SCOPE_CONFIG][0], "skin_common"))
-		resolveList.append(defaultPaths[SCOPE_CONFIG][0])  # Can we deprecate top level of SCOPE_CONFIG directory to allow a clean up?
+		resolveList.append(defaultPaths[SCOPE_CONFIG][0])
+		resolveList.append(os.path.join(defaultPaths[SCOPE_SKIN][0], skin, "fonts"))
 		resolveList.append(os.path.join(defaultPaths[SCOPE_SKIN][0], skin))
+		resolveList.append(os.path.join(defaultPaths[SCOPE_SKIN][0], "skin_default", "fonts"))
 		resolveList.append(os.path.join(defaultPaths[SCOPE_SKIN][0], "skin_default"))
 		if display:
 			resolveList.append(os.path.join(defaultPaths[SCOPE_LCDSKIN][0], display))


### PR DESCRIPTION
Before this commit it was necessary to use a path when accessing a font from the current skin. It makes sense, if we are trying to locate a font, that the "fonts" folder is tested directly as this is the most likely place a font file will be located in the currently active skin.

e.g. to access...
<font name="Regular" filename="/usr/share/enigma2/<skin-name>/fonts/SFNSDisplay-Regular.otf" scale="100" />
or this...
<font name="Regular" filename="fonts/SFNSDisplay-Regular.otf" scale="100" />

it is now possible to do this...
<font name="Regular" filename="SFNSDisplay-Regular.otf" scale="100" />

It is wrong that it is possible to access a font located in "/usr/share/fonts" without using a path, but if accessing a font in "/usr/share/enigma2/<skin-name>/fonts" a path is required. This commit allows consistence between these locations.

Consistency needs to come first. We shouldn't have confusing traps like this in enigma.

Also remove some comments that if ever implemented would wreak havoc throughout the enigma community.