### PR TITLE
Allow automatically scaling images in LoadPixmap

### DIFF
--- a/lib/python/Tools/LoadPixmap.py
+++ b/lib/python/Tools/LoadPixmap.py
@@ -1,13 +1,6 @@
 from enigma import loadPNG, loadJPG, loadSVG, getDesktop
 
 
-# Return a scaling factor (float) that can be used to rescale images
-# to suit the current resolution of the skin.
-# The scales are based on a default screen resolution of HD (720p).
-# That is the scale factor for a HD screen will be 1.
-SKIN_FACTOR = getDesktop(0).size().height() / 720.0
-
-
 # If cached is not supplied, LoadPixmap defaults to caching PNGs and not caching JPGs
 # Split alpha channel JPGs are never cached as the C++ layer's caching is based on
 # a single file per image in the cache
@@ -19,7 +12,8 @@ def LoadPixmap(path, desktop=None, cached=None, width=0, height=0):
 		# don't cache unless caller explicity requests caching
 		ptr = loadJPG(path, 1 if cached is True else 0)
 	elif path[-4:] == ".svg":
-		ptr = loadSVG(path, 0 if cached is False else 1, width, height, SKIN_FACTOR)
+		scale = getDesktop(0).size().height() / 720.0 if height == 0 else 0
+		ptr = loadSVG(path, 0 if cached is False else 1, width, height, scale)
 	elif path[-1:] == ".":
 		# caching mechanism isn't suitable for multi file images, so it's explicitly disabled
 		alpha = loadPNG(path + "a.png", 0, 0)

--- a/lib/python/Tools/LoadPixmap.py
+++ b/lib/python/Tools/LoadPixmap.py
@@ -1,4 +1,12 @@
-from enigma import loadPNG, loadJPG, loadSVG
+from enigma import loadPNG, loadJPG, loadSVG, getDesktop
+
+
+# Return a scaling factor (float) that can be used to rescale images
+# to suit the current resolution of the skin.
+# The scales are based on a default screen resolution of HD (720p).
+# That is the scale factor for a HD screen will be 1.
+SKIN_FACTOR = getDesktop(0).size().height() / 720.0
+
 
 # If cached is not supplied, LoadPixmap defaults to caching PNGs and not caching JPGs
 # Split alpha channel JPGs are never cached as the C++ layer's caching is based on
@@ -6,12 +14,12 @@ from enigma import loadPNG, loadJPG, loadSVG
 def LoadPixmap(path, desktop=None, cached=None, width=0, height=0):
 	if path[-4:] == ".png":
 		# cache unless caller explicity requests to not cache
-		ptr = loadPNG(path, 0, 0 if cached == False else 1)
+		ptr = loadPNG(path, 0, 0 if cached is False else 1)
 	elif path[-4:] == ".jpg":
 		# don't cache unless caller explicity requests caching
-		ptr = loadJPG(path, 1 if cached == True else 0)
+		ptr = loadJPG(path, 1 if cached is True else 0)
 	elif path[-4:] == ".svg":
-		ptr = loadSVG(path, 0 if cached == False else 1, width, height)
+		ptr = loadSVG(path, 0 if cached is False else 1, width, height, SKIN_FACTOR)
 	elif path[-1:] == ".":
 		# caching mechanism isn't suitable for multi file images, so it's explicitly disabled
 		alpha = loadPNG(path + "a.png", 0, 0)


### PR DESCRIPTION
Use the scaling factor to rescale svg images to suit the current resolution of the skin.
This allows later remove the skin_fallback_1080 folder and replace the images in this folder with svg images in the skin_default folder that can be scaled without loss of quality.
Variable SKIN_FACTOR there is temporary solution that needs to be changed later, when SkinFactor for enigma components will be fully implemented.