### PR TITLE
[ChannelSelection] Optimized string for translation

### DIFF
--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -1103,11 +1103,11 @@ class ChannelSelectionEdit:
 			messageText = _("Are you sure to remove all terrestrial services?")
 		else:
 			if unsigned_orbpos > 1800:
-				unsigned_orbpos = 3600 - unsigned_orbpos
-				direction = _("W")
+				orbpos = _("%.1f° W") % ((3600 - unsigned_orbpos) / 10.0)
 			else:
-				direction = _("E")
-			messageText = _("Are you sure to remove all %d.%d%s%s services?") % (unsigned_orbpos / 10, unsigned_orbpos % 10, "\xc2\xb0", direction)
+				orbpos = _("%.1f° E") % (unsigned_orbpos / 10.0)
+			# TRANSLATORS: The user is asked to delete all satellite services from a specific orbital position after a configuration change
+			messageText = _("Are you sure to remove all %s services?") % orbpos
 		self.session.openWithCallback(self.removeSatelliteServicesCallback, MessageBox, messageText)
 
 	def removeSatelliteServicesCallback(self, answer):

--- a/po/ar.po
+++ b/po/ar.po
@@ -1158,8 +1158,8 @@ msgid "Are you sure to reboot to"
 msgstr "هل تريد بالتاكيد أزاله هذا الإدخال ؟"
 
 #, fuzzy, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "هل أنت متأكد من أنك تريد إزالة جميع %d.%d%s%s القنوات؟"
+msgid "Are you sure to remove all %s services?"
+msgstr "هل أنت متأكد من أنك تريد إزالة جميع %s القنوات؟"
 
 #, fuzzy
 msgid "Are you sure to remove all cable services?"

--- a/po/bg.po
+++ b/po/bg.po
@@ -1062,8 +1062,8 @@ msgid "Are you sure to reboot to"
 msgstr "Наистина ли искате да рестартирате към"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Наистина ли искате да изтриете всички %d.%d%s%s канали?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Наистина ли искате да изтриете всички %s канали?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Наистина ли искате да изтриете всички кабелни канали?"

--- a/po/ca.po
+++ b/po/ca.po
@@ -1181,8 +1181,8 @@ msgid "Are you sure to reboot to"
 msgstr "Segur que heu de reiniciar ?"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Confirmeu que elimineu tots els serveis de% d.% d% s% s?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Confirmeu que elimineu tots els serveis de %s?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Esteu segur de suprimir tots els serveis per cable?"

--- a/po/cs.po
+++ b/po/cs.po
@@ -1215,8 +1215,8 @@ msgid "Are you sure to reboot to"
 msgstr "Opravdu chcete restartovat do"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Opravdu smazat všechny %d.%d%s%s programy?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Opravdu smazat všechny %s programy?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Opravdu smazat všechny programy kabelové televize?"

--- a/po/da.po
+++ b/po/da.po
@@ -1185,8 +1185,8 @@ msgid "Are you sure to reboot to"
 msgstr "Er du sikker på at dette punkt skal slettes?"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Er du sikker på du vil fjerne alle %d.%d%s%s services?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Er du sikker på du vil fjerne alle %s services?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Er du sikker på du vil fjerne alle kabel services?"

--- a/po/de.po
+++ b/po/de.po
@@ -1062,8 +1062,8 @@ msgid "Are you sure to reboot to"
 msgstr "Sind Sie sicher neuzustarten zu"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Sind Sie sicher, dass %d.%d%s%s entfernt werden soll?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Sind Sie sicher, dass %s entfernt werden soll?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Sind Sie sicher, dass alle Kabel-Dienste entfernt werden sollen?"

--- a/po/el.po
+++ b/po/el.po
@@ -1061,8 +1061,8 @@ msgid "Are you sure to reboot to"
 msgstr "Σίγουρα θέλετε να γίνει επανεκκίνηση στο"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Θέλετε σίγουρα να αφαιρεθούν όλες οι %d.%d%s%s υπηρεσίες;"
+msgid "Are you sure to remove all %s services?"
+msgstr "Θέλετε σίγουρα να αφαιρεθούν όλες οι %s υπηρεσίες;"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Θέλετε σίγουρα να αφαιρεθούν όλες οι καλωδιακές υπηρεσίες;"

--- a/po/en.po
+++ b/po/en.po
@@ -1064,7 +1064,7 @@ msgid "Are you sure to reboot to"
 msgstr ""
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
+msgid "Are you sure to remove all %s services?"
 msgstr ""
 
 msgid "Are you sure to remove all cable services?"

