### PR TITLE
[Converter/FrontendInfo] fix not visible tuner as internally_connectable

### DIFF
--- a/lib/python/Components/Converter/FrontendInfo.py
+++ b/lib/python/Components/Converter/FrontendInfo.py
@@ -73,7 +73,7 @@ class FrontendInfo(Converter):
 						color = Hex2strColor(colors[0])
 					elif self.source.tuner_mask & 1 << n.slot:
 						color = Hex2strColor(colors[1])
-					elif len(nimmanager.nim_slots) <= self.space_for_tuners or n.isFBCRoot() or self.show_all_non_link_tuners and not(n.isFBCLink() or n.internally_connectable):
+					elif len(nimmanager.nim_slots) <= self.space_for_tuners or n.isFBCRoot() or self.show_all_non_link_tuners and not (n.isFBCLink() or n.config_mode == "loopthrough"):
 						color = Hex2strColor(colors[2])
 					else:
 						continue


### PR DESCRIPTION
-when self.type == self.STRING and config tuner not "loopthrough" not
need remove tuner in nim list