### PR TITLE
[MovieSelection] Use named arguments for string

### DIFF
--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -1967,7 +1967,7 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 					else:
 						files += 1
 			if files or subdirs:
-				msg = _("Directory contains %s and %s.") % (ngettext("%d file", "%d files", files) % files, ngettext("%d subdirectory", "%d subdirectories", subdirs) % subdirs) + '\n' + are_you_sure
+				msg = _("Directory contains %(file)s and %(subdir)s.") % {"file": ngettext("%d file", "%d files", files) % files, "subdir": ngettext("%d subdirectory", "%d subdirectories", subdirs) % subdirs} + '\n' + are_you_sure
 				if isInTrashFolder(current):
 					# Red button to empty trashcan item or subdir
 					msg = _("Deleted items") + "\n" + msg

--- a/po/ar.po
+++ b/po/ar.po
@@ -3029,7 +3029,7 @@ msgid "Directory browser"
 msgstr "تصفح الدليل"
 
 #, fuzzy, python-format
-msgid "Directory contains %s and %s."
+msgid "Directory contains %(file)s and %(subdir)s."
 msgstr "المجلد %s غير موجود."
 
 msgid "Disable"

--- a/po/bg.po
+++ b/po/bg.po
@@ -2820,8 +2820,8 @@ msgid "Directory browser"
 msgstr "Браузър директории"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Директорията съдържа %s и %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Директорията съдържа %(file)s и %(subdir)s."
 
 msgid "Disable"
 msgstr "Спри"

--- a/po/ca.po
+++ b/po/ca.po
@@ -3125,8 +3125,8 @@ msgid "Directory browser"
 msgstr "Navegador de directoris"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "El directori conté% s i% s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "El directori conté %(file)s i %(subdir)s."
 
 #
 msgid "Disable"

--- a/po/cs.po
+++ b/po/cs.po
@@ -3228,8 +3228,8 @@ msgid "Directory browser"
 msgstr "Prohlížeč adresářů"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Adresář obsahuje %s a %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Adresář obsahuje %(file)s a %(subdir)s."
 
 #
 msgid "Disable"

--- a/po/da.po
+++ b/po/da.po
@@ -3196,8 +3196,8 @@ msgid "Directory browser"
 msgstr "Mappe gennemsyn"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Mappen indeholder %s og %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Mappen indeholder %(file)s og %(subdir)s."
 
 #
 msgid "Disable"

--- a/po/de.po
+++ b/po/de.po
@@ -2823,8 +2823,8 @@ msgid "Directory browser"
 msgstr "Verzeichnis Browser"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Das Verzeichnis enthält %s und %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Das Verzeichnis enthält %(file)s und %(subdir)s."
 
 msgid "Disable"
 msgstr "Aus"

--- a/po/el.po
+++ b/po/el.po
@@ -297,8 +297,8 @@ msgstr[1] "%d δευτερόλεπτα"
 #, python-format
 msgid "%d subdirectory"
 msgid_plural "%d subdirectories"
-msgstr[0] "%d υποφάκελος"
-msgstr[1] "%d υποφάκελοι"
+msgstr[0] "%d υποφάκελο"
+msgstr[1] "%d υποφακέλους"
 
 #, python-format
 msgid "%d wireless network found!"
@@ -2814,8 +2814,8 @@ msgid "Directory browser"
 msgstr "Πλοηγός φακέλων"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Ο φάκελος περιέχει %s αρχείο(α) και %s υποφακέλους."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Ο φάκελος περιέχει %(file)s και %(subdir)s."
 
 msgid "Disable"
 msgstr "Απενεργοποίηση"

--- a/po/en.po
+++ b/po/en.po
@@ -2849,9 +2849,9 @@ msgstr "Directory %s does not exist."
 msgid "Directory browser"
 msgstr "Directory browser"
 
-#, fuzzy, python-format
-msgid "Directory contains %s and %s."
-msgstr "Directory contains %d file(s) and %d sub-directories.\n"
+#, python-format
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Directory contains %(file)s and %(subdir)s."
 
 msgid "Disable"
 msgstr "Disable"