--- a/po/es.po
+++ b/po/es.po
@@ -1186,8 +1186,8 @@ msgid "Are you sure to reboot to"
 msgstr "¿Seguro que quieres eliminar esta entrada"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "¿Estás seguro que quieres eliminar todos los canales %d.%d%s%s?"
+msgid "Are you sure to remove all %s services?"
+msgstr "¿Estás seguro que quieres eliminar todos los canales %s?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "¿Estás seguro que quieres eliminar los canales de cable?"

--- a/po/et.po
+++ b/po/et.po
@@ -1069,8 +1069,8 @@ msgid "Are you sure to reboot to"
 msgstr "Kas eemaldada see kirje?"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Kas kindlasti eemaldada kõik %d.%d%s%s teenused?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Kas kindlasti eemaldada kõik %s teenused?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Kas kindlasti eemaldada kõik kaabliteenused?"

--- a/po/fa.po
+++ b/po/fa.po
@@ -1066,7 +1066,7 @@ msgid "Are you sure to reboot to"
 msgstr ""
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
+msgid "Are you sure to remove all %s services?"
 msgstr ""
 
 msgid "Are you sure to remove all cable services?"

--- a/po/fi.po
+++ b/po/fi.po
@@ -1172,7 +1172,7 @@ msgid "Are you sure to reboot to"
 msgstr "Haluatko poistaa tämän kohteen?"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
+msgid "Are you sure to remove all %s services?"
 msgstr ""
 
 msgid "Are you sure to remove all cable services?"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1060,8 +1060,8 @@ msgid "Are you sure to reboot to"
 msgstr "Etes-vous sûr de redémarrer sur"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Êtes-vous sûr de vouloir supprimer tous les %d.%d%s%s services?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Êtes-vous sûr de vouloir supprimer tous les %s services?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Êtes-vous sûr de vouloir supprimer tous les services du câble?"

--- a/po/fy.po
+++ b/po/fy.po
@@ -1195,7 +1195,7 @@ msgid "Are you sure to reboot to"
 msgstr ""
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
+msgid "Are you sure to remove all %s services?"
 msgstr ""
 
 msgid "Are you sure to remove all cable services?"

--- a/po/gl.po
+++ b/po/gl.po
@@ -1187,8 +1187,8 @@ msgid "Are you sure to reboot to"
 msgstr "Seguro que queres reiniciar a"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Seguro que queres eliminar todos os servizos %d.%d%s%s?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Seguro que queres eliminar todos os servizos %s?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Seguro que queres eliminar todos os servizos de cable?"

--- a/po/he.po
+++ b/po/he.po
@@ -1139,7 +1139,7 @@ msgid "Are you sure to reboot to"
 msgstr ""
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
+msgid "Are you sure to remove all %s services?"
 msgstr ""
 
 msgid "Are you sure to remove all cable services?"

--- a/po/hr.po
+++ b/po/hr.po
@@ -1076,8 +1076,8 @@ msgid "Are you sure to reboot to"
 msgstr "Želite li ponovno pokrenuti sustav?"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Želite li zaista ukloniti sve %d.%d%s%s usluge?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Želite li zaista ukloniti sve %s usluge?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Jeste li sigurni da želite ukloniti sve kabelske usluge?"

--- a/po/hu.po
+++ b/po/hu.po
@@ -1061,8 +1061,8 @@ msgid "Are you sure to reboot to"
 msgstr "Biztos benne, hogy újraindítja"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Biztos benne, hogy eltávolítja az összes %d.%d%s%s szolgáltatást?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Biztos benne, hogy eltávolítja az összes %s szolgáltatást?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Biztos benne, hogy eltávolítja az összes kábeles szolgáltatást?"

--- a/po/id.po
+++ b/po/id.po
@@ -1084,8 +1084,8 @@ msgid "Are you sure to reboot to"
 msgstr "Anda yakin ingin menghapus entri ini?"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Anda yakin ingin menghapus semua layanan %d.%d%s%s?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Anda yakin ingin menghapus semua layanan %s?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Anda yakin ingin menghapus semua layanan kabel?"

--- a/po/is.po
+++ b/po/is.po
@@ -1171,7 +1171,7 @@ msgid "Are you sure to reboot to"
 msgstr ""
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
+msgid "Are you sure to remove all %s services?"
 msgstr ""
 
 msgid "Are you sure to remove all cable services?"

