### PR TITLE
[ClockToText] Don't translate time strings

### DIFF
--- a/lib/python/Components/Converter/ClockToText.py
+++ b/lib/python/Components/Converter/ClockToText.py
@@ -94,11 +94,9 @@ class ClockToText(Converter, object):
 		t = localtime(time)
 
 		if self.type == self.WITH_SECONDS:
-			# TRANSLATORS: full time representation hour:minute:seconds
-			return fix_space(_("%(hour)2d:%(min)02d:%(sec)02d") % {"hour": t.tm_hour, "min": t.tm_min, "sec": t.tm_sec})
+			return fix_space("%2d:%02d:%02d" % (t.tm_hour, t.tm_min, t.tm_sec))
 		elif self.type == self.DEFAULT:
-			# TRANSLATORS: short time representation hour:minute
-			return fix_space(_("%(hour)2d:%(min)02d") % {"hour": t.tm_hour, "min": t.tm_min})
+			return fix_space("%2d:%02d" % (t.tm_hour, t.tm_min))
 		elif self.type == self.DATE:
 			# TRANSLATORS: full date representation dayname daynum monthname year in strftime() format! See 'man strftime'
 			d = _("%A %e %B %Y")


### PR DESCRIPTION
As discussed in #3067 and in https://github.com/OpenPLi/enigma2/commit/67d96537c3ecb679fd808a63c932c6bc8505a0b1 there's no point in offering these for translation.