--- a/po/es.po
+++ b/po/es.po
@@ -3134,8 +3134,8 @@ msgstr "Examinar directorios"
 
 #
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "El directorio contiene % s y %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "El directorio contiene %(file)s y %(subdir)s."
 
 #
 msgid "Disable"

--- a/po/et.po
+++ b/po/et.po
@@ -2838,8 +2838,8 @@ msgid "Directory browser"
 msgstr "Kataloogi brauser"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Kataloog sisaldab %s ja %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Kataloog sisaldab %(file)s ja %(subdir)s."
 
 msgid "Disable"
 msgstr "Keela"

--- a/po/fa.po
+++ b/po/fa.po
@@ -2896,7 +2896,7 @@ msgid "Directory browser"
 msgstr "مرورگر شاخه"
 
 #, fuzzy, python-format
-msgid "Directory contains %s and %s."
+msgid "Directory contains %(file)s and %(subdir)s."
 msgstr "پوشه %s وجود ندارد"
 
 msgid "Disable"

--- a/po/fi.po
+++ b/po/fi.po
@@ -3116,8 +3116,8 @@ msgid "Directory browser"
 msgstr "Hakemistoselain"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Hakemisto sisältää %s ja %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Hakemisto sisältää %(file)s ja %(subdir)s."
 
 #
 msgid "Disable"

--- a/po/fr.po
+++ b/po/fr.po
@@ -2818,8 +2818,8 @@ msgid "Directory browser"
 msgstr "Navigateur des répertoires"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Répertoire contient %s et %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Répertoire contient %(file)s et %(subdir)s."
 
 msgid "Disable"
 msgstr "Désactiver"

--- a/po/fy.po
+++ b/po/fy.po
@@ -3221,7 +3221,7 @@ msgstr ""
 
 #
 #, fuzzy, python-format
-msgid "Directory contains %s and %s."
+msgid "Directory contains %(file)s and %(subdir)s."
 msgstr "Map %s bestiit net"
 
 #

--- a/po/gl.po
+++ b/po/gl.po
@@ -3144,8 +3144,8 @@ msgstr "Explorador de directorios"
 
 #
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "O directorio contén %s e %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "O directorio contén %(file)s e %(subdir)s."
 
 #
 msgid "Disable"

--- a/po/he.po
+++ b/po/he.po
@@ -3026,7 +3026,7 @@ msgid "Directory browser"
 msgstr "סייר תיקיות"
 
 #, fuzzy, python-format
-msgid "Directory contains %s and %s."
+msgid "Directory contains %(file)s and %(subdir)s."
 msgstr " .לא קיימת %s הספרייה"
 
 msgid "Disable"

--- a/po/hr.po
+++ b/po/hr.po
@@ -2834,8 +2834,8 @@ msgid "Directory browser"
 msgstr "Imenik preglednika"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Direktorij sadrži %s i %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Direktorij sadrži %(file)s i %(subdir)s."
 
 msgid "Disable"
 msgstr "Onemogućite"

--- a/po/hu.po
+++ b/po/hu.po
@@ -2817,8 +2817,8 @@ msgid "Directory browser"
 msgstr "Mappa tallózása"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "A mappa tartalma %s és %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "A mappa tartalma %(file)s és %(subdir)s."
 
 msgid "Disable"
 msgstr "Letiltás"

--- a/po/id.po
+++ b/po/id.po
@@ -2901,8 +2901,8 @@ msgid "Directory browser"
 msgstr "Perambah direktori"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Direktori berisi %s dan %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Direktori berisi %(file)s dan %(subdir)s."
 
 msgid "Disable"
 msgstr "Matikan"

--- a/po/is.po
+++ b/po/is.po
@@ -3075,7 +3075,7 @@ msgstr "Möppu vafri"
 
 #
 #, fuzzy, python-format
-msgid "Directory contains %s and %s."
+msgid "Directory contains %(file)s and %(subdir)s."
 msgstr "Mappa %s ekki til."
 
 #

