### PR TITLE
[InfoBarSeek] seekFwdManual/seekBackManual return 0 if not seek

### DIFF
--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -1663,14 +1663,20 @@ class InfoBarSeek:
 				self.setSeekState(self.SEEK_STATE_PAUSE)
 
 	def seekFwdManual(self):
-		self.session.openWithCallback(self.fwdSeekTo, MinuteInput)
+		if self.isSeekable():
+			self.session.openWithCallback(self.rwdSeekTo, MinuteInput)
+		else:
+			return 0
 
 	def fwdSeekTo(self, minutes):
 		print "Seek", minutes, "minutes forward"
 		self.doSeekRelative(minutes * 60 * 90000)
 
 	def seekBackManual(self):
-		self.session.openWithCallback(self.rwdSeekTo, MinuteInput)
+		if self.isSeekable():
+			self.session.openWithCallback(self.rwdSeekTo, MinuteInput)
+		else:
+			return 0
 
 	def rwdSeekTo(self, minutes):
 		print "rwdSeekTo"


### PR DESCRIPTION
-In fact, this is a bug, because at the moment
self["SeekActions"].setEnabled(False).So this button must be disabled.