### PR TITLE
Use StartEnigma name instead of Startup

### DIFF
--- a/lib/python/Makefile.am
+++ b/lib/python/Makefile.am
@@ -12,5 +12,5 @@ install_PYTHON = \
 	RecordTimer.py \
 	ServiceReference.py \
 	skin.py \
-	Startup.py \
+	StartEnigma.py \
 	timer.py

--- a/lib/python/Screens/Standby.py
+++ b/lib/python/Screens/Standby.py
@@ -247,7 +247,7 @@ class QuitMainloopScreen(Screen):
 			QUIT_REBOOT: _("Your receiver is rebooting"),
 			QUIT_RESTART: _("The user interface of your receiver is restarting"),
 			QUIT_UPGRADE_FP: _("Your frontprocessor will be updated\nPlease wait until your receiver reboots\nThis may take a few minutes"),
-			QUIT_ERROR_RESTART: _("The user interface of your receiver is restarting\ndue to an error in mytest.py"),
+			QUIT_ERROR_RESTART: _("The user interface of your receiver is restarting\ndue to an error in StartEnigma.py"),
 			QUIT_DEBUG_RESTART: _("The user interface of your receiver is restarting in debug mode"),
 			QUIT_UPGRADE_PROGRAM: _("Unattended update in progress\nPlease wait until your receiver reboots\nThis may take a few minutes"),
 			QUIT_MANUFACTURER_RESET: _("Manufacturer reset in progress\nPlease wait until enigma2 restarts")

--- a/lib/python/StartEnigma.py
+++ b/lib/python/StartEnigma.py
@@ -98,7 +98,7 @@ try:
 	def runReactor():
 		reactor.run(installSignalHandlers=False)
 except ImportError:
-	print "twisted not available"
+	print "[StartEnigma] Twisted not available"
 	def runReactor():
 		enigma.runMainloop()
 
@@ -190,7 +190,7 @@ class Session:
 			try:
 				p(reason=0, session=self)
 			except:
-				print "Plugin raised exception at WHERE_SESSIONSTART"
+				print "[StartEnigma] Plugin raised exception at WHERE_SESSIONSTART"
 				import traceback
 				traceback.print_exc()
 
@@ -305,7 +305,7 @@ class Session:
 
 	def close(self, screen, *retval):
 		if not self.in_exec:
-			print "close after exec!"
+			print "[StartEnigma] Close after exec!"
 			return
 
 		# be sure that the close is for the right dialog!
@@ -351,7 +351,7 @@ class PowerKey:
 		globalActionMap.actions["discrete_off"] = self.standby
 
 	def shutdown(self):
-		print "PowerOff - Now!"
+		print "[StartEnigma] PowerOff - Now!"
 		if not Screens.Standby.inTryQuitMainloop and self.session.current_dialog and self.session.current_dialog.ALLOW_SUSPEND:
 			self.session.open(Screens.Standby.TryQuitMainloop, 1)
 		else:
@@ -377,7 +377,7 @@ class PowerKey:
 					exec "from " + selected[1] + " import *"
 					exec "self.session.open(" + ",".join(selected[2:]) + ")"
 				except:
-					print "[mytest] error during executing module %s, screen %s" % (selected[1], selected[2])
+					print "[StartEnigma] Error during executing module %s, screen %s" % (selected[1], selected[2])
 			elif selected[0] == "Menu":
 				from Screens.Menu import MainMenu, mdom
 				root = mdom.getroot()
@@ -507,9 +507,9 @@ def runScreenTest():
 		else:
 			wptime = startTime[0] - 240
 		if not config.misc.useTransponderTime.value:
-			print "dvb time sync disabled... so set RTC now to current linux time!", strftime("%Y/%m/%d %H:%M", localtime(nowTime))
+			print "[StartEnigma] DVB time sync disabled... so set RTC now to current linux time!", strftime("%Y/%m/%d %H:%M", localtime(nowTime))
 			setRTCtime(nowTime)
-		print "set wakeup time to", strftime("%Y/%m/%d %H:%M", localtime(wptime))
+		print "[StartEnigma] Set wakeup time to", strftime("%Y/%m/%d %H:%M", localtime(wptime))
 		setFPWakeuptime(wptime)
 		config.misc.prev_wakeup_time.value = int(startTime[0])
 		config.misc.prev_wakeup_time_type.value = startTime[1]
@@ -592,7 +592,7 @@ try:
 
 	Components.ParentalControl.parentalControl.save()
 except:
