### PR TITLE
[ScanSetup] fix VU+ auto terrestial scan T2 (binar utility) part 2

### DIFF
--- a/lib/python/Screens/ScanSetup.py
+++ b/lib/python/Screens/ScanSetup.py
@@ -818,6 +818,8 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 				if nimmanager.getNimName(nim.slot).startswith("Sundtek"):
 					self.TerrestrialCompleteEntry = getConfigListEntry(_('Scan options'), self.scan_ter_complete_type)
 					self.list.append(self.TerrestrialCompleteEntry)
+				elif SystemInfo["Blindscan_t2_available"]:
+					self.list.append(getConfigListEntry(_('Blindscan'), self.scan_terrestrial_blindscan))
 				if self.TerrestrialCompleteEntry is None or self.scan_ter_complete_type.value == "extended":
 					if nim.canBeCompatible("DVB-T2"):
 						self.systemEntry = getConfigListEntry(_('System'), self.scan_ter.system)
@@ -1250,6 +1252,7 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 		self.scan_clearallservices = ConfigSelection(default = "no", choices = [("no", _("no")), ("yes", _("yes")), ("yes_hold_feeds", _("yes (keep feeds)"))])
 		self.scan_onlyfree = ConfigYesNo(default = False)
 		self.scan_networkScan = ConfigYesNo(default = False)
+		self.scan_terrestrial_blindscan = ConfigYesNo(default = False)
 
 		return True
 
@@ -1449,7 +1452,7 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 				skip_t2 = False
 				if nimmanager.getNimName(nim.slot).startswith("Sundtek") and self.scan_ter_complete_type.value == "all":
 					action = SEARCH_TERRESTRIAL2_TRANSPONDERS
-				elif SystemInfo["Blindscan_t2_available"]:
+				elif SystemInfo["Blindscan_t2_available"] and self.scan_terrestrial_blindscan.value:
 					if nim.isCompatible("DVB-T2"):
 						if len(self.terrestrialTransponderGetCmd(nim.slot)):
 							action = SEARCH_TERRESTRIAL2_TRANSPONDERS


### PR DESCRIPTION
Continues the work of Dima73: https://github.com/OpenPLi/enigma2/commit/3d3a8e545f8ac87f55860d52b9da25806f84031f#diff-2c1342073235ee5fbd5511a02bc53ab721c106cfb29ab7772f7ea5388d8d2a44

Solves various problems...

1) Prior to this commit the scan was started with "self.tlist" already populated which means any failures found by the binary executable were ignored. This commit rectifies that (starts with an empty list) and now the code is parallel to the functioning of the cable binary executable scan.

2) "self.terrestrial_search_data += str", that should not be concatenating. This is one item processed at a time.

3) "data[3] == 1", that can never work because data[3] is always a string.

4) "parm.bandwidth = int(data[2])", is wrong. Should be converted to the correct bandwidth parameter, not use the bandwidth value directly.

5) Binary executable returns junk for system value, i.e. returns "2" even when it is not a T2 multiplex.

6) Add handling for when binary executable returns "system == 2" but no plp details. (we don't have plp stuff in terrestrials.xml anyway and enigma has no problem with that).

Tested and working as expected on Vu Ultimo 4k with "TT3L10" DVB-T2 twin tuner module.