### PR TITLE
[FlashImage] Small enhancements

### DIFF
--- a/lib/python/Screens/FlashImage.py
+++ b/lib/python/Screens/FlashImage.py
@@ -33,16 +33,14 @@ def checkimagefiles(files):
 class SelectImage(Screen):
 	def __init__(self, session, *args):
 		Screen.__init__(self, session)
-		self.session = session
 		self.jsonlist = {}
 		self.imagesList = {}
 		self.setIndex = 0
 		self.expanded = []
-		self.setTitle(_("Multiboot image selector"))
+		self.setTitle(_("Select image"))
 		self["key_red"] = StaticText(_("Cancel"))
 		self["key_green"] = StaticText()
 		self["key_yellow"] = StaticText()
-		self["key_blue"] = StaticText()
 		self["description"] = StaticText()
 		self["list"] = ChoiceList(list=[ChoiceEntryComponent('', ((_("Retrieving image list - Please wait...")), "Waiter"))])
 
@@ -407,9 +405,8 @@ class FlashImage(Screen):
 
 class MultibootSelection(SelectImage):
 	def __init__(self, session, *args):
-		Screen.__init__(self, session)
-		self.skinName = "SelectImage"
-		self.session = session
+		SelectImage.__init__(self, session)
+		self.skinName = ["MultibootSelection", "SelectImage"]
 		self.expanded = []
 		self.tmp_dir = None
 		self.setTitle(_("Multiboot image selector"))


### PR DESCRIPTION
SelectImage
* Removed redundant variable assigment ("session" is already assigned in parent class "Screen")
* Use correct title
* Removed unused "key_blue" variable

MultibootSelection
* Directly initialize parent class instead of grandparent one
* Allow for individual skinning
* Removed redundant variable assignment ("session" is already assigned in parent class "Screen")


Only change visible to the user is the correct title shown when choosing "menu --> settings --> flash image". The screen title was wrong there.