### PR TITLE
[epgcache.cpp] Fix UTF-8 double encoding bug

### DIFF
--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -158,8 +158,13 @@ eventData::eventData(const eit_event_struct* e, int size, int _type, int tsidoni
 
 					//convert our strings to UTF8
 					std::string eventNameUTF8 = convertDVBUTF8((const unsigned char*)&descr[6], eventNameLen, table, tsidonid);
-					std::string text((const char*)&descr[7 + eventNameLen], eventTextLen);
-					unsigned int eventNameUTF8len = eventNameUTF8.length();
+					std::string eventTextUTF8 = convertDVBUTF8((const unsigned char*)&descr[7 + eventNameLen], eventTextLen, table, tsidonid);
+					
+					//hack to fix split titles
+					undoAbbreviation(eventNameUTF8, eventTextUTF8);
+
+ 					unsigned int eventNameUTF8len = eventNameUTF8.length();
+ 					unsigned int eventTextUTF8len = eventTextUTF8.length();
 
 					//Rebuild the short event descriptor with UTF-8 strings
 
@@ -201,10 +206,11 @@ eventData::eventData(const eit_event_struct* e, int size, int _type, int tsidoni
 						*pdescr++ = title_crc;
 					}
 
-					//save text with original encoding
-					if( eventTextLen > 0 ) //only store the data if there is something to store
+					//save text with UTF-8 encoding
+					if( eventTextUTF8len > 0 ) //only store the data if there is something to store
 					{
-						int text_len = 6 + eventTextLen;
+						eventTextUTF8len = truncateUTF8(eventTextUTF8, 255 - 6);
+						int text_len = 6 + eventTextUTF8len;
 						uint8_t *text_data = new uint8_t[text_len + 2];
 						text_data[0] = SHORT_EVENT_DESCRIPTOR;
 						text_data[1] = text_len;
@@ -212,8 +218,9 @@ eventData::eventData(const eit_event_struct* e, int size, int _type, int tsidoni
 						text_data[3] = descr[3];
 						text_data[4] = descr[4];
 						text_data[5] = 0;
-						text_data[6] = eventTextLen;
-						memcpy(&text_data[7], text.data(), eventTextLen);
+						text_data[6] = eventTextUTF8len + 1;
+						text_data[7] = 0x15; //identify event text as UTF-8
+						memcpy(&text_data[8], eventTextUTF8.data(), eventTextUTF8len);
 
 						text_len += 2; //add 2 the length to include the 2 bytes in the header
 						uint32_t text_crc = calculate_crc_hash(text_data, text_len);


### PR DESCRIPTION
This bug was causing some EPG and AutoTimer searches to fail due to an encoding mismatch.

Patch author: LraiZer.