### PR TITLE
[Task] Use named arguments for string

### DIFF
--- a/lib/python/Components/Task.py
+++ b/lib/python/Components/Task.py
@@ -488,7 +488,7 @@ class DiskspacePrecondition(Condition):
 			return False
 
 	def getErrorMessage(self, task):
-		return _("Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)") % (self.diskspace_required / 1024 / 1024, self.diskspace_available / 1024 / 1024)
+		return _("Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)") % {"req": self.diskspace_required / 1024 / 1024, "avail": self.diskspace_available / 1024 / 1024}
 
 
 class ToolExistsPrecondition(Condition):

--- a/po/ar.po
+++ b/po/ar.po
@@ -6072,8 +6072,8 @@ msgid "Not defined"
 msgstr "غير معرف"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "مساحة غير كافيه في القرص الصلب. الرجاء تحرير بعض المساحة على القرص وحاول مرة أخرى. (%d مطلوب بالميقابايت, %d ميقابايت متوفرة)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "مساحة غير كافيه في القرص الصلب. الرجاء تحرير بعض المساحة على القرص وحاول مرة أخرى. (%(req)d مطلوب بالميقابايت, %(avail)d ميقابايت متوفرة)"
 
 #, fuzzy
 msgid "Not tested:"

--- a/po/bg.po
+++ b/po/bg.po
@@ -5669,8 +5669,8 @@ msgid "Not defined"
 msgstr "Не определен"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Няма достатъчно място на диска. Моля освободете място на диска и опитайте отново. (%d MB трябват, %d MB налични)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Няма достатъчно място на диска. Моля освободете място на диска и опитайте отново. (%(req)d MB трябват, %(avail)d MB налични)"
 
 msgid "Not tested:"
 msgstr "Не е тестван:"

--- a/po/ca.po
+++ b/po/ca.po
@@ -6322,8 +6322,8 @@ msgid "Not defined"
 msgstr "No definit"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "No hi ha prou espai al disc. Allibereu espai per al disc i torneu-ho a provar. (% d MB obligatori,% d MB disponible)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "No hi ha prou espai al disc. Allibereu espai per al disc i torneu-ho a provar. (%(req)d MB obligatori, %(avail)d MB disponible)"
 
 msgid "Not tested:"
 msgstr "No provat:"

--- a/po/cs.po
+++ b/po/cs.po
@@ -6508,8 +6508,8 @@ msgstr "Nedefinován"
 
 #
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Nedostatek místa na disku. Uvolněte prostor na disku a zkuste znovu. (%d MB požadováno, %d MB k dispozici)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Nedostatek místa na disku. Uvolněte prostor na disku a zkuste znovu. (%(req)d MB požadováno, %(avail)d MB k dispozici)"
 
 msgid "Not tested:"
 msgstr "Netestováno:"

--- a/po/da.po
+++ b/po/da.po
@@ -6486,8 +6486,8 @@ msgstr "Ikke defineret"
 
 #
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Ikke diskplads nok. Venligst skab mere plads på disken og prøv igen. (%d MB nødvendig, %d MB ledig)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Ikke diskplads nok. Venligst skab mere plads på disken og prøv igen. (%(req)d MB nødvendig, %(avail)d MB ledig)"
 
 msgid "Not tested:"
 msgstr "Ikke testet: "

--- a/po/de.po
+++ b/po/de.po
@@ -5672,8 +5672,8 @@ msgid "Not defined"
 msgstr "Nicht definiert"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Nicht genügend freier Speicherplatz. Bitte löschen Sie nicht mehr benötigte Dateien und versuchen es erneut. (%d MB benötigt, %d MB verfügbar)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Nicht genügend freier Speicherplatz. Bitte löschen Sie nicht mehr benötigte Dateien und versuchen es erneut. (%(req)d MB benötigt, %(avail)d MB verfügbar)"
 
 msgid "Not tested:"
 msgstr "Nicht getestet:"

--- a/po/el.po
+++ b/po/el.po
@@ -5661,8 +5661,8 @@ msgid "Not defined"
 msgstr "Απροσδιόριστο"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Μη επαρκής χώρος δίσκου. Ελευθερώστε χώρο και προσπαθήστε ξανά. (%d MB απαιτούνται, %d MB διαθέσιμα)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Μη επαρκής χώρος δίσκου. Ελευθερώστε χώρο και προσπαθήστε ξανά. (%(req)d MB απαιτούνται, %(avail)d MB διαθέσιμα)"
 
 msgid "Not tested:"
 msgstr "Μη ελεγμένα:"

