### PR TITLE
[AudioSelection] fix selected_subtitle for some plugins

### DIFF
--- a/lib/python/Screens/AudioSelection.py
+++ b/lib/python/Screens/AudioSelection.py
@@ -32,6 +32,8 @@ class AudioSelection(Screen, ConfigListScreen):
 		self.Plugins = []
 		ConfigListScreen.__init__(self, [])
 		self.infobar = infobar or self.session.infobar
+		if not hasattr(self.infobar, "selected_subtitle"):
+			self.infobar.selected_subtitle = None
 
 		self.__event_tracker = ServiceEventTracker(screen=self, eventmap={
 				iPlayableService.evUpdatedInfo: self.__updatedInfo


### PR DESCRIPTION
-File "/usr/lib/enigma2/python/Screens/AudioSelection.py", line 239, in
getSubtitleList
AttributeError: 'RemotePlayer' object has no attribute
'selected_subtitle'