### PR TITLE
Add SystemInfo["HasPhysicalLoopthrough"]

### DIFF
--- a/lib/python/Components/SystemInfo.py
+++ b/lib/python/Components/SystemInfo.py
@@ -133,3 +133,4 @@ SystemInfo["CanDownmixAAC"] = fileHas("/proc/stb/audio/aac_choices", "downmix")
 SystemInfo["HDMIAudioSource"] = fileCheck("/proc/stb/hdmi/audio_source")
 SystemInfo["BootDevice"] = getBootdevice()
 SystemInfo["FbcTunerPowerAlwaysOn"] = model in ("vusolo4k", "vuduo4k", "vuduo4kse", "vuultimo4k", "vuuno4k", "vuuno4kse", "gbquad4k", "gbue4k")
+SystemInfo["HasPhysicalLoopthrough"] = ["Vuplus DVB-S NIM(AVL2108)", "GIGA DVB-S2 NIM (Internal)"]


### PR DESCRIPTION
-this is name slot "Vuplus DVB-S NIM(AVL2108)", "GIGA DVB-S2 NIM
(Internal)"
-"Has_Outputs: yes" not in /proc/bus/nim_sockets NIM, but the physical
loopthrough exist