-	print 'EXCEPTION IN PYTHON STARTUP CODE:'
+	print '[StartEnigma] EXCEPTION IN PYTHON STARTUP CODE:'
 	print '-'*60
 	print_exc(file=stdout)
 	enigma.quitMainloop(5)

--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -108,7 +108,7 @@ def InitSkins():
 		loadSkin(USER_SKIN, scope=SCOPE_CURRENT_SKIN, desktop=getDesktop(GUI_SKIN_ID), screenID=GUI_SKIN_ID)
 	runCallbacks = True
 
-# Temporary entry point for older versions of mytest.py.
+# Temporary entry point for older versions of StartEnigma.py.
 #
 def loadSkinData(desktop):
 	InitSkins()

--- a/main/enigma.cpp
+++ b/main/enigma.cpp
@@ -300,7 +300,7 @@ int main(int argc, char **argv)
 	/* start at full size */
 	eVideoWidget::setFullsize(true);
 
-	python.execFile(eEnv::resolve("${libdir}/enigma2/python/Startup.py").c_str());
+	python.execFile(eEnv::resolve("${libdir}/enigma2/python/StartEnigma.py").c_str());
 
 	/* restore both decoders to full size */
 	eVideoWidget::setFullsize(true);

--- a/po/ar.po
+++ b/po/ar.po
@@ -9706,7 +9706,7 @@ msgstr "جاري إعادة تشغيل واجهة المستخدم على %s %s 
 #, fuzzy
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "جاري %s %s إعادة تشغيل واجهة المستخدم الخاصة\n"
 "هناك خطاء في ملف الاختبار.البايثون"

--- a/po/bg.po
+++ b/po/bg.po
@@ -9046,10 +9046,10 @@ msgstr "Потребителският интерфейс на приемник�
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Потребителският интерфейс на приемника се рестартира\n"
-"поради грешка в mytest.py"
+"поради грешка в StartEnigma.py"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "Потребителският интерфейс на приемника се рестартира в режим за отстраняване на грешки"

--- a/po/ca.po
+++ b/po/ca.po
@@ -10130,10 +10130,10 @@ msgstr "S’inicia la interfície d’usuari del receptor"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "S’inicia la interfície d’usuari del receptor\n"
-"a causa d’un error a mytest.py"
+"a causa d’un error a StartEnigma.py"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "La interfície d’usuari del receptor es reinicia en mode de depuració"

--- a/po/cs.po
+++ b/po/cs.po
@@ -10431,10 +10431,10 @@ msgstr "Uživatelské rozhraní se restartuje"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Uživatelské rozhraní bylo restartováno\n"
-"kvůli chybě v mytest.py"
+"kvůli chybě v StartEnigma.py"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "Uživatelské rozhraní se restartuje v debug módu"

--- a/po/da.po
+++ b/po/da.po
@@ -10410,10 +10410,10 @@ msgstr "Brugerinterfacet på din modtager genstarter"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Brugerinterfacet på din modtager genstarter\n"
-"på grund af en fejl i mytest.py"
+"på grund af en fejl i StartEnigma.py"
 
 #, fuzzy
 msgid "The user interface of your receiver is restarting in debug mode"

--- a/po/de.po
+++ b/po/de.po
@@ -9071,10 +9071,10 @@ msgstr "Die Benutzeroberfläche des Receivers wird neu gestartet"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Die Benutzeroberfläche des Receivers wird aufgrund eines Fehlers\n"
-"in mytest.py neu gestartet"
+"in StartEnigma.py neu gestartet"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "Die Benutzeroberfläche Ihres Empfängers wird im Debug-Modus neu gestartet"

--- a/po/el.po
+++ b/po/el.po
@@ -9056,10 +9056,10 @@ msgstr "Γίνεται επανεκκίνηση της διεπαφής χρήσ
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Γίνεται επανεκκίνηση της διεπαφής χρήστη του δέκτη σας\n"
-"εξαιτίας σφάλματος στο mytest.py"
+"εξαιτίας σφάλματος στο StartEnigma.py"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "Γίνεται επανεκκίνηση της διεπαφής χρήστη του δέκτη σας σε λειτουργία αποσφαλμάτωσης"

--- a/po/en.po
+++ b/po/en.po
@@ -9197,10 +9197,10 @@ msgstr "The user interface of your receiver is restarting"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 
 #, fuzzy
 msgid "The user interface of your receiver is restarting in debug mode"

