### PR TITLE
Unicable/FBC  loop through add checking the availability of multiple …

### DIFF
--- a/lib/dvb/dvb.cpp
+++ b/lib/dvb/dvb.cpp
@@ -961,7 +961,7 @@ RESULT eDVBResourceManager::allocateFrontendByIndex(ePtr<eDVBAllocatedFrontend> 
 				while ( tmp != -1 )
 				{
 					eDVBRegisteredFrontend *next = (eDVBRegisteredFrontend *) tmp;
-					if (next->m_inuse)
+					if (next->m_inuse || (i->m_frontend->is_FBCTuner() && m_sec && m_sec->tunerLinkedInUse(slot_index)))
 					{
 						eDebug("[eDVBResourceManager] another linked frontend is in use.. so allocateFrontendByIndex not possible!");
 						err = errAllSourcesBusy;

--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -747,7 +747,7 @@ int eDVBFrontend::closeFrontend(bool force, bool no_delayed)
 		while (tmp != -1)
 		{
 			eDVBRegisteredFrontend *linked_fe = (eDVBRegisteredFrontend*)tmp;
-			if (linked_fe->m_inuse)
+			if (linked_fe->m_inuse || (m_fbc && m_sec && m_sec->tunerLinkedInUse(m_slotid)))
 			{
 				eDebugNoSimulate("[eDVBFrontend%d] dont close frontend while the linked frontend %d in slot %d is still in use",
 					m_dvbid, linked_fe->m_frontend->getDVBID(), linked_fe->m_frontend->getSlotID());
@@ -805,6 +805,7 @@ int eDVBFrontend::closeFrontend(bool force, bool no_delayed)
 			m_fd=-1;
 		else
 			eWarning("[eDVBFrontend %d] couldnt close frontend", m_dvbid);
+		m_data[SAT_POSITION] = -1;
 	}
 	else if (m_simulate)
 	{
@@ -1982,13 +1983,12 @@ int eDVBFrontend::tuneLoopInt()  // called by m_tuneTimer
 				break;
 			case eSecCommand::INVALIDATE_CURRENT_ROTORPARMS:
 				eDebugNoSimulate("[eDVBFrontend%d] invalidate current rotorparams", m_dvbid);
-				sec_fe_data[ROTOR_CMD] = -1;
-				sec_fe_data[ROTOR_POS] = -1;
+				sec_fe_data[ROTOR_CMD] = sec_fe_data[ROTOR_POS] = sec_fe_data[SAT_POSITION] = -1;
 				++m_sec_sequence.current();
 				break;
 			case eSecCommand::UPDATE_CURRENT_ROTORPARAMS:
 				sec_fe_data[ROTOR_CMD] = sec_fe_data[NEW_ROTOR_CMD];
-				sec_fe_data[ROTOR_POS] = sec_fe_data[NEW_ROTOR_POS];
+				sec_fe_data[ROTOR_POS] = sec_fe_data[SAT_POSITION] = sec_fe_data[NEW_ROTOR_POS];
 				if (!m_simulate)
 					m_sec->forceUpdateRotorPos(m_slotid, sec_fe_data[ROTOR_POS]);
 				eDebugNoSimulate("[eDVBFrontend%d] update current rotorparams %d %04lx %ld", m_dvbid, m_timeoutCount, sec_fe_data[ROTOR_CMD], sec_fe_data[ROTOR_POS]);

--- a/lib/dvb/frontend.h
+++ b/lib/dvb/frontend.h
@@ -66,6 +66,8 @@ public:
 		NEW_ROTOR_POS,               // new rotor position (not validated)
 		ROTOR_CMD,                   // completed rotor cmd (finalized)
 		ROTOR_POS,                   // current rotor position
+		SAT_POSITION,                // current frontend satellite position
+		ADVANCED_LINKED_ROOT,        // number slot connected frontend
 		LINKED_PREV_PTR,             // prev double linked list (for linked FEs)
 		LINKED_NEXT_PTR,             // next double linked list (for linked FEs)
 		SATPOS_DEPENDS_PTR,          // pointer to FE with configured rotor (with twin/quattro lnb)

--- a/lib/dvb/idvb.h
+++ b/lib/dvb/idvb.h
@@ -557,6 +557,7 @@ public:
 	virtual void setRotorMoving(int slotid, bool)=0;
 	virtual RESULT resetAdvancedsatposdependsRoot(int link)=0;
 	virtual bool isOrbitalPositionConfigured(int orbital_position)=0;
+	virtual bool tunerLinkedInUse(int root)=0;
 	virtual void forceUpdateRotorPos(int slot, int orbital_position)=0;
 };
 

--- a/lib/dvb/sec.h
+++ b/lib/dvb/sec.h
@@ -413,6 +413,7 @@ public:
 	int getRotorAdvancedsatposdependsPosition(int advanced_satposdepends);
 	bool setAdvancedsatposdependsRoot(int advanced_satposdepends);
 	bool tunerAdvancedsatposdependsInUse(int root);
+	bool tunerLinkedInUse(int root);
 	void setSlotNotLinked(int tuner_no);
 	void setRotorMoving(int, bool); // called from the frontend's
 	bool isRotorMoving();


### PR DESCRIPTION
…tuners

-[frontend] Unicable add new variable SAT_POSITION for all
tuners(earlier only rotor ROTOR_POS ).
SAT_POSITION reset(-1) when closed tuner.
-[sec] add check when tuner is linked using  combination DiSEqC
1.0/1.1(Unicable LNB + simple LNB).
-[frontend/sec] add checking the availability of  loop through(linked)
multiple FBC tuners.
Earlier, example:
Tuner A --> FBC DVB-S root
DiSEqC 1.0 --> port A --> sat 19.2E /port B  --> sat 13E Unicable

Tuner C --> FBC DVB-S list
advanced mode --> sat 13E Unicable --> port B --> connected tuner A

Tuner D --> FBC DVB-S list
advanced mode --> sat 13E Unicable --> port B --> connected tuner A

Situation:
Zap to service 13E --> use tuner A
Play as PiP other service 13E -->use tuner C
Zap to service 19.2E --> use tuner A

A unique sight!
PiP(13E) and live tv(19.2E) I work one second at a time.

Same DiSEqC!

Cause:
setTunerLinked overwrites the data for each tuner.