### PR TITLE
[PluginList] Fix another double loading of the plugin icons

### DIFF
--- a/lib/python/Components/PluginList.py
+++ b/lib/python/Components/PluginList.py
@@ -32,10 +32,7 @@ def PluginCategoryComponent(name, png, width=440):
 
 
 def PluginDownloadComponent(plugin, name, version=None, width=440):
-	if plugin.icon is None:
-		png = LoadPixmap(resolveFilename(SCOPE_CURRENT_SKIN, "icons/plugin.png"))
-	else:
-		png = plugin.icon
+	png = plugin.icon or LoadPixmap(resolveFilename(SCOPE_CURRENT_SKIN, "icons/plugin.png"))
 	if version:
 		if "+git" in version:
 			# remove git "hash"


### PR DESCRIPTION
Follows this commit: https://github.com/OpenPLi/enigma2/commit/5defa28aabeabfe238fbcbce897042c2eb536c64

Pointed out by @nautilus7