--- a/po/en.po
+++ b/po/en.po
@@ -5746,8 +5746,8 @@ msgid "Not defined"
 msgstr ""
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
 
 msgid "Not tested:"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -6318,8 +6318,8 @@ msgid "Not defined"
 msgstr "No definido"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "No hay suficiente espacio en el disco. Libere espacio en disco e inténtelo de nuevo. (% d MB requerido,% d MB disponible)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "No hay suficiente espacio en el disco. Libere espacio en disco e inténtelo de nuevo. (%(req)d MB requerido, %(avail)d MB disponible)"
 
 msgid "Not tested:"
 msgstr "No probado:"

--- a/po/et.po
+++ b/po/et.po
@@ -5716,8 +5716,8 @@ msgid "Not defined"
 msgstr "Määramata"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Kõvakettal pole piisavalt ruumi. Kustuta ebavajalik ja proovi uuesti. (%d MB vaja, %d MB saadaval)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Kõvakettal pole piisavalt ruumi. Kustuta ebavajalik ja proovi uuesti. (%(req)d MB vaja, %(avail)d MB saadaval)"
 
 msgid "Not tested:"
 msgstr "Pole testitud:"

--- a/po/fa.po
+++ b/po/fa.po
@@ -5847,8 +5847,8 @@ msgid "Not defined"
 msgstr ""
 
 #, fuzzy, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "فضای کافی وجود ندارد ، لطفا مقداری فضا خالی و دوباره تلاش کنید . (%d مگابایت نیاز است و %d مگابایت در دسترس است)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "فضای کافی وجود ندارد ، لطفا مقداری فضا خالی و دوباره تلاش کنید . (%(req)d مگابایت نیاز است و %(avail)d مگابایت در دسترس است)"
 
 msgid "Not tested:"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -6348,8 +6348,8 @@ msgstr "Ei määritetty"
 
 #
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Liian vähän levytilaa. Vapauta levytilaa ja yritä uudelleen. (%d Mt tarvitaan, %d Mt vapaana)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Liian vähän levytilaa. Vapauta levytilaa ja yritä uudelleen. (%(req)d Mt tarvitaan, %(avail)d Mt vapaana)"
 
 msgid "Not tested:"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -5663,8 +5663,8 @@ msgid "Not defined"
 msgstr "Pas défini"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Espace disque insuffisant. Veuillez libérer de l'espace disque et réessayer. (%d MB requis, %d MB disponible)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Espace disque insuffisant. Veuillez libérer de l'espace disque et réessayer. (%(req)d MB requis, %(avail)d MB disponible)"
 
 msgid "Not tested:"
 msgstr "Pas testé:"

--- a/po/fy.po
+++ b/po/fy.po
@@ -6546,8 +6546,8 @@ msgstr ""
 
 #
 #, fuzzy, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Net genôch diskrûmte. Rûmje wat rotzooi op en besykje opnei. (%d MB nedich, %d oanwêzich)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Net genôch diskrûmte. Rûmje wat rotzooi op en besykje opnei. (%(req)d MB nedich, %(avail)d oanwêzich)"
 
 msgid "Not tested:"
 msgstr ""

--- a/po/gl.po
+++ b/po/gl.po
@@ -6330,8 +6330,8 @@ msgid "Not defined"
 msgstr "Non definido"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "No hai espazo abondo no disco. Libera espazo no disco e inténtao outra vez. (%d MB requiridos,%d MB dispoñibles)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "No hai espazo abondo no disco. Libera espazo no disco e inténtao outra vez. (%(req)d MB requiridos, %(avail)d MB dispoñibles)"
 
 msgid "Not tested:"
 msgstr "Non probado:"

--- a/po/he.po
+++ b/po/he.po
@@ -6165,8 +6165,8 @@ msgstr ""
 
 #
 #, fuzzy, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "אין מקום בכונן הקשיח, פנה מעט מקום ונסה שוב (%d MB required, %d MB available)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "אין מקום בכונן הקשיח, פנה מעט מקום ונסה שוב (%(req)d MB required, %(avail)d MB available)"
 
 msgid "Not tested:"
 msgstr ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -5688,8 +5688,8 @@ msgid "Not defined"
 msgstr "Nije definirano"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Nedovoljno prostora na disku. Oslobodite prostor na disku i pokušajte ponovno. (%d MB potrebno, %d MB dostupno)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Nedovoljno prostora na disku. Oslobodite prostor na disku i pokušajte ponovno. (%(req)d MB potrebno, %(avail)d MB dostupno)"
 
 msgid "Not tested:"
 msgstr "Nije testirano:"

