### PR TITLE
Use StartEnigma name instead of Startup

### DIFF
--- a/lib/python/Makefile.am
+++ b/lib/python/Makefile.am
@@ -12,5 +12,5 @@ install_PYTHON = \
 	RecordTimer.py \
 	ServiceReference.py \
 	skin.py \
-	Startup.py \
+	StartEnigma.py \
 	timer.py

--- a/lib/python/StartEnigma.py
+++ b/lib/python/StartEnigma.py
@@ -98,7 +98,7 @@ try:
 	def runReactor():
 		reactor.run(installSignalHandlers=False)
 except ImportError:
-	print "twisted not available"
+	print "[StartEnigma] Twisted not available"
 	def runReactor():
 		enigma.runMainloop()
 
@@ -190,7 +190,7 @@ class Session:
 			try:
 				p(reason=0, session=self)
 			except:
-				print "Plugin raised exception at WHERE_SESSIONSTART"
+				print "[StartEnigma] Plugin raised exception at WHERE_SESSIONSTART"
 				import traceback
 				traceback.print_exc()
 
@@ -305,7 +305,7 @@ class Session:
 
 	def close(self, screen, *retval):
 		if not self.in_exec:
-			print "close after exec!"
+			print "[StartEnigma] Close after exec!"
 			return
 
 		# be sure that the close is for the right dialog!
@@ -351,7 +351,7 @@ class PowerKey:
 		globalActionMap.actions["discrete_off"] = self.standby
 
 	def shutdown(self):
-		print "PowerOff - Now!"
+		print "[StartEnigma] PowerOff - Now!"
 		if not Screens.Standby.inTryQuitMainloop and self.session.current_dialog and self.session.current_dialog.ALLOW_SUSPEND:
 			self.session.open(Screens.Standby.TryQuitMainloop, 1)
 		else:
@@ -377,7 +377,7 @@ class PowerKey:
 					exec "from " + selected[1] + " import *"
 					exec "self.session.open(" + ",".join(selected[2:]) + ")"
 				except:
-					print "[mytest] error during executing module %s, screen %s" % (selected[1], selected[2])
+					print "[StartEnigma] Error during executing module %s, screen %s" % (selected[1], selected[2])
 			elif selected[0] == "Menu":
 				from Screens.Menu import MainMenu, mdom
 				root = mdom.getroot()
@@ -507,9 +507,9 @@ def runScreenTest():
 		else:
 			wptime = startTime[0] - 240
 		if not config.misc.useTransponderTime.value:
-			print "dvb time sync disabled... so set RTC now to current linux time!", strftime("%Y/%m/%d %H:%M", localtime(nowTime))
+			print "[StartEnigma] DVB time sync disabled... so set RTC now to current linux time!", strftime("%Y/%m/%d %H:%M", localtime(nowTime))
 			setRTCtime(nowTime)
-		print "set wakeup time to", strftime("%Y/%m/%d %H:%M", localtime(wptime))
+		print "[StartEnigma] Set wakeup time to", strftime("%Y/%m/%d %H:%M", localtime(wptime))
 		setFPWakeuptime(wptime)
 		config.misc.prev_wakeup_time.value = int(startTime[0])
 		config.misc.prev_wakeup_time_type.value = startTime[1]
@@ -592,7 +592,7 @@ try:
 
 	Components.ParentalControl.parentalControl.save()
 except:
-	print 'EXCEPTION IN PYTHON STARTUP CODE:'
+	print '[StartEnigma] EXCEPTION IN PYTHON STARTUP CODE:'
 	print '-'*60
 	print_exc(file=stdout)
 	enigma.quitMainloop(5)

--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -108,7 +108,7 @@ def InitSkins():
 		loadSkin(USER_SKIN, scope=SCOPE_CURRENT_SKIN, desktop=getDesktop(GUI_SKIN_ID), screenID=GUI_SKIN_ID)
 	runCallbacks = True
 
-# Temporary entry point for older versions of mytest.py.
+# Temporary entry point for older versions of StartEnigma.py.
 #
 def loadSkinData(desktop):
 	InitSkins()

--- a/main/enigma.cpp
+++ b/main/enigma.cpp
@@ -300,7 +300,7 @@ int main(int argc, char **argv)
 	/* start at full size */
 	eVideoWidget::setFullsize(true);
 
-	python.execFile(eEnv::resolve("${libdir}/enigma2/python/Startup.py").c_str());
+	python.execFile(eEnv::resolve("${libdir}/enigma2/python/StartEnigma.py").c_str());
 
 	/* restore both decoders to full size */
 	eVideoWidget::setFullsize(true);

--- a/tests/enigma.py
+++ b/tests/enigma.py
@@ -331,7 +331,7 @@ def init_parental_control():
 	InitParentalControl()
 
 def init_all():
-	# this is stuff from mytest.py
+	# this is stuff from StartEnigma.py
 	init_nav()
 
 	init_record_config()


### PR DESCRIPTION
- This is a better name as we're starting enigma not something else, Startup is very general and common as we may ask startup what?

- Add StartEnigma in debug lines so we understand StartEnigma is producing them.

- Correct related .py files which advertise this file.