### PR TITLE
MovieSelection: display 'Empty Trash' label for the delete button when you're on trash can in the list

### DIFF
--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -970,7 +970,9 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 				except:
 					check = self.can_default
 			if check(item):
-				if userDefinedButtons[name].value != "sort":
+				if item and isTrashFolder(item[0]) and userDefinedButtons[name].value == 'delete':
+					self['key_%s' % name].setText(_("Empty Trash"))
+				elif userDefinedButtons[name].value != "sort":
 					self['key_%s' % name].setText(userDefinedActions[userDefinedButtons[name].value])
 			else:
 				self["key_%s" % name].setText("")


### PR DESCRIPTION

Now a 'Delete' label for delete defined button in movie list is displayed always, also when trash can is highlighted.
However you can not literally 'delete' the trash can, by pressing it you can purge all items from it.
'Empty trash' label unambiguously indicates actual available action after pressing the button in this case.