### PR TITLE
opentv: fix long event duration

### DIFF
--- a/lib/dvb/opentv.cpp
+++ b/lib/dvb/opentv.cpp
@@ -224,7 +224,7 @@ uint16_t OpenTvTitle::getEventId(void) const
 	return eventId;
 }
 
-uint16_t OpenTvTitle::getDuration(void) const
+uint32_t OpenTvTitle::getDuration(void) const
 {
 	return duration;
 }

--- a/lib/dvb/opentv.h
+++ b/lib/dvb/opentv.h
@@ -77,7 +77,7 @@ public:
 	uint16_t getChannelId(void) const;
 	uint32_t getStartTime(void) const;
 	uint16_t getEventId(void) const;
-	uint16_t getDuration(void) const;
+	uint32_t getDuration(void) const;
 	void setChannelId(uint16_t channelid);
 	void setEventId(uint16_t eventId);
 };


### PR DESCRIPTION
duration limit (65535) is not large enough,
20 hour events (72000 seconds) can be seen.