### PR TITLE
Make sure we have 644 .po files not 755 and remove .mo ones.

### DIFF
--- a/po/updateallpo-multiOS.sh
+++ b/po/updateallpo-multiOS.sh
@@ -217,3 +217,5 @@ printf "           3) unselect keep original file format\n"
 printf "You only need to do this once in PoEdit.\n\n"
 printf "Please read the translators wiki page:\n"
 printf "\nhttps://wiki.openpli.org/Information_for_Translators\n"
+rm -rf *.mo
+chmod 644 *.po

--- a/po/updateallpo.sh
+++ b/po/updateallpo.sh
@@ -77,5 +77,5 @@ done
 rm enigma2-py.pot enigma2-xml.pot enigma2.pot
 IFS=$OLDIFS
 printf "Po files update/creation from script finished!\n"
-
-
+rm -rf *.mo
+chmod 644 *.po


### PR DESCRIPTION
I saw time to time people change .po permissions and it's very common in PLi's repo as it's upstream.

Lets fix this once for all, each time someone (usually @pr2git ) updates the .po files they will be fixed so no harm.

Also remove .mo files as we don't need them for git.

Please squash merge this PR as one commit :+1: 