### PR TITLE
[Directories.py] Fix SyntaxWarning

### DIFF
--- a/lib/python/Tools/Directories.py
+++ b/lib/python/Tools/Directories.py
@@ -116,7 +116,7 @@ def resolveFilename(scope, base="", path_prefix=None):
 					return file
 
 	# If base is "" then set path to the scope.  Otherwise use the scope to resolve the base filename.
-	if base is "":
+	if base == "":
 		path, flags = defaultPaths.get(scope)
 		# If the scope is SCOPE_CURRENT_SKIN or SCOPE_ACTIVE_SKIN append the current skin to the scope path.
 		if scope in (SCOPE_CURRENT_SKIN, SCOPE_ACTIVE_SKIN):


### PR DESCRIPTION
```
Compiling './lib/python/Tools/Directories.py'...
./lib/python/Tools/Directories.py:119: SyntaxWarning: "is" with a literal. Did you mean "=="?
 if base is "":
```