### PR TITLE
[LoadPixmap] Add new skin parameter "AutoscaleSVG"

### DIFF
--- a/lib/python/Tools/LoadPixmap.py
+++ b/lib/python/Tools/LoadPixmap.py
@@ -1,4 +1,4 @@
-from enigma import loadPNG, loadJPG, loadSVG, getDesktop
+from enigma import loadPNG, loadJPG, loadSVG
 
 
 # If cached is not supplied, LoadPixmap defaults to caching PNGs and not caching JPGs
@@ -12,7 +12,9 @@ def LoadPixmap(path, desktop=None, cached=None, width=0, height=0):
 		# don't cache unless caller explicity requests caching
 		ptr = loadJPG(path, 1 if cached is True else 0)
 	elif path[-4:] == ".svg":
-		scale = getDesktop(0).size().height() / 720.0 if height == 0 else 0
+		from skin import parameters, getSkinFactor # imported here to avoid circular import
+		autoscale = int(parameters.get("AutoscaleSVG", -1)) # skin_default only == -1, disabled == 0 or enabled == 1
+		scale = height == 0 and (autoscale == -1 and "/skin_default/" in path or autoscale == 1) and getSkinFactor() or 0
 		ptr = loadSVG(path, 0 if cached is False else 1, width, height, scale)
 	elif path[-1:] == ".":
 		# caching mechanism isn't suitable for multi file images, so it's explicitly disabled


### PR DESCRIPTION
<parameter name="AutoscaleSVG" value="1"/>

SVG images are scaled based on the width/height, but if width/height are "0" the image will be automatically scaled based on the "AutoscaleSVG" skin parameter.

There are 3 options:
-1 : only auto scale SVG graphics if "/skin_default/" is in the path (this is the default),
 0 : never auto scale SVG graphics,
 1 : always auto scale SVG graphics