--- a/po/es.po
+++ b/po/es.po
@@ -10117,10 +10117,10 @@ msgstr "La interfaz de usuario de su receptor se está reiniciando"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "La interfaz de usuario de su receptor se está reiniciando\n"
-"Debido a un error en mytest.py"
+"Debido a un error en StartEnigma.py"
 
 #
 msgid "The user interface of your receiver is restarting in debug mode"

--- a/po/et.po
+++ b/po/et.po
@@ -9155,10 +9155,10 @@ msgstr "Vastuvõtja kasutajaliides taaskäivitub."
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Vastuvõtja kasutajaliides taaskäivitub\n"
-" vea tõttu 'mytest.py' failis"
+" vea tõttu 'StartEnigma.py' failis"
 
 #, fuzzy
 msgid "The user interface of your receiver is restarting in debug mode"

--- a/po/fa.po
+++ b/po/fa.po
@@ -9381,7 +9381,7 @@ msgstr "رابط کاربری دستگاه شما در حال راه انداز�
 #, fuzzy
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr "رابط کاربری دستگاه شما در حال راه اندازی مجدد است"
 
 #, fuzzy

--- a/po/fi.po
+++ b/po/fi.po
@@ -10217,10 +10217,10 @@ msgstr "Vastaanottimesi käyttöliittymä käynnistyy uudelleen"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Vastaanottimesi käyttöliittymä käynnistyy uudelleen\n"
-"johtuen virheestä mytest.py tiedostossa"
+"johtuen virheestä StartEnigma.py tiedostossa"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "Vastaanottimesi käyttöliittymä käynnistyy uudelleen debug tilaan"

--- a/po/fr.po
+++ b/po/fr.po
@@ -9055,10 +9055,10 @@ msgstr "L'interface utilisateur de votre récepteur redémarre"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "L'interface utilisateur de votre récepteur redémarre\n"
-"en raison d'une erreur dans mytest.py"
+"en raison d'une erreur dans StartEnigma.py"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "L'interface utilisateur de votre récepteur redémarre en mode déboggage"

--- a/po/fy.po
+++ b/po/fy.po
@@ -10527,7 +10527,7 @@ msgstr "Wachtsje oant it netwurk opnei start is..."
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 
 #

--- a/po/gl.po
+++ b/po/gl.po
@@ -10123,10 +10123,10 @@ msgstr "Está a reiniciarse a interface de usuario do receptor"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Está a reiniciarse a interface de usuario do receptor\n"
-"debido a un erro en mytest.py"
+"debido a un erro en StartEnigma.py"
 
 #
 msgid "The user interface of your receiver is restarting in debug mode"

--- a/po/he.po
+++ b/po/he.po
@@ -9918,7 +9918,7 @@ msgstr "...נא המתן בעת איתחול הרשת"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 
 #, fuzzy

--- a/po/hr.po
+++ b/po/hr.po
@@ -9070,10 +9070,10 @@ msgstr "Korisničko sučelje vašeg prijemnika se ponovno pokreće."
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Korisničko sučelje vašeg prijemnika se ponovno pokreće\n"
-"zbog pogreške u mytest.py"
+"zbog pogreške u StartEnigma.py"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "Korisničko sučelje vašeg prijemnika ponovno se pokreće u načinu za otklanjanje pogrešaka"

--- a/po/hu.po
+++ b/po/hu.po
@@ -9051,10 +9051,10 @@ msgstr "A kezelőfelület újraindítása folyamatban van"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "A kezelőfelület újraindítása folyamatban van\n"
-"a mytest.py fájlban lévő hiba miatt"
+"a StartEnigma.py fájlban lévő hiba miatt"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "A kezelőfelület hibakeresési módban indul újra"

--- a/po/id.po
+++ b/po/id.po
@@ -9334,10 +9334,10 @@ msgstr "Antarmuka pengguna rx anda sedang memulai ulang"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Antarmuka pengguna rx anda sedang memulai ulang\n"
-"disebabkan kesalahan pada berkas mytest.py"
+"disebabkan kesalahan pada berkas StartEnigma.py"
 
 #, fuzzy
 msgid "The user interface of your receiver is restarting in debug mode"

--- a/po/is.po
+++ b/po/is.po
@@ -10355,7 +10355,7 @@ msgstr "Vinsamlega bíðið á meðan netkerfið er endurræst..."
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 
 #

