### PR TITLE
Fix font and itemHeight scale in TemplatedMultiContent

### DIFF
--- a/lib/gdi/gfont.h
+++ b/lib/gdi/gfont.h
@@ -28,6 +28,11 @@ public:
 	{
 	}
 
+	gFont(const std::string &family, float pointSize):
+		family(family), pointSize((int)pointSize)
+	{
+	}
+
 	virtual ~gFont()
 	{
 	}

--- a/lib/python/Components/Converter/TemplatedMultiContent.py
+++ b/lib/python/Components/Converter/TemplatedMultiContent.py
@@ -53,7 +53,7 @@ class TemplatedMultiContent(StringList):
 				if len(templates[style]) > 3:
 					scrollbarMode = templates[style][3]
 			self.content.setTemplate(template)
-			self.content.setItemHeight(itemheight)
+			self.content.setItemHeight(int(itemheight))
 			self.selectionEnabled = selectionEnabled
 			self.scrollbarMode = scrollbarMode
 			self.active_style = style

--- a/lib/python/Tools/LoadPixmap.py
+++ b/lib/python/Tools/LoadPixmap.py
@@ -3,7 +3,7 @@ from enigma import loadPNG, loadJPG, loadSVG
 # If cached is not supplied, LoadPixmap defaults to caching PNGs and not caching JPGs
 # Split alpha channel JPGs are never cached as the C++ layer's caching is based on
 # a single file per image in the cache
-def LoadPixmap(path, desktop=None, cached=None, size=None):
+def LoadPixmap(path, desktop=None, cached=None, _size=None):
 	if path[-4:] == ".png":
 		# cache unless caller explicity requests to not cache
 		ptr = loadPNG(path, 0, 0 if cached == False else 1)
@@ -11,7 +11,7 @@ def LoadPixmap(path, desktop=None, cached=None, size=None):
 		# don't cache unless caller explicity requests caching
 		ptr = loadJPG(path, 1 if cached == True else 0)
 	elif path[-4:] == ".svg":
-		ptr = loadSVG(path, 0 if cached == False else 1, size.height() if size else 0, size.width() if size else 0)
+		ptr = loadSVG(path, 0 if cached == False else 1, _size.height() if _size else 0, _size.width() if _size else 0)
 	elif path[-1:] == ".":
 		# caching mechanism isn't suitable for multi file images, so it's explicitly disabled
 		alpha = loadPNG(path + "a.png", 0, 0)


### PR DESCRIPTION
If in skin uses "*f" to use getSkinFactor on FHD skin getSkinFactor return 1.5 which is flaot.
Therefore, when it multiplied by the values on eval they are also converted to float.
To fix this allows use float in gFont and convert the value to int in setItemHeight.