### PR TITLE
[DiskInfo] Use named arguments in string

### DIFF
--- a/lib/python/Components/DiskInfo.py
+++ b/lib/python/Components/DiskInfo.py
@@ -37,7 +37,7 @@ class DiskInfo(VariableText, GUIComponent):
 					free = _("%d MB") % (free >> 20)
 				else:
 					free = _("%d GB") % (free >> 30)
-				self.setText(_("%s %s free disk space") % (free, percent))
+				self.setText(_("%(freespace)s %(percent)s free disk space") % {"freespace": free, "percent": percent})
 			except:
 				# occurs when f_blocks is 0 or a similar error
 				self.setText("-?-")

--- a/po/ar.po
+++ b/po/ar.po
@@ -408,7 +408,7 @@ msgid "%s %d.%d"
 msgstr ""
 
 #, fuzzy, python-format
-msgid "%s %s free disk space"
+msgid "%(freespace)s %(percent)s free disk space"
 msgstr "المساحه المتبقيه فى القرص"
 
 #, python-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -358,8 +358,8 @@ msgid "%s %d.%d"
 msgstr "%s %d.%d"
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s свободно място на диска"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s свободно място на диска"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -379,8 +379,8 @@ msgstr "%s %d.%d"
 
 #
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %sespai lliure al disc"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s espai lliure al disc"
 
 #
 #, python-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -388,8 +388,8 @@ msgstr "%s %d.%d"
 
 #
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s volného místa"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s volného místa"
 
 #
 #, python-format

--- a/po/da.po
+++ b/po/da.po
@@ -369,8 +369,8 @@ msgstr ""
 
 #
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s fri HDD plads"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s fri HDD plads"
 
 #
 #, python-format

--- a/po/de.po
+++ b/po/de.po
@@ -358,8 +358,8 @@ msgid "%s %d.%d"
 msgstr "%s %d.%d"
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s freier Festplattenspeicher"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s freier Festplattenspeicher"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/el.po
+++ b/po/el.po
@@ -358,8 +358,8 @@ msgid "%s %d.%d"
 msgstr "%s %d.%d"
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s ελεύθερος χώρος δίσκου"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s ελεύθερος χώρος δίσκου %(percent)s"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/en.po
+++ b/po/en.po
@@ -347,8 +347,8 @@ msgid "%s %d.%d"
 msgstr ""
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s free disk space"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s free disk space"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/es.po
+++ b/po/es.po
@@ -376,8 +376,8 @@ msgstr "%s %d.%d"
 
 #
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s espacio libre en disco"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s espacio libre en disco"
 
 #
 #, python-format

--- a/po/et.po
+++ b/po/et.po
@@ -355,8 +355,8 @@ msgid "%s %d.%d"
 msgstr "%s %d.%d"
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s vaba kettaruumi"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s vaba kettaruumi"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/fa.po
+++ b/po/fa.po
@@ -338,7 +338,7 @@ msgid "%s %d.%d"
 msgstr "%s %d.%d"
 
 #, python-format
-msgid "%s %s free disk space"
+msgid "%(freespace)s %(percent)s free disk space"
 msgstr ""
 
 #, python-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -371,8 +371,8 @@ msgstr ""
 
 #
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s vapaata levytilaa"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s vapaata levytilaa"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -356,8 +356,8 @@ msgid "%s %d.%d"
 msgstr "%s %d.%d"
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s espace disque libre"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s espace disque libre"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/fy.po
+++ b/po/fy.po
@@ -369,7 +369,7 @@ msgstr ""
 
 #
 #, fuzzy, python-format
-msgid "%s %s free disk space"
+msgid "%(freespace)s %(percent)s free disk space"
 msgstr "freie skiif rûmte"
 
 #

--- a/po/gl.po
+++ b/po/gl.po
@@ -377,8 +377,8 @@ msgstr "%s %d.%d"
 
 #
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s espazo libre en disco"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s espazo libre en disco"
 
 #
 #, python-format

--- a/po/he.po
+++ b/po/he.po
@@ -363,7 +363,7 @@ msgstr ""
 
 #
 #, fuzzy, python-format
-msgid "%s %s free disk space"
+msgid "%(freespace)s %(percent)s free disk space"
 msgstr "מקום פנוי בכונן הקשיח"
 
 #, python-format

--- a/po/hr.po
+++ b/po/hr.po
@@ -369,8 +369,8 @@ msgid "%s %d.%d"
 msgstr "%s %d.%d"
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s slobodnog prostora na disku"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s slobodnog prostora na disku"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/hu.po
+++ b/po/hu.po
@@ -357,8 +357,8 @@ msgid "%s %d.%d"
 msgstr "%s %d.%d"
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s szabad tárterület"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s szabad tárterület"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/id.po
+++ b/po/id.po
@@ -361,8 +361,8 @@ msgid "%s %d.%d"
 msgstr "%s %d.%d"
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s sisa penyimpanan disk"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s sisa penyimpanan disk"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/is.po
+++ b/po/is.po
@@ -366,7 +366,7 @@ msgstr ""
 
 #
 #, fuzzy, python-format
-msgid "%s %s free disk space"
+msgid "%(freespace)s %(percent)s free disk space"
 msgstr "laust diskpláss"
 
 #