--- a/po/it.po
+++ b/po/it.po
@@ -9108,10 +9108,10 @@ msgstr "Riavvio dell'interfaccia utente del ricevitore in corso..."
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "L'interfaccia utente del ricevitore si sta riavviando\n"
-"a causa di un errore in mytest.py"
+"a causa di un errore in StartEnigma.py"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "L'interfaccia utente del ricevitore si riavvia in modalità debug"

--- a/po/ku.po
+++ b/po/ku.po
@@ -9198,10 +9198,10 @@ msgstr "The user interface of your receiver is restarting"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 
 #, fuzzy
 msgid "The user interface of your receiver is restarting in debug mode"

--- a/po/lt.po
+++ b/po/lt.po
@@ -9069,10 +9069,10 @@ msgstr "Vartotojo grafinė aplinka paleidžiama iš naujo"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Vartotojo grafinė aplinka bus paleista iš naujo\n"
-"dėl klaidos mytest.py"
+"dėl klaidos StartEnigma.py"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "Jūsų imtuvo vartotojo sąsaja paleidžiama iš naujo derinimo režimu"

--- a/po/lv.po
+++ b/po/lv.po
@@ -9057,10 +9057,10 @@ msgstr "Uztvērēja lietotāja interfeiss tiek pārstartēts"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Lietotāja interfeiss tiek pārstartēts\n"
-"dēļ kļūdas failā mytest.py"
+"dēļ kļūdas failā StartEnigma.py"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "Uztvērēja lietotāja interfeiss tiek pārstartēts testa režīmā"

--- a/po/mk.po
+++ b/po/mk.po
@@ -9038,10 +9038,10 @@ msgstr "Корисничкиот интерфејс на вашиот прием
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Корисничкиот интерфејс на вашиот приемник се рестартира\n"
-"поради грешка во mytest.py"
+"поради грешка во StartEnigma.py"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "Корисничкиот интерфејс на вашиот приемник ќе се рестартира во режим на отстранување грешки"

--- a/po/nb.po
+++ b/po/nb.po
@@ -10078,10 +10078,10 @@ msgstr "Brukergrensesnittet til mottakeren starter på nytt"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Brukergrensesnittet til mottakeren starter på nytt\n"
-"på grunn av en feil i mytest.py"
+"på grunn av en feil i StartEnigma.py"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "Brukergrensesnittet til mottakeren starter på nytt i feilsøkingsmodus"

--- a/po/nl.po
+++ b/po/nl.po
@@ -9318,10 +9318,10 @@ msgstr "De gebruikersomgeving van uw ontvanger wordt herstart."
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "De gebruikersomgeving van uw ontvanger wordt opnieuw opgestart\n"
-"als gevolg van een geconstateerd probleem in mytest.py"
+"als gevolg van een geconstateerd probleem in StartEnigma.py"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "De gebruikersomgeving van uw ontvanger wordt in debug modus herstart"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10032,10 +10032,10 @@ msgstr "Enigma2 starter på nytt"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Mottakerens brukergrensesnitt må startes på nytt\n"
-"på grunn av en feil i mytest.py"
+"på grunn av en feil i StartEnigma.py"
 
 #, fuzzy
 msgid "The user interface of your receiver is restarting in debug mode"

--- a/po/pl.po
+++ b/po/pl.po
@@ -9069,10 +9069,10 @@ msgstr "Trwa restart GUI odbiornika"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Trwa restart GUI odbiornika\n"
-"z powodu błędu w mytest.py"
+"z powodu błędu w StartEnigma.py"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "GUI odbiornika jest restartowane do trybu debugowania"

--- a/po/pt.po
+++ b/po/pt.po
@@ -10626,10 +10626,10 @@ msgstr "O interface gráfico está a reiniciar"
 #, fuzzy
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "O interface gráfico está a reiniciar\n"
-"devido a um erro em mytest.py"
+"devido a um erro em StartEnigma.py"
 
 #, fuzzy
 msgid "The user interface of your receiver is restarting in debug mode"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -9188,10 +9188,10 @@ msgstr "Reiniciando interface. Aguarde..."
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "A interface do receptor está reiniciando\n"
-"devido a um erro em mytest.py"
+"devido a um erro em StartEnigma.py"
 
 #, fuzzy
 msgid "The user interface of your receiver is restarting in debug mode"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9380,7 +9380,7 @@ msgstr "Va rugam asteptati pana cand reteaua se va restarta..."
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 
 #, fuzzy

