### PR TITLE
[OSDPositionSetup] use standard save instead config.save()

### DIFF
--- a/lib/python/Plugins/SystemPlugins/OSDPositionSetup/overscanwizard.py
+++ b/lib/python/Plugins/SystemPlugins/OSDPositionSetup/overscanwizard.py
@@ -191,10 +191,6 @@ class OverscanWizard(Screen, ConfigListScreen):
 					config.plugins.OSDPositionSetup.dst_top.value = 0
 					config.plugins.OSDPositionSetup.dst_height.value = 576
 				config.misc.do_overscanwizard.value = False
-				config.plugins.OSDPositionSetup.dst_left.save()
-				config.plugins.OSDPositionSetup.dst_width.save()
-				config.plugins.OSDPositionSetup.dst_top.save()
-				config.plugins.OSDPositionSetup.dst_height.save()
 				config.misc.do_overscanwizard.save()
 				setConfiguredPosition()
 				self.close()

--- a/lib/python/Plugins/SystemPlugins/OSDPositionSetup/overscanwizard.py
+++ b/lib/python/Plugins/SystemPlugins/OSDPositionSetup/overscanwizard.py
@@ -191,7 +191,11 @@ class OverscanWizard(Screen, ConfigListScreen):
 					config.plugins.OSDPositionSetup.dst_top.value = 0
 					config.plugins.OSDPositionSetup.dst_height.value = 576
 				config.misc.do_overscanwizard.value = False
-				config.save()
+				config.plugins.OSDPositionSetup.dst_left.save()
+				config.plugins.OSDPositionSetup.dst_width.save()
+				config.plugins.OSDPositionSetup.dst_top.save()
+				config.plugins.OSDPositionSetup.dst_height.save()
+				config.misc.do_overscanwizard.save()
 				setConfiguredPosition()
 				self.close()
 			else:


### PR DESCRIPTION
If several windows are open at the same time, then only the settings of
the last window are saved.