--- a/po/it.po
+++ b/po/it.po
@@ -2829,8 +2829,8 @@ msgid "Directory browser"
 msgstr "Sfogliare le  cartelle"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "La cartella contiene %s e %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "La cartella contiene %(file)s e %(subdir)s."
 
 msgid "Disable"
 msgstr "Disabilitare"

--- a/po/ku.po
+++ b/po/ku.po
@@ -2856,9 +2856,9 @@ msgstr "Directory %s does not exist."
 msgid "Directory browser"
 msgstr "Directory browser"
 
-#, fuzzy, python-format
-msgid "Directory contains %s and %s."
-msgstr "Directory contains %d file(s) and %d sub-directories.\n"
+#, python-format
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Directory contains %(file)s and %(subdir)s."
 
 msgid "Disable"
 msgstr "Disable"

--- a/po/lt.po
+++ b/po/lt.po
@@ -2831,8 +2831,8 @@ msgid "Directory browser"
 msgstr "Katalogų naršyklė"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Kataloge yra %s ir %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Kataloge yra %(file)s ir %(subdir)s."
 
 msgid "Disable"
 msgstr "Išjungti"

--- a/po/lv.po
+++ b/po/lv.po
@@ -2834,8 +2834,8 @@ msgid "Directory browser"
 msgstr "Mapju pārlūks"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Mape satur %s un %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Mape satur %(file)s un %(subdir)s."
 
 msgid "Disable"
 msgstr "Izslēgt"

--- a/po/mk.po
+++ b/po/mk.po
@@ -2820,8 +2820,8 @@ msgid "Directory browser"
 msgstr "Прелистувач на директориуми"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Директориумот содржи% s и% s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Директориумот содржи %(file)s и %(subdir)s."
 
 msgid "Disable"
 msgstr "Оневозможи"

--- a/po/nb.po
+++ b/po/nb.po
@@ -3106,8 +3106,8 @@ msgid "Directory browser"
 msgstr "Filutforsker"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Mappen inneholder %s og %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Mappen inneholder %(file)s og %(subdir)s."
 
 #
 msgid "Disable"

--- a/po/nl.po
+++ b/po/nl.po
@@ -2994,8 +2994,8 @@ msgid "Directory browser"
 msgstr "Bestandsverkenner"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Directory bevat %s en %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Directory bevat %(file)s en %(subdir)s."
 
 msgid "Disable"
 msgstr "Uit"

--- a/po/nn.po
+++ b/po/nn.po
@@ -3096,8 +3096,8 @@ msgid "Directory browser"
 msgstr "Søk i kataloger"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Katalogen inneholder %s og %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Katalogen inneholder %(file)s og %(subdir)s."
 
 #
 msgid "Disable"

--- a/po/pl.po
+++ b/po/pl.po
@@ -2831,8 +2831,8 @@ msgid "Directory browser"
 msgstr "Przeglądarka katalogów"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Katalog zawiera %s i %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Katalog zawiera %(file)s i %(subdir)s."
 
 msgid "Disable"
 msgstr "Wyłącz"

--- a/po/pt.po
+++ b/po/pt.po
@@ -3235,9 +3235,9 @@ msgstr "O directório %s não existe."
 msgid "Directory browser"
 msgstr "Explorador de directórios"
 
-#, fuzzy, python-format
-msgid "Directory contains %s and %s."
-msgstr "O directório contém %s e %s."
+#, python-format
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "O directório contém %(file)s e %(subdir)s."
 
 #
 msgid "Disable"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -2847,8 +2847,8 @@ msgid "Directory browser"
 msgstr "Navegador de arquivos"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "O diretório contém %s e %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "O diretório contém %(file)s e %(subdir)s."
 
 msgid "Disable"
 msgstr "Desativar"

--- a/po/ro.po
+++ b/po/ro.po
@@ -2892,7 +2892,7 @@ msgid "Directory browser"
 msgstr ""
 
 #, fuzzy, python-format
-msgid "Directory contains %s and %s."
+msgid "Directory contains %(file)s and %(subdir)s."
 msgstr "Directorul %s nu exista."
 
 msgid "Disable"

