### PR TITLE
Update EventInfo for audio internet streams

### DIFF
--- a/lib/python/Components/Sources/EventInfo.py
+++ b/lib/python/Components/Sources/EventInfo.py
@@ -1,7 +1,102 @@
 from Components.PerServiceDisplay import PerServiceBase
 from Components.Element import cached
 from enigma import iPlayableService, iServiceInformation, eServiceReference, eEPGCache
-from Source import Source
+from Components.Sources.Source import Source
+
+
+# Fake eServiceEvent to fill Event_Now and Event_Next in Infobar for Streams
+class pServiceEvent(object):
+	NOW = 0
+	NEXT = 1
+
+	def __init__(self, info, now_or_next):
+		self.now_or_next = now_or_next
+
+		self.m_EventNameNow = ""
+		self.m_EventNameNext = ""
+		self.m_ShortDescriptionNow = ""
+		self.m_ShortDescriptionNext = ""
+		self.m_ExtendedDescriptionNow = ""
+		self.m_ExtendedDescriptionNext = ""
+		
+		sTagTitle = info.getInfoString(iServiceInformation.sTagTitle)
+		if sTagTitle:
+			sTagTitleList = sTagTitle.split(" - ")
+			element1 = sTagTitleList[0] if len(sTagTitleList) >= 1 else ""
+			element2 = sTagTitleList[1] if len(sTagTitleList) >= 2 else ""
+			element3 = sTagTitleList[2] if len(sTagTitleList) >= 3 else ""
+			if element3 == "":
+				self.m_EventNameNow = element1
+				self.m_EventNameNext = element2
+			if element3 != "":
+				self.m_EventNameNow = element1 + " - " + element2
+				self.m_EventNameNext = element3
+
+		sTagGenre = info.getInfoString(iServiceInformation.sTagGenre)
+		if sTagGenre:
+			element4 = sTagGenre
+			self.m_ShortDescriptionNow = element4
+
+		sTagOrganization = info.getInfoString(iServiceInformation.sTagOrganization)
+		if sTagOrganization:
+			element5 = sTagOrganization
+			self.m_ExtendedDescriptionNow = element5
+
+		sTagLocation = info.getInfoString(iServiceInformation.sTagLocation)
+		if sTagLocation:
+			element6 = sTagLocation
+			self.m_ExtendedDescriptionNow += "\n\n" + element6
+
+	def getEventName(self):
+		return self.m_EventNameNow if self.now_or_next == self.NOW else self.m_EventNameNext
+
+	def getShortDescription(self):
+		return self.m_ShortDescriptionNow if self.now_or_next == self.NOW else self.m_ShortDescriptionNext
+
+	def getExtendedDescription(self):
+		return self.m_ExtendedDescriptionNow if self.now_or_next == self.NOW else self.m_ExtendedDescriptionNext
+
+	def getBeginTime(self):
+		return 0
+
+	def getEndTime(self):
+		return 0
+
+	def getDuration(self):
+		return 0
+
+	def getEventId(self):
+		return 0
+
+	def getBeginTimeString(self):
+		return ""
+
+	def getPdcPil(self):
+		return ""
+
+	def getGenreData(self):
+		return None
+
+	def getParentalData(self):
+		return None
+
+	def getRunningStatus(self):
+		return 0
+
+	def getSeriesCrid(self):
+		return ""
+
+	def getEpisodeCrid(self):
+		return ""
+
+	def getComponentData(self):
+		return 0
+
+	def getNumOfLinkageServices(self):
+		return 0
+
+	def getLinkageService(self):
+		return 0
 
 
 class EventInfo(PerServiceBase, Source, object):
@@ -28,6 +123,10 @@ class EventInfo(PerServiceBase, Source, object):
 			if not ret or ret.getEventName() == "":
 				refstr = info.getInfoString(iServiceInformation.sServiceref)
 				ret = self.epgQuery(eServiceReference(refstr), -1, self.now_or_next and 1 or 0)
+				if not ret and refstr.split(':')[0] in ['4097', '5001', '5002', '5003']: # No EPG Try to get Meta
+					ev = pServiceEvent(info, self.now_or_next)
+					if ev.getEventName:
+						return ev
 		return ret
 
 	event = property(getEvent)


### PR DESCRIPTION
* Split MP3 Stream titles by "-" and display it for Event_Now /
Event_Next
* rename to pServiceEvent (pythonServiceEvent)
* fill short and extended description for Event_Now and Event_Next
* Move element3 to Event_Next if it is not empty and place element1 and
element2 on Event_Now. If element3 is empty place element1 on Event_Now
and element2 on Event_Next

based:
https://github.com/openatv/enigma2/commit/a11139f617df6690fef750108db487b935c82b67#diff-76b5a357391276b282a516f54f48ef3c207f46d8192dc58c208d5183d38415f8

thanks  @4l3x2k @jbleyel