### PR TITLE
[Satconfig/ServiceStopScreen] reopen tuner after save

### DIFF
--- a/lib/python/Screens/Satconfig.py
+++ b/lib/python/Screens/Satconfig.py
@@ -684,10 +684,13 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 			# sanity check for empty sat list
 			if not (self.nimConfig.configMode.value == "satposdepends" or self.nimConfig.configMode.value == "advanced" and int(self.nimConfig.advanced.sat[3607].lnb.value) != 0) and len(nimmanager.getSatListForNim(self.slotid)) < 1:
 				self.nimConfig.configMode.value = "nothing"
-		elif self.nim.isCompatible("DVB-C") and self.nim.isFBCRoot() and self.nimConfig.configMode.value == "nothing":
+		elif self.nim.isCompatible("DVB-C") and self.nim.isFBCRoot():
+			value = "nothing"
+			if self.nimConfig.configMode.value == "enabled":
+				value = "enabled"
 			for slot in nimmanager.nim_slots:
-				if slot.isFBCLink() and slot.is_fbc[2] == self.nim.is_fbc[2] and slot.config.configMode.value != "nothing":
-					slot.config.configMode.value = "nothing"
+				if slot.isFBCLink() and slot.is_fbc[2] == self.nim.is_fbc[2] and slot.config.configMode.value != value:
+					slot.config.configMode.value = value
 					slot.config.configMode.save()
 		if reopen and self.oldref and self.slot_number == self.slotid:
 			refstr = self.oldAlternativeref.toString()

--- a/lib/python/Screens/Satconfig.py
+++ b/lib/python/Screens/Satconfig.py
@@ -692,9 +692,9 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 		if reopen and self.oldref and self.slot_number == self.slotid:
 			refstr = self.oldAlternativeref.toString()
 			force_reopen = False
-			if "EEEE0000" in refstr and (self.nim.isCompatible("DVB-T") and self.nimConfig.configMode.value == "nothing") or (self.nim.isCombined() and self.nim.canBeCompatible("DVB-T") and not self.nimConfig.configModeDVBT.value):
+			if "EEEE" in refstr and (self.nim.isCompatible("DVB-T") and self.nimConfig.configMode.value == "nothing") or (self.nim.isCombined() and self.nim.canBeCompatible("DVB-T") and not self.nimConfig.configModeDVBT.value):
 				force_reopen = True
-			elif "FFFF0000" in refstr and ((self.nim.isCompatible("DVB-C") and self.nimConfig.configMode.value == "nothing") or (self.nim.isCombined() and self.nim.canBeCompatible("DVB-C") and not self.nimConfig.configModeDVBC.value)) or ((self.nim.isCompatible("ATSC") and self.nimConfig.configMode.value == "nothing") or (self.nim.isCombined() and self.nim.canBeCompatible("ATSC") and not self.nimConfig.configModeATSC.value)):
+			elif "FFFF" in refstr and ((self.nim.isCompatible("DVB-C") and self.nimConfig.configMode.value == "nothing") or (self.nim.isCombined() and self.nim.canBeCompatible("DVB-C") and not self.nimConfig.configModeDVBC.value)) or ((self.nim.isCompatible("ATSC") and self.nimConfig.configMode.value == "nothing") or (self.nim.isCombined() and self.nim.canBeCompatible("ATSC") and not self.nimConfig.configModeATSC.value)):
 				force_reopen = True
 			if force_reopen:
 				raw_channel = eDVBResourceManager.getInstance().allocateRawChannel(self.slotid)


### PR DESCRIPTION
*[ServiceStopScreen] fix stop alternative service, add slot_number, add
oldAlternativeref
*[Satconfig] when tuner DVB-T/C or ATCS mode and disable tuner and the
previous playing service was of the same type close/reopen frontend for
clear all setting