--- a/po/it.po
+++ b/po/it.po
@@ -365,8 +365,8 @@ msgid "%s %d.%d"
 msgstr "%s %d.%d"
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s di spazio libero su disco"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s di spazio libero su disco"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/ku.po
+++ b/po/ku.po
@@ -354,8 +354,8 @@ msgid "%s %d.%d"
 msgstr ""
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s nav diké da vekiri"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s nav diké da vekiri"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/lt.po
+++ b/po/lt.po
@@ -368,8 +368,8 @@ msgid "%s %d.%d"
 msgstr "%s %d.%d"
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s laisvos vietos diske"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s laisvos vietos diske"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/lv.po
+++ b/po/lv.po
@@ -371,8 +371,8 @@ msgid "%s %d.%d"
 msgstr "%s %d.%d"
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s brīva vieta uz diska"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s brīva vieta uz diska"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/mk.po
+++ b/po/mk.po
@@ -358,8 +358,8 @@ msgid "%s %d.%d"
 msgstr ""
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s слободен простор на дискот"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s слободен простор на дискот"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/nb.po
+++ b/po/nb.po
@@ -373,8 +373,8 @@ msgid "%s %d.%d"
 msgstr "%s %d.%d"
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s ledig diskplass"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s ledig diskplass"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -357,8 +357,8 @@ msgid "%s %d.%d"
 msgstr "%s %d.%d"
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s beschikbare schijfruimte"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s beschikbare schijfruimte"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/nn.po
+++ b/po/nn.po
@@ -357,8 +357,8 @@ msgid "%s %d.%d"
 msgstr ""
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s ledig diskplass"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s ledig diskplass"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -368,8 +368,8 @@ msgid "%s %d.%d"
 msgstr ""
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s wolnej przestrzeni dyskowej"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s wolnej przestrzeni dyskowej"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/pt.po
+++ b/po/pt.po
@@ -366,8 +366,8 @@ msgstr ""
 
 #
 #, fuzzy, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s espaço livre em disco"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s espaço livre em disco"
 
 #
 #, python-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -351,8 +351,8 @@ msgid "%s %d.%d"
 msgstr ""
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s de espaço livre"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s de espaço livre"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/ro.po
+++ b/po/ro.po
@@ -348,7 +348,7 @@ msgid "%s %d.%d"
 msgstr ""
 
 #, fuzzy, python-format
-msgid "%s %s free disk space"
+msgid "%(freespace)s %(percent)s free disk space"
 msgstr "spatiu liber pe disk"
 
 #, python-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -367,8 +367,8 @@ msgid "%s %d.%d"
 msgstr "%s %d.%d"
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s свободное место на диске"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s свободное место на диске"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/sk.po
+++ b/po/sk.po
@@ -370,8 +370,8 @@ msgid "%s %d.%d"
 msgstr "%s %d.%d"
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s voľného miesta na disku"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s voľného miesta na disku"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -393,8 +393,8 @@ msgstr ""
 
 #
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s praznega prostora na disku"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s praznega prostora na disku"
 
 #
 #, python-format

--- a/po/sr.po
+++ b/po/sr.po
@@ -381,7 +381,7 @@ msgstr ""
 
 #
 #, fuzzy, python-format
-msgid "%s %s free disk space"
+msgid "%(freespace)s %(percent)s free disk space"
 msgstr "slobodan prostor na disku"
 
 #

--- a/po/sv.po
+++ b/po/sv.po
@@ -365,8 +365,8 @@ msgstr ""
 
 #
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s ledigt diskutrymme"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s ledigt diskutrymme"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/th.po
+++ b/po/th.po
@@ -352,7 +352,7 @@ msgid "%s %d.%d"
 msgstr ""
 
 #, fuzzy, python-format
-msgid "%s %s free disk space"
+msgid "%(freespace)s %(percent)s free disk space"
 msgstr "เนื้อที่เหลือยู่"
 
 #, python-format

--- a/po/tr.po
+++ b/po/tr.po
@@ -346,8 +346,8 @@ msgid "%s %d.%d"
 msgstr ""
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s boş disk alanı"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s boş disk alanı"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -367,8 +367,8 @@ msgid "%s %d.%d"
 msgstr "%s %d.%d"
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s вільне місце на диску"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s вільне місце на диску"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/vi.po
+++ b/po/vi.po
@@ -358,8 +358,8 @@ msgid "%s %d.%d"
 msgstr "%s %d.%d"
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s dung lượng đĩa trống"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s dung lượng đĩa trống"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -348,8 +348,8 @@ msgid "%s %d.%d"
 msgstr ""
 
 #, python-format
-msgid "%s %s free disk space"
-msgstr "%s %s 空闲空间"
+msgid "%(freespace)s %(percent)s free disk space"
+msgstr "%(freespace)s %(percent)s 空闲空间"
 
 #, python-format
 msgid "%s (%s)\n"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -345,7 +345,7 @@ msgid "%s %d.%d"
 msgstr ""
 
 #, python-format
-msgid "%s %s free disk space"
+msgid "%(freespace)s %(percent)s free disk space"
 msgstr ""
 
 #, python-format


### PR DESCRIPTION
This fixes the following issue:

'msgid' format string with unnamed arguments cannot be properly localized:
The translator cannot reorder the arguments.
Please consider using a format string with named arguments,
and a mapping instead of a tuple for the arguments.

Existing translations are updated as needed.