--- a/po/ru.po
+++ b/po/ru.po
@@ -2829,8 +2829,8 @@ msgid "Directory browser"
 msgstr "Директория браузера"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr " Директория содержит %s и %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr " Директория содержит %(file)s и %(subdir)s."
 
 msgid "Disable"
 msgstr "Отключить"

--- a/po/sk.po
+++ b/po/sk.po
@@ -2830,8 +2830,8 @@ msgid "Directory browser"
 msgstr "Prehliadač adresárov"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Adresár obsahuje %s a %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Adresár obsahuje %(file)s a %(subdir)s."
 
 msgid "Disable"
 msgstr "Zakázať"

--- a/po/sl.po
+++ b/po/sl.po
@@ -3259,8 +3259,8 @@ msgid "Directory browser"
 msgstr "Raziskovalec"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Mapa vsebuje %s datotek in %s pod-map."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Mapa vsebuje %(file)s in (subdir)%s."
 
 #
 msgid "Disable"

--- a/po/sr.po
+++ b/po/sr.po
@@ -3272,7 +3272,7 @@ msgstr "Pretraživač direktorijuma"
 
 #
 #, fuzzy, python-format
-msgid "Directory contains %s and %s."
+msgid "Directory contains %(file)s and %(subdir)s."
 msgstr "Direktorijum %s ne postoji"
 
 #

--- a/po/sv.po
+++ b/po/sv.po
@@ -3188,8 +3188,8 @@ msgid "Directory browser"
 msgstr "Biblioteksbläddrare"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Katalogen innehåller %s och %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Katalogen innehåller %(file)s och %(subdir)s."
 
 #
 msgid "Disable"

--- a/po/th.po
+++ b/po/th.po
@@ -2908,7 +2908,7 @@ msgid "Directory browser"
 msgstr "ดูโฟล์เดอร์"
 
 #, fuzzy, python-format
-msgid "Directory contains %s and %s."
+msgid "Directory contains %(file)s and %(subdir)s."
 msgstr "ไม่พบโฟล์เดอร์ %s ในระบบ"
 
 msgid "Disable"

--- a/po/tr.po
+++ b/po/tr.po
@@ -2861,8 +2861,8 @@ msgid "Directory browser"
 msgstr "Klasör gezgini"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr " %s ve %s dizin içermektedir."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "%(file)s ve %(subdir)s dizin içermektedir."
 
 msgid "Disable"
 msgstr "Pasif"

--- a/po/uk.po
+++ b/po/uk.po
@@ -2830,8 +2830,8 @@ msgid "Directory browser"
 msgstr "Провідник каталогів"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Директорія містить %s і %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Директорія містить %(file)s і %(subdir)s."
 
 msgid "Disable"
 msgstr "Вимкнуто"

--- a/po/vi.po
+++ b/po/vi.po
@@ -2802,8 +2802,8 @@ msgid "Directory browser"
 msgstr "Trình duyệt thư mục"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "Thư mục chứa%s và%s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "Thư mục chứa %(file)s và %(subdir)s."
 
 msgid "Disable"
 msgstr "Vô hiệu hóa"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -2820,8 +2820,8 @@ msgid "Directory browser"
 msgstr "目录浏览"
 
 #, python-format
-msgid "Directory contains %s and %s."
-msgstr "目录包含 %s 和 %s."
+msgid "Directory contains %(file)s and %(subdir)s."
+msgstr "目录包含 %(file)s 和 %(subdir)s."
 
 msgid "Disable"
 msgstr "禁用"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -2820,7 +2820,7 @@ msgid "Directory browser"
 msgstr "目錄流覽"
 
 #, python-format
-msgid "Directory contains %s and %s."
+msgid "Directory contains %(file)s and %(subdir)s."
 msgstr ""
 
 msgid "Disable"


### PR DESCRIPTION
This fixes the following warning:

```
'msgid' format string with unnamed arguments cannot be properly localized:
The translator cannot reorder the arguments.
Please consider using a format string with named arguments,
and a mapping instead of a tuple for the arguments.
```