### PR TITLE
[ClockToText] Use named arguments in strings

### DIFF
--- a/lib/python/Components/Converter/ClockToText.py
+++ b/lib/python/Components/Converter/ClockToText.py
@@ -95,10 +95,10 @@ class ClockToText(Converter, object):
 
 		if self.type == self.WITH_SECONDS:
 			# TRANSLATORS: full time representation hour:minute:seconds
-			return fix_space(_("%2d:%02d:%02d") % (t.tm_hour, t.tm_min, t.tm_sec))
+			return fix_space(_("%(hour)2d:%(min)02d:%(sec)02d") % {"hour": t.tm_hour, "min": t.tm_min, "sec": t.tm_sec})
 		elif self.type == self.DEFAULT:
 			# TRANSLATORS: short time representation hour:minute
-			return fix_space(_("%2d:%02d") % (t.tm_hour, t.tm_min))
+			return fix_space(_("%(hour)2d:%(min)02d") % {"hour": t.tm_hour, "min": t.tm_min})
 		elif self.type == self.DATE:
 			# TRANSLATORS: full date representation dayname daynum monthname year in strftime() format! See 'man strftime'
 			d = _("%A %e %B %Y")


### PR DESCRIPTION
This eliminates the following warning:

```
'msgid' format string with unnamed arguments cannot be properly localized:
The translator cannot reorder the arguments.
Please consider using a format string with named arguments,
and a mapping instead of a tuple for the arguments.
```

Existing translations DO NOT need any modification by hand, because ALL of them use the original string (untranslated or just copied and pasted).

I don't really see the point in offering these two strings for translation anyway, but since they're already there, I would prefer not seeing the warning when running the updateallpo.sh script.