### PR TITLE
Add SystemInfo["HasPhysicalLoopthrough"]

### DIFF
--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -909,7 +909,7 @@ class NimManager:
 			if "i2c" not in entry:
 				entry["i2c"] = None
 			if "has_outputs" not in entry:
-				entry["has_outputs"] = True
+				entry["has_outputs"] = entry["name"] in SystemInfo["HasPhysicalLoopthrough"] # "Has_Outputs: yes" not in /proc/bus/nim_sockets NIM, but the physical loopthrough exist
 			if "frontend_device" in entry: # check if internally connectable
 				if os.path.exists("/proc/stb/frontend/%d/rf_switch" % entry["frontend_device"]) and (not id or entries[id]["name"] == entries[id - 1]["name"]):
 					entry["internally_connectable"] = entry["frontend_device"] - 1

--- a/lib/python/Components/SystemInfo.py
+++ b/lib/python/Components/SystemInfo.py
@@ -133,3 +133,4 @@ SystemInfo["CanDownmixAAC"] = fileHas("/proc/stb/audio/aac_choices", "downmix")
 SystemInfo["HDMIAudioSource"] = fileCheck("/proc/stb/hdmi/audio_source")
 SystemInfo["BootDevice"] = getBootdevice()
 SystemInfo["FbcTunerPowerAlwaysOn"] = model in ("vusolo4k", "vuduo4k", "vuduo4kse", "vuultimo4k", "vuuno4k", "vuuno4kse", "gbquad4k", "gbue4k")
+SystemInfo["HasPhysicalLoopthrough"] = ["Vuplus DVB-S NIM(AVL2108)", "GIGA DVB-S2 NIM (Internal)"]


### PR DESCRIPTION
-this is name slot "Vuplus DVB-S NIM(AVL2108)", "GIGA DVB-S2 NIM
(Internal)"
-"Has_Outputs: yes" not in /proc/bus/nim_sockets NIM, but the physical
loopthrough exist