### PR TITLE
[EventView] Use "info" button to close screen

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -647,7 +647,7 @@
 		<key id="KEY_RIGHT" mapto="nextEvent" flags="mr" />
 		<key id="KEY_RED" mapto="openSimilarList" flags="m" />
 		<key id="KEY_GREEN" mapto="timerAdd" flags="m" />
-		<key id="KEY_INFO" mapto="contextMenu" flags="m" />
+		<key id="KEY_INFO" mapto="cancel" flags="m" />
 		<key id="KEY_MENU" mapto="contextMenu" flags="m" />
 		<key id="KEY_PROGRAM" mapto="timerAdd" flags="m" />
 		<key id="KEY_EDIT" mapto="timerAdd" flags="m" />


### PR DESCRIPTION
While the "EventView" screen is displayed by pressing the "info" button on the remote control while watching a channel, you cannot use the same button to close it. This is not convenient and rather unusual, since most screens can be closed with the same button they are opened with (e.g. menus, infobar, etc).

This change will reassign the "info" button to close (cancel) operation for the "EventView" screen. Prior to this, the "info button and the "menu" button were used for the same purpose: To open a menu with specific plugins (if any of these plugins are actually installed in the system - I don't have any, so I don't know which they are) when the "EventView" screen in on.

The "EventViewActions" actions that are modified here, are not used anywhere else in enigma2, so I don't expect any side effects.