### PR TITLE
[PluginList] Bug fix to prevent plugin icons being loaded twice

### DIFF
--- a/lib/python/Components/PluginList.py
+++ b/lib/python/Components/PluginList.py
@@ -9,10 +9,7 @@ from skin import applySkinFactor, fonts, parameters
 
 
 def PluginEntryComponent(plugin, width=440):
-	if plugin.icon is None:
-		png = LoadPixmap(resolveFilename(SCOPE_CURRENT_SKIN, "icons/plugin.png"))
-	else:
-		png = plugin.icon
+	png = plugin.icon or LoadPixmap(resolveFilename(SCOPE_CURRENT_SKIN, "icons/plugin.png"))
 	nx, ny, nh = parameters.get("PluginBrowserName", applySkinFactor(120, 5, 25))
 	dx, dy, dh = parameters.get("PluginBrowserDescr", applySkinFactor(120, 26, 17))
 	ix, iy, iw, ih = parameters.get("PluginBrowserIcon", applySkinFactor(10, 5, 100, 40))


### PR DESCRIPTION
"plugin.icon" is a callable which loads the plugin icon and returns the reference. It therefore should not be called in an "if" condition and then again in an "else" clause as was happening prior to this change.