--- a/po/it.po
+++ b/po/it.po
@@ -1074,8 +1074,8 @@ msgid "Are you sure to reboot to"
 msgstr "Sei sicuro di riavviare"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Si desidera eliminare tutti %d.%d%s%s canali?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Si desidera eliminare tutti %s canali?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Si desidera eliminare tutti i canali via cavo?"

--- a/po/ku.po
+++ b/po/ku.po
@@ -1071,7 +1071,7 @@ msgid "Are you sure to reboot to"
 msgstr ""
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
+msgid "Are you sure to remove all %s services?"
 msgstr ""
 
 msgid "Are you sure to remove all cable services?"

--- a/po/lt.po
+++ b/po/lt.po
@@ -1073,8 +1073,8 @@ msgid "Are you sure to reboot to"
 msgstr "Ar norite paleisti iš naujo į"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Ar tikrai norite pašalinti visus %d.%d%s%s kanalus?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Ar tikrai norite pašalinti visus %s kanalus?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Ar tikrai norite pašalinti visus kabelinius kanalus?"

--- a/po/lv.po
+++ b/po/lv.po
@@ -1076,8 +1076,8 @@ msgid "Are you sure to reboot to"
 msgstr "Vai tiešām vēlaties pārstartēt"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Vai tiešām vēlaties nodzēst visus %d.%d%s%s kanālus?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Vai tiešām vēlaties nodzēst visus %s kanālus?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Vai tiešām vēlaties nodzēst visus kabeļu kanālus?"

--- a/po/mk.po
+++ b/po/mk.po
@@ -1062,8 +1062,8 @@ msgid "Are you sure to reboot to"
 msgstr "Дали сигурно ќе го рестартирате"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Дали сте сигурни дека ќе ги отстраните сите канали на %d.% d %s%s?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Дали сте сигурни дека ќе ги отстраните сите канали на %s?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Дали сте сигурни дека ќе ги отстраните сите кабелски канали?"

--- a/po/nb.po
+++ b/po/nb.po
@@ -1166,8 +1166,8 @@ msgstr "Er du sikker på at du vil starte på nytt for å"
 
 #
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Er du sikker på at du vil fjerne alle %d.%d%s%s kanaler?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Er du sikker på at du vil fjerne alle %s kanaler?"
 
 #
 msgid "Are you sure to remove all cable services?"

--- a/po/nl.po
+++ b/po/nl.po
@@ -1060,8 +1060,8 @@ msgid "Are you sure to reboot to"
 msgstr "Wilt u zeker herstarten naar"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Wilt u definitief alle %d.%d%s%s zenders verwijderen?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Wilt u definitief alle %s zenders verwijderen?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Wilt u definitief alle kabelzenders verwijderen?"

--- a/po/nn.po
+++ b/po/nn.po
@@ -1148,7 +1148,7 @@ msgid "Are you sure to reboot to"
 msgstr ""
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
+msgid "Are you sure to remove all %s services?"
 msgstr ""
 
 msgid "Are you sure to remove all cable services?"

--- a/po/pl.po
+++ b/po/pl.po
@@ -1073,8 +1073,8 @@ msgid "Are you sure to reboot to"
 msgstr "Jesteś pewien, że chcesz zrestartować do"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Jesteś pewien, że chcesz usunąć wszystkie  %d.%d%s%s kanały?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Jesteś pewien, że chcesz usunąć wszystkie %s kanały?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Jesteś pewien, że chcesz usunąć wszystkie kanały tv kablowej?"

--- a/po/pt.po
+++ b/po/pt.po
@@ -1195,7 +1195,7 @@ msgid "Are you sure to reboot to"
 msgstr "Tem a certeza que deseja remover esta entrada?"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
+msgid "Are you sure to remove all %s services?"
 msgstr ""
 
 msgid "Are you sure to remove all cable services?"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1065,7 +1065,7 @@ msgid "Are you sure to reboot to"
 msgstr ""
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
+msgid "Are you sure to remove all %s services?"
 msgstr ""
 
 msgid "Are you sure to remove all cable services?"

--- a/po/ro.po
+++ b/po/ro.po
@@ -1071,7 +1071,7 @@ msgid "Are you sure to reboot to"
 msgstr ""
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
+msgid "Are you sure to remove all %s services?"
 msgstr ""
 
 msgid "Are you sure to remove all cable services?"

--- a/po/ru.po
+++ b/po/ru.po
@@ -1072,8 +1072,8 @@ msgid "Are you sure to reboot to"
 msgstr "Вы действительно хотите выполнить перезагрузку ресивера?"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Вы действительно хотите удалить все сервисы %d.%d%s%s?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Вы действительно хотите удалить все сервисы %s?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Вы действительно хотите удалить все кабельные сервисы?"