--- a/po/hu.po
+++ b/po/hu.po
@@ -5665,8 +5665,8 @@ msgid "Not defined"
 msgstr "Nincs megadva"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Nincs elég tárhely. Kérem, szabadítson fel némi helyet és próbálja meg újra. (%d MB területre lenne szükség, %d MB hely szabad jelenleg)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Nincs elég tárhely. Kérem, szabadítson fel némi helyet és próbálja meg újra. (%(req)d MB területre lenne szükség, %(avail)d MB hely szabad jelenleg)"
 
 msgid "Not tested:"
 msgstr "Nincs tesztelve:"

--- a/po/id.po
+++ b/po/id.po
@@ -5857,8 +5857,8 @@ msgid "Not defined"
 msgstr "Tak ditetapkan"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Tidak cukup ruang simpan disk. Mohon kosongkan beberapa ruang disk dan coba lagi. (%d MB diperlukan, %d MB tersedia)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Tidak cukup ruang simpan disk. Mohon kosongkan beberapa ruang disk dan coba lagi. (%(req)d MB diperlukan, %(avail)d MB tersedia)"
 
 msgid "Not tested:"
 msgstr "Tidak teruji:"

--- a/po/is.po
+++ b/po/is.po
@@ -6376,8 +6376,8 @@ msgstr ""
 
 #
 #, fuzzy, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Ekki nóg diskpláss. Taktu til á diskinum og reyndu aftur. (%d MB þarf, %d MB tiltæk)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Ekki nóg diskpláss. Taktu til á diskinum og reyndu aftur. (%(req)d MB þarf, %(avail)d MB tiltæk)"
 
 msgid "Not tested:"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -5706,8 +5706,8 @@ msgid "Not defined"
 msgstr "Non definito"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Spazio su disco insufficiente. Liberare spazio sul disco e riprovare. (%d MB richiesti, %d MB disponibili)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Spazio su disco insufficiente. Liberare spazio sul disco e riprovare. (%(req)d MB richiesti, %(avail)d MB disponibili)"
 
 msgid "Not tested:"
 msgstr "Non verificato:"

--- a/po/ku.po
+++ b/po/ku.po
@@ -5752,8 +5752,8 @@ msgid "Not defined"
 msgstr ""
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
 
 msgid "Not tested:"
 msgstr ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -5679,8 +5679,8 @@ msgid "Not defined"
 msgstr "Neapibrėžta"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Diske nepakanka vietos. Atlaisvinkite vietos diske ir bandykite dar kartą (reikia %d MB, laisva %d MB)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Diske nepakanka vietos. Atlaisvinkite vietos diske ir bandykite dar kartą (reikia %(req)d MB, laisva %(avail)d MB)"
 
 msgid "Not tested:"
 msgstr "Netikrinta:"

--- a/po/lv.po
+++ b/po/lv.po
@@ -5682,8 +5682,8 @@ msgid "Not defined"
 msgstr "Nav definēts"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Nav pietiekami vietas uz diska. Lūdzu atbrīvot vietu uz diska un mēģināt vēlreiz. (%d MB ir nepieciešami, bet %d MB pieejami)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Nav pietiekami vietas uz diska. Lūdzu atbrīvot vietu uz diska un mēģināt vēlreiz. (%(req)d MB ir nepieciešami, bet %(avail)d MB pieejami)"
 
 msgid "Not tested:"
 msgstr "Nav pārbaudīts:"

--- a/po/mk.po
+++ b/po/mk.po
@@ -5669,8 +5669,8 @@ msgid "Not defined"
 msgstr "Недефинирано"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Нема доволно место на дискот. Ослободете простор на дискот и обидете се повторно. (Задолжително е %d MB, достапно е %d MB)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Нема доволно место на дискот. Ослободете простор на дискот и обидете се повторно. (Задолжително е %(req)d MB, достапно е %(avail)d MB)"
 
 msgid "Not tested:"
 msgstr "Не е тестирано:"

