### PR TITLE
Travis auto PEP8 cleanup by Persian Prince (not enabled)

### DIFF
--- a/PEP8.sh
+++ b/PEP8.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+echo ""
+echo "PEP8 double aggressive safe cleanup by Persian Prince"
+# Script by Persian Prince for https://github.com/OpenVisionE2
+# You're not allowed to remove my copyright or reuse this script without putting this header.
+echo ""
+echo "Changing py files, please wait ..." 
+begin=$(date +"%s")
+
+echo ""
+echo "PEP8 double aggressive E401"
+autopep8 . -a -a -j 0 --recursive --select=E401 --in-place
+git add -u
+git add *
+git commit -m "PEP8 double aggressive E401 (build $TRAVIS_BUILD_NUMBER)"
+
+echo ""
+echo "PEP8 double aggressive E701, E70 and E502"
+autopep8 . -a -a -j 0 --recursive --select=E701,E70,E502 --in-place
+git add -u
+git add *
+git commit -m "PEP8 double aggressive E701, E70 and E502 (build $TRAVIS_BUILD_NUMBER)"
+
+echo ""
+echo "PEP8 double aggressive E251 and E252"
+autopep8 . -a -a -j 0 --recursive --select=E251,E252 --in-place
+git add -u
+git add *
+git commit -m "PEP8 double aggressive E251 and E252 (build $TRAVIS_BUILD_NUMBER)"
+
+echo ""
+echo "PEP8 double aggressive E20 and E211"
+autopep8 . -a -a -j 0 --recursive --select=E20,E211 --in-place
+git add -u
+git add *
+git commit -m "PEP8 double aggressive E20 and E211 (build $TRAVIS_BUILD_NUMBER)"
+
+echo ""
+echo "PEP8 double aggressive E22, E224, E241, E242 and E27"
+autopep8 . -a -a -j 0 --recursive --select=E22,E224,E241,E242,E27 --in-place
+git add -u
+git add *
+git commit -m "PEP8 double aggressive E22, E224, E241, E242 and E27 (build $TRAVIS_BUILD_NUMBER)"
+
+echo ""
+echo "PEP8 double aggressive E225 ~ E228 and E231"
+autopep8 . -a -a -j 0 --recursive --select=E225,E226,E227,E228,E231 --in-place
+git add -u
+git add *
+git commit -m "PEP8 double aggressive E225 ~ E228 and E231 (build $TRAVIS_BUILD_NUMBER)"
+
+echo ""
+echo "PEP8 double aggressive E301 ~ E306"
+autopep8 . -a -a -j 0 --recursive --select=E301,E302,E303,E304,E305,E306 --in-place
+git add -u
+git add *
+git commit -m "PEP8 double aggressive E301 ~ E306 (build $TRAVIS_BUILD_NUMBER)"
+
+echo ""
+echo "PEP8 double aggressive W291 ~ W293 and W391"
+autopep8 . -a -a -j 0 --recursive --select=W291,W292,W293,W391 --in-place
+git add -u
+git add *
+git commit -m "PEP8 double aggressive W291 ~ W293 and W391 (build $TRAVIS_BUILD_NUMBER)"
+
+echo ""
+finish=$(date +"%s")
+timediff=$(($finish-$begin))
+echo -e "Change time was $(($timediff / 60)) minutes and $(($timediff % 60)) seconds."
+echo -e "Fast changing would be less than 1 minute."
+echo ""
+echo "PEP8 Done!"
+echo ""

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+setup_git() {
+  git config --global user.email "bot@openpli.org"
+  git config --global user.name "OpenPLi python bot"
+}
+
+commit_files() {
+  git clean -fd
+  rm -rf *.pyc
+  rm -rf *.pyo
+  rm -rf *.mo
+  git checkout develop
+  ./PEP8.sh
+}
+
+upload_files() {
+  git remote add upstream https://${GH_TOKEN}@github.com/OpenPLi/enigma2.git > /dev/null 2>&1
+  git push --quiet upstream develop || echo "failed to push with error $?"
+}
+
+setup_git
+commit_files
+upload_files


### PR DESCRIPTION
This is not enabled so you could merge and test it yourself, if you check https://github.com/OpenVisionE2/enigma2-openvision/commit/bd67fa69a04c6195c502da76bf33af77aa086abd you'll see the needed changes for .travis.yml

Also you need to set "GH_TOKEN" varialbe for build.sh which you can define it under https://github.com/settings/tokens and add it later to https://travis-ci.org/github/OpenPLi/enigma2/settings so could be used for Travis.

 We use this for almost all Open Vision repos, also Open WebIF added it https://github.com/E2OpenPlugins/e2openplugin-OpenWebif/commit/ecd89f224623245724713ed0e06a26e2fad8303b and ATV is using it for their new images: https://github.com/openatv/enigma2/commits/6.5

My PEP8.sh script proved to be 100% safe after lots of tests me and @IanSav did and we're using it for long, I removed some naughty PEP8 codes so this would be just fine.

Example: https://github.com/OpenVisionE2/enigma2-openvision/commit/74ee9d43c307048a215b81026b6c63c936ab82b5

The good thing is if you enable it on Travis you just merge your PRs and it will take care of the problems.

I hope you decide to use it on all of your repos like us.