### PR TITLE
Use width and height instead of size in LoadPixmap

### DIFF
--- a/lib/gdi/epng.cpp
+++ b/lib/gdi/epng.cpp
@@ -362,7 +362,7 @@ static int savePNGto(FILE *fp, gPixmap *pixmap)
 	return 0;
 }
 
-int loadSVG(ePtr<gPixmap> &result, const char *filename, int cached, int height, int width)
+int loadSVG(ePtr<gPixmap> &result, const char *filename, int cached, int width, int height)
 {
 	result = nullptr;
 

--- a/lib/gdi/epng.cpp
+++ b/lib/gdi/epng.cpp
@@ -377,9 +377,7 @@ int loadSVG(ePtr<gPixmap> &result, const char *filename, int cached, int height,
 
 	image = nsvgParseFromFile(filename, "px", 96.0);
 	if (image == nullptr)
-	{
 		return 0;
-	}
 
 	rast = nsvgCreateRasterizer();
 	if (rast == nullptr)
@@ -388,10 +386,22 @@ int loadSVG(ePtr<gPixmap> &result, const char *filename, int cached, int height,
 		return 0;
 	}
 
-	if (height > 0 && width > 0)
+	if (height > 0)
+		yscale = ((double) height) / image->height;
+
+	if (width > 0)
 	{
 		xscale = ((double) width) / image->width;
-		yscale = ((double) height) / image->height;
+		if (height <= 0)
+		{
+			yscale = xscale;
+			height = (int)(image->height * yscale);
+		}
+	}
+	else if (height > 0)
+	{
+		xscale = yscale;
+		width = (int)(image->width * xscale);
 	}
 	else
 	{

--- a/lib/gdi/epng.h
+++ b/lib/gdi/epng.h
@@ -6,7 +6,7 @@
 SWIG_VOID(int) loadPNG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, int accel = 0, int cached = 1);
 SWIG_VOID(int) loadJPG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, int cached = 0);
 SWIG_VOID(int) loadJPG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, ePtr<gPixmap> alpha, int cached = 0);
-SWIG_VOID(int) loadSVG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, int cached = 0, int height = 0, int width = 0);
+SWIG_VOID(int) loadSVG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, int cached = 0, int width = 0, int height = 0);
 
 int savePNG(const char *filename, gPixmap *pixmap);
 

--- a/lib/python/Tools/LoadPixmap.py
+++ b/lib/python/Tools/LoadPixmap.py
@@ -3,7 +3,7 @@ from enigma import loadPNG, loadJPG, loadSVG
 # If cached is not supplied, LoadPixmap defaults to caching PNGs and not caching JPGs
 # Split alpha channel JPGs are never cached as the C++ layer's caching is based on
 # a single file per image in the cache
-def LoadPixmap(path, desktop=None, cached=None, _size=None):
+def LoadPixmap(path, desktop=None, cached=None, width=0, height=0):
 	if path[-4:] == ".png":
 		# cache unless caller explicity requests to not cache
 		ptr = loadPNG(path, 0, 0 if cached == False else 1)
@@ -11,7 +11,7 @@ def LoadPixmap(path, desktop=None, cached=None, _size=None):
 		# don't cache unless caller explicity requests caching
 		ptr = loadJPG(path, 1 if cached == True else 0)
 	elif path[-4:] == ".svg":
-		ptr = loadSVG(path, 0 if cached == False else 1, _size.height() if _size else 0, _size.width() if _size else 0)
+		ptr = loadSVG(path, 0 if cached == False else 1, width, height)
 	elif path[-1:] == ".":
 		# caching mechanism isn't suitable for multi file images, so it's explicitly disabled
 		alpha = loadPNG(path + "a.png", 0, 0)

--- a/skin.py
+++ b/skin.py
@@ -355,13 +355,13 @@ def parseParameter(s):
 	else:  # Integer.
 		return int(s)
 
-def loadPixmap(path, desktop, size=None):
+def loadPixmap(path, desktop, width=0, height=0):
 	option = path.find("#")
 	if option != -1:
 		path = path[:option]
 	if rc_model.rcIsDefault() is False and basename(path) in ("rc.png", "rc0.png", "rc1.png", "rc2.png", "oldrc.png"):
 		path = rc_model.getRcImg()
-	pixmap = LoadPixmap(path, desktop, None, size)
+	pixmap = LoadPixmap(path, desktop, None, width, height)
 	if pixmap is None:
 		raise SkinError("Pixmap file '%s' not found" % path)
 	return pixmap
@@ -475,7 +475,7 @@ class AttributeParser:
 		self.guiObject.setItemHeight(int(value))
 
 	def pixmap(self, value):
-		self.guiObject.setPixmap(loadPixmap(value, self.desktop, self.guiObject.size()))
+		self.guiObject.setPixmap(loadPixmap(value, self.desktop, self.guiObject.size().width(), self.guiObject.size().height()))
 
 	def backgroundPixmap(self, value):
 		self.guiObject.setBackgroundPicture(loadPixmap(value, self.desktop))


### PR DESCRIPTION
Allow scale svg only from height or width size