--- a/po/nb.po
+++ b/po/nb.po
@@ -6308,8 +6308,8 @@ msgid "Not defined"
 msgstr "Ikke definert"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Ikke nok diskplass. Frigjør litt diskplass og prøv på nytt. (%d MB nødvendig, %d MB tilgjengelig)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Ikke nok diskplass. Frigjør litt diskplass og prøv på nytt. (%(req)d MB nødvendig, %(avail)d MB tilgjengelig)"
 
 msgid "Not tested:"
 msgstr "Ikke testet:"

--- a/po/nl.po
+++ b/po/nl.po
@@ -5869,8 +5869,8 @@ msgid "Not defined"
 msgstr "Niet vestgelegd"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Onvoldoende schijfruimte. Maak ruimte vrij en probeer het opnieuw (%d MB noodzakelijk, %d MB beschikbaar)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Onvoldoende schijfruimte. Maak ruimte vrij en probeer het opnieuw (%(req)d MB noodzakelijk, %(avail)d MB beschikbaar)"
 
 msgid "Not tested:"
 msgstr "Niet getest:"

--- a/po/nn.po
+++ b/po/nn.po
@@ -6299,8 +6299,8 @@ msgid "Not defined"
 msgstr ""
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Ikke nok diskplass. Vennligst frigjør litt diskplass og prøv på nytt. (%d MB nødvendig, %d MB tilgjengelig)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Ikke nok diskplass. Vennligst frigjør litt diskplass og prøv på nytt. (%(req)d MB nødvendig, %(avail)d MB tilgjengelig)"
 
 msgid "Not tested:"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -5680,8 +5680,8 @@ msgid "Not defined"
 msgstr "Niezdefiniowany"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Nie wystarczająca ilość przestrzeni dyskowej. Zwolnij miejsce na dysku i spróbuj ponownie. (%d MB wymagane, %d MB dostępne)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Nie wystarczająca ilość przestrzeni dyskowej. Zwolnij miejsce na dysku i spróbuj ponownie. (%(req)d MB wymagane, %(avail)d MB dostępne)"
 
 msgid "Not tested:"
 msgstr "Nieprzetestowane:"

--- a/po/pt.po
+++ b/po/pt.po
@@ -6580,8 +6580,8 @@ msgstr ""
 
 #
 #, fuzzy, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Não existe espaço suficiente no disco. Por favor liberte algum espaço e tente de novo. (%d MB necessário, %d MB disponível)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Não existe espaço suficiente no disco. Por favor liberte algum espaço e tente de novo. (%(req)d MB necessário, %(avail)d MB disponível)"
 
 msgid "Not tested:"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -5741,8 +5741,8 @@ msgid "Not defined"
 msgstr ""
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Espaço insuficiente no disco. Libere espaço e tente novamente. (%d MB necessário, %d MB disponível)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Espaço insuficiente no disco. Libere espaço e tente novamente. (%(req)d MB necessário, %(avail)d MB disponível)"
 
 msgid "Not tested:"
 msgstr ""

--- a/po/ro.po
+++ b/po/ro.po
@@ -5851,8 +5851,8 @@ msgid "Not defined"
 msgstr ""
 
 #, fuzzy, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Nu este spatiu suficient. Va rugam eliberati din spatiu si incercati din nou. (%d MB necesari, %d MB disponibili)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Nu este spatiu suficient. Va rugam eliberati din spatiu si incercati din nou. (%(req)d MB necesari, %(avail)d MB disponibili)"
 
 msgid "Not tested:"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -5678,8 +5678,8 @@ msgid "Not defined"
 msgstr "Не определено"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Нет места на диске. Пожалуйста, освободите немного места на диске и попробуйте снова. (%d MB требуется, %d MB доступно)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Нет места на диске. Пожалуйста, освободите немного места на диске и попробуйте снова. (%(req)d MB требуется, %(avail)d MB доступно)"
 
 msgid "Not tested:"
 msgstr "Без теста:"

--- a/po/sk.po
+++ b/po/sk.po
@@ -5679,8 +5679,8 @@ msgid "Not defined"
 msgstr "Nedefinované"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Nie je dostatok miesta na disku. Uvoľnite miesto na disku a a skúste to znova. (Potrebných je %d MB, ale voľných je iba %d MB.)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Nie je dostatok miesta na disku. Uvoľnite miesto na disku a a skúste to znova. (Potrebných je %(req)d MB, ale voľných je iba %(avail)d MB.)"
 
 msgid "Not tested:"
 msgstr "Netestované:"