--- a/po/sk.po
+++ b/po/sk.po
@@ -1072,8 +1072,8 @@ msgid "Are you sure to reboot to"
 msgstr "Naozaj chcete reštartovať"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Naozaj chcete odstrániť všetky %d.%d%s%s stanice?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Naozaj chcete odstrániť všetky %s stanice?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Naozaj chcete odstrániť všetky stanice káblovej televízie?"

--- a/po/sl.po
+++ b/po/sl.po
@@ -1231,8 +1231,8 @@ msgid "Are you sure to reboot to"
 msgstr "Ste prepričani, da želite izbrisati izbrani vnos?"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Ali si prepričan, da želiš izbrisati vse %d.%d%s%s kanale?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Ali si prepričan, da želiš izbrisati vse %s kanale?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Ali si prepričan, da želiš izbrisati vse kabelske kanale?"

--- a/po/sr.po
+++ b/po/sr.po
@@ -1219,7 +1219,7 @@ msgid "Are you sure to reboot to"
 msgstr ""
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
+msgid "Are you sure to remove all %s services?"
 msgstr ""
 
 msgid "Are you sure to remove all cable services?"

--- a/po/sv.po
+++ b/po/sv.po
@@ -1187,8 +1187,8 @@ msgid "Are you sure to reboot to"
 msgstr "Är du säker på att ta bort denna posten?"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Är du säker på att ta bort alla %d.%d%s%s kanaler?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Är du säker på att ta bort alla %s kanaler?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Är du säker på att ta bort alla kabel-tv kanaler?"

--- a/po/th.po
+++ b/po/th.po
@@ -1077,7 +1077,7 @@ msgid "Are you sure to reboot to"
 msgstr ""
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
+msgid "Are you sure to remove all %s services?"
 msgstr ""
 
 msgid "Are you sure to remove all cable services?"

--- a/po/tr.po
+++ b/po/tr.po
@@ -1064,8 +1064,8 @@ msgid "Are you sure to reboot to"
 msgstr "Bu giriş silinecek. Emin misin?"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Bütün %d.%d%s%s servisler silinecek. Emin misin?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Bütün %s servisler silinecek. Emin misin?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Bütün kablo servisleri silinecek. Emin misin?"

--- a/po/uk.po
+++ b/po/uk.po
@@ -1072,8 +1072,8 @@ msgid "Are you sure to reboot to"
 msgstr "Перезавантажити до"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Ви впевнені, що хочете видалити усі %d.%d%s%s канали?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Ви впевнені, що хочете видалити усі %s канали?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Ви впевнені, що хочете видалити всі кабельні канали?"

--- a/po/vi.po
+++ b/po/vi.po
@@ -1048,8 +1048,8 @@ msgid "Are you sure to reboot to"
 msgstr "Bạn có chắc để khởi động lại"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Bạn có chắc chắn xóa tất cả các dịch vụ %d. %d%s %s không?"
+msgid "Are you sure to remove all %s services?"
+msgstr "Bạn có chắc chắn xóa tất cả các dịch vụ %s không?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "Bạn có chắc chắn để loại bỏ tất cả các dịch vụ cáp?"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1062,8 +1062,8 @@ msgid "Are you sure to reboot to"
 msgstr "是否重新启动"
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "是否要移除所有 %d.%d%s%s 频道?"
+msgid "Are you sure to remove all %s services?"
+msgstr "是否要移除所有 %s 频道?"
 
 msgid "Are you sure to remove all cable services?"
 msgstr "是否要移除所有有线频道？"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -1046,7 +1046,7 @@ msgid "Are you sure to reboot to"
 msgstr ""
 
 #, python-format
-msgid "Are you sure to remove all %d.%d%s%s services?"
+msgid "Are you sure to remove all %s services?"
 msgstr ""
 
 msgid "Are you sure to remove all cable services?"


### PR DESCRIPTION
Not sure why a 4 variable string (%d.%d%s%s) was needed to display the orbital position... This was misleading (couple of translations had errors) and was producing the following warning as well:

```
'msgid' format string with unnamed arguments cannot be properly localized:
The translator cannot reorder the arguments.
Please consider using a format string with named arguments,
and a mapping instead of a tuple for the arguments.
```
The new string is using already existing ones for the orbital position ("%.1f° W" and "%.1f° E") and is much simpler (only one variable is used for the orbital posiiton in the final string).

All existing translations are updated as needed.