### PR TITLE
estring: undo abbreviation function

### DIFF
--- a/lib/base/estring.cpp
+++ b/lib/base/estring.cpp
@@ -27,6 +27,71 @@ std::string buildShortName( const std::string &str )
 	return tmp.length() ? tmp : str;
 }
 
+void undoAbbreviation(std::string &title, std::string &summary)
+{
+	//strip emphasis <EM>title...</EM> from eit
+	std::string sTitle = buildShortName(title);
+	std::string sSummary = summary;
+
+	if (sTitle.length() > 3 && sSummary.length() > 3)
+	{
+		// check if the title is split
+		if (sTitle.substr(sTitle.length() - 3) == "..." && sSummary.substr(0, 3) == "...")
+		{
+			// find the end of the title in the sumarry
+			std::size_t found = sSummary.find_first_of(".:!?", 4);
+
+			if (found < sSummary.length())
+			{
+				std::string sTmpTitle;
+				std::string sTmpSummary;
+
+				// strip off the ellipsis and any leading/trailing space
+				if (sTitle.substr(sTitle.length() - 4, 1) == " ")
+				{
+					sTmpTitle  = sTitle.substr(0, sTitle.length() - 4);
+				}
+				else
+				{
+					sTmpTitle = sTitle.substr(0, sTitle.length() - 3);
+				}
+
+				if (sSummary.substr(3, 1) == " ")
+				{
+					sTmpSummary  = sSummary.substr(4);
+				}
+				else
+				{
+					sTmpSummary = sSummary.substr(3);
+				}
+
+				// construct the new title and summary
+				found = sTmpSummary.find_first_of(".:!?");
+				if (found < sTmpSummary.length())
+				{
+					sTitle = sTmpTitle + " " + sTmpSummary.substr(0, found);
+					if (sTmpSummary.length() - found > 2)
+					{
+						sSummary = sTmpSummary.substr(found + 2);
+					}
+					else
+					{
+						sSummary = "";
+					}
+				}
+				else
+				{
+					// shouldn't happen, but you never know...
+					sTitle = sTmpTitle;
+					sSummary = sTmpSummary;
+				}
+			}
+		}
+	}
+	title = sTitle;
+	summary = sSummary;
+}
+
 std::string getNum(int val, int sys)
 {
 //	Returns a string that contain the value val as string

--- a/lib/base/estring.h
+++ b/lib/base/estring.h
@@ -9,6 +9,8 @@
 
 std::string buildShortName( const std::string &str );
 
+void undoAbbreviation(std::string &title, std::string &summary);
+
 int strnicmp(const char*, const char*, int);
 
 std::string getNum(int num, int base=10);

--- a/lib/dvb/epgchanneldata.cpp
+++ b/lib/dvb/epgchanneldata.cpp
@@ -1936,62 +1936,8 @@ void eEPGChannelData::OPENTV_SummariesSection(const uint8_t *d)
 					// hack to fix split titles
 					std::string sTitle = m_OPENTV_descriptors_map[ote.title_crc];
 					std::string sSummary = (*summary)->getSummary();
+					undoAbbreviation(sTitle, sSummary);
 
-					if (sTitle.length() > 3 && sSummary.length() > 3)
-					{
-						// check if the title is split
-						if (sTitle.substr(sTitle.length() - 3) == "..." && sSummary.substr(0, 3) == "...")
-						{
-							// find the end of the title in the sumarry
-							std::size_t found = sSummary.find_first_of(".:!?", 4);
-
-							if (found < sSummary.length())
-							{
-								std::string sTmpTitle;
-								std::string sTmpSummary;
-
-								// strip off the ellipsis and any leading/trailing space
-								if (sTitle.substr(sTitle.length() - 4, 1) == " ")
-								{
-									sTmpTitle  = sTitle.substr(0, sTitle.length() - 4);
-								}
-								else
-								{
-									sTmpTitle = sTitle.substr(0, sTitle.length() - 3);
-								}
-
-								if (sSummary.substr(3, 1) == " ")
-								{
-									sTmpSummary  = sSummary.substr(4);
-								}
-								else
-								{
-									sTmpSummary = sSummary.substr(3);
-								}
-
-								// construct the new title and summary
-								found = sTmpSummary.find_first_of(".:!?");
-								if (found < sTmpSummary.length())
-								{
-									sTitle = sTmpTitle + " " + sTmpSummary.substr(0, found);
-									if (sTmpSummary.length() - found > 2)
-									{
-										sSummary = sTmpSummary.substr(found + 2);
-									}
-									else
-									{
-										sSummary = "";
-									}
-								}
-								else
-								{
-									// shouldn't happen, but you never know...
-									sTitle + sTmpTitle;
-									sSummary = sTmpSummary;
-								}
-							}
-						}
-					}
 					if (eEPGCache::getInstance())
 						eEPGCache::getInstance()->submitEventData(sids, chids, ote.startTime, ote.duration, sTitle.c_str(), "", sSummary.c_str(), 0, ote.eventId, eEPGCache::OPENTV);
 				}

--- a/lib/dvb/epgchanneldata.h
+++ b/lib/dvb/epgchanneldata.h
@@ -5,6 +5,7 @@
 #include <lib/dvb/epgcache.h>
 #include <lib/dvb/lowlevel/eit.h>
 #include <lib/base/ebase.h>
+#include <lib/base/estring.h>
 
 #ifdef ENABLE_MHW_EPG
 #include <lib/dvb/lowlevel/mhw.h>

--- a/lib/service/event.cpp
+++ b/lib/service/event.cpp
@@ -205,6 +205,9 @@ bool eServiceEvent::loadLanguage(Event *evt, const std::string &lang, int tsidon
 		m_extended_description_items = "";
 	}
 
+	// hack to fix split titles
+	undoAbbreviation(m_event_name, m_short_description);
+
 	return retval;
 }
 


### PR DESCRIPTION
move undo abbreviation code to its own function.

This function stitches back together title name from short description.

Title and...
...title continued. More short description.

Title and title continued.
More short description.