--- a/po/sl.po
+++ b/po/sl.po
@@ -6595,8 +6595,8 @@ msgstr ""
 
 #
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Ni dovolj prostora! Sprostite prostor na disku in poizkusite ponovno (%d MB zahtevano, %d MB na voljo)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Ni dovolj prostora! Sprostite prostor na disku in poizkusite ponovno (%(req)d MB zahtevano, %(avail)d MB na voljo)"
 
 msgid "Not tested:"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -6635,8 +6635,8 @@ msgstr ""
 
 #
 #, fuzzy, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Nedovoljno prostora na disku. Molimo oslobodite nešto prostora i probajte ponovo. (%d MB potrebno,%d MB omogućeno)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Nedovoljno prostora na disku. Molimo oslobodite nešto prostora i probajte ponovo. (%(req)d MB potrebno, %(avail)d MB omogućeno)"
 
 msgid "Not tested:"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -6458,8 +6458,8 @@ msgstr "Inte definerad"
 
 #
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Inte tillräckligt med diskutrymme. Vänligen frigör diskutrymme och försök igen. (%d MB krävs, %d MB tillgängligt)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Inte tillräckligt med diskutrymme. Vänligen frigör diskutrymme och försök igen. (%(req)d MB krävs, %(avail)d MB tillgängligt)"
 
 msgid "Not tested:"
 msgstr "Inte testad :"

--- a/po/th.po
+++ b/po/th.po
@@ -5878,8 +5878,8 @@ msgid "Not defined"
 msgstr ""
 
 #, fuzzy, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "เนื้อที่ไม่เพียงพอ ลบไฟล์ที่ไม่ต้องการออกแล้วลองใหม่ (ต้องการ %d MB แต่เหลืออยู่ %d)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "เนื้อที่ไม่เพียงพอ ลบไฟล์ที่ไม่ต้องการออกแล้วลองใหม่ (ต้องการ %(req)d MB แต่เหลืออยู่ %(avail)d)"
 
 msgid "Not tested:"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -5773,8 +5773,8 @@ msgid "Not defined"
 msgstr "Tanımlanmamış"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Yetersiz disk alanı. Disk alanı boşaltarak tekrar deneyin. (%d MB gerekli, kullanılabilir %d MB)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Yetersiz disk alanı. Disk alanı boşaltarak tekrar deneyin. (%(req)d MB gerekli, kullanılabilir %(avail)d MB)"
 
 msgid "Not tested:"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -5679,8 +5679,8 @@ msgid "Not defined"
 msgstr "Не визначений"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Недостатньо місця на диску. Будь ласка, звільніть місце на диску і спробуйте ще раз. (потрібно %d МБ, доступний %d МБ)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Недостатньо місця на диску. Будь ласка, звільніть місце на диску і спробуйте ще раз. (потрібно %(req)d МБ, доступний %(avail)d МБ)"
 
 msgid "Not tested:"
 msgstr "Не протестовано:"

--- a/po/vi.po
+++ b/po/vi.po
@@ -5646,8 +5646,8 @@ msgid "Not defined"
 msgstr "Không xác định"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Không đủ dung lượng đĩa. Vui lòng giải phóng không gian đĩa và thử lại. (Yêu cầu%d MB,%d MB khả dụng)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "Không đủ dung lượng đĩa. Vui lòng giải phóng không gian đĩa và thử lại. (Yêu cầu %(req)d MB, %(avail)d MB khả dụng)"
 
 msgid "Not tested:"
 msgstr "Không được kiểm tra:"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -5659,8 +5659,8 @@ msgid "Not defined"
 msgstr "未定义"
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "磁盘空间不足.请释放一些磁盘空间并重试.（%d MB 被请求,%d MB 可用）"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
+msgstr "磁盘空间不足.请释放一些磁盘空间并重试.（%(req)d MB 被请求, %(avail)d MB 可用）"
 
 msgid "Not tested:"
 msgstr "还未测试:"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -5699,7 +5699,7 @@ msgid "Not defined"
 msgstr ""
 
 #, python-format
-msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
+msgid "Not enough disk space. Please free up some disk space and try again. (%(req)d MB required, %(avail)d MB available)"
 msgstr ""
 
 msgid "Not tested:"


### PR DESCRIPTION
This fixes the following issue:

```
'msgid' format string with unnamed arguments cannot be properly localized:
The translator cannot reorder the arguments.
Please consider using a format string with named arguments,
and a mapping instead of a tuple for the arguments.
```

Existing translations are updated as needed.