--- a/po/ru.po
+++ b/po/ru.po
@@ -9066,10 +9066,10 @@ msgstr "Рестарт GUI Вашего ресивера"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Рестарт GUI Вашего ресивера\n"
-"из-за ошибки в mytest.py"
+"из-за ошибки в StartEnigma.py"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "Рестарт GUI Вашего ресивера выполнен для режима отладки"

--- a/po/sk.po
+++ b/po/sk.po
@@ -9066,10 +9066,10 @@ msgstr "Užívateľské rozhranie prijímača sa reštartuje..."
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Užívateľské rozhranie vášho prijímača sa reštartuje\n"
-"kvôli chybe v mytest.py"
+"kvôli chybe v StartEnigma.py"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "Užívateľské rozhranie prijímača sa reštartuje v debug režime..."

--- a/po/sl.po
+++ b/po/sl.po
@@ -10600,10 +10600,10 @@ msgstr "Poteka ponovni zagon uporabniškega vmesnika (GUI) ..."
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Uporabniški vmesnik (GUI) sprejemnika se bo v kratkem ponovno zagnal!\n"
-"Razlog je napaka v datoteki mytest.py"
+"Razlog je napaka v datoteki StartEnigma.py"
 
 #, fuzzy
 msgid "The user interface of your receiver is restarting in debug mode"

--- a/po/sr.po
+++ b/po/sr.po
@@ -10673,7 +10673,7 @@ msgstr "Molim sačekajte dok se vaša mreža ponovo startuje"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 
 #

--- a/po/sv.po
+++ b/po/sv.po
@@ -10373,10 +10373,10 @@ msgstr "Användargränssnittet för din mottagare startas om"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Användargränssnittet för din mottagare startas om\n"
-"på grund av ett fel i mytest.py"
+"på grund av ett fel i StartEnigma.py"
 
 #, fuzzy
 msgid "The user interface of your receiver is restarting in debug mode"

--- a/po/th.po
+++ b/po/th.po
@@ -9424,7 +9424,7 @@ msgstr "กรุณารอสักครู่... กำลังเริ�
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 
 #, fuzzy

--- a/po/tr.po
+++ b/po/tr.po
@@ -9235,9 +9235,9 @@ msgstr "Alıcınızın kullanıcı arayüzü yeniden başlatılıyor..."
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
-"mytest.py deki bir hata nedeniyle\n"
+"StartEnigma.py deki bir hata nedeniyle\n"
 "Alıcınızın kullanıcı arayüzü yeniden başlatılıyor..."
 
 #, fuzzy

--- a/po/uk.po
+++ b/po/uk.po
@@ -9076,10 +9076,10 @@ msgstr "Графічний інтерфейс користувача прийм�
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Графічний інтерфейс Вашого приймача перезавантажується\n"
-"через помилку в mytest.py"
+"через помилку в StartEnigma.py"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "Графічний інтерфейс Вашого приймача перезавантажується в режим налагодження"

--- a/po/vi.po
+++ b/po/vi.po
@@ -9112,10 +9112,10 @@ msgstr "Giao diện người dùng của máy thu của bạn đang khởi độ
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "Giao diện người dùng của máy thu của bạn đang khởi động lại\n"
-"do lỗi trong mytest.py"
+"do lỗi trong StartEnigma.py"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "Giao diện người dùng của máy thu của bạn đang khởi động lại ở chế độ gỡ lỗi"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -9053,10 +9053,10 @@ msgstr "接收机用户界面正在重启中!"
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 "接收机用户界面重启中\n"
-"在mytest.py文件中存在一处错误"
+"在StartEnigma.py文件中存在一处错误"
 
 msgid "The user interface of your receiver is restarting in debug mode"
 msgstr "接收器的用户界面正在调试模式下重新启动"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -9122,7 +9122,7 @@ msgstr ""
 
 msgid ""
 "The user interface of your receiver is restarting\n"
-"due to an error in mytest.py"
+"due to an error in StartEnigma.py"
 msgstr ""
 
 msgid "The user interface of your receiver is restarting in debug mode"

--- a/tests/enigma.py
+++ b/tests/enigma.py
@@ -331,7 +331,7 @@ def init_parental_control():
 	InitParentalControl()
 
 def init_all():
-	# this is stuff from mytest.py
+	# this is stuff from StartEnigma.py
 	init_nav()
 
 	init_record_config()


### PR DESCRIPTION
- This is a better name as we're starting enigma not something else, Startup is very general and common as we may ask startup what?

- Add StartEnigma in debug lines so we understand StartEnigma is producing them.

- Correct all .po and other related .py files which advertise this file.