### PR TITLE
[Ci.py] rework first text slot numer

### DIFF
--- a/lib/python/Screens/Ci.py
+++ b/lib/python/Screens/Ci.py
@@ -392,13 +392,18 @@ class CiSelection(Screen):
 		menuList.l.setList(self.list)
 		self["entries"] = menuList
 		self["entries"].onSelectionChanged.append(self.selectionChanged)
-		self["text"] = Label(_("Slot %d") % 1)
+		self["text"] = Label("")
 		self.onLayoutFinish.append(self.layoutFinished)
 
 	def layoutFinished(self):
 		global forceNotShowCiMessages
 		forceNotShowCiMessages = False
 		self.setTitle(_("Common Interface"))
+		cur = self["entries"].getCurrent()
+		if cur and len(cur) > 2:
+			self["text"].setText(_("Slot %d") % (cur[3] + 1))
+		elif not cur:
+			self["text"].setText(_("no module found"))
 
 	def selectionChanged(self):
 		if self.slot > 1:


### PR DESCRIPTION
-when not module set text "no module found"
-when found module and  slot is number 2(e.g. duo4k/zgemma H9twin)  or
always one slot -->set correct slot number