### PR TITLE
[StartWizard] Reworked string

### DIFF
--- a/lib/python/Screens/StartWizard.py
+++ b/lib/python/Screens/StartWizard.py
@@ -130,7 +130,7 @@ class AutoInstallWizard(Screen):
 		except IOError:
 			pass
 		self.package = self.packages.pop(0)
-		self["header"].setText(_("%s%% Autoinstalling %s") % (self["progress"].value, self.package))
+		self["header"].setText(_("Autoinstalling %s") % self.package + " - %s%%" % self["progress"].value)
 		try:
 			if self.container.execute('opkg install "%s"' % self.package):
 				raise Exception, "failed to execute command!"

--- a/po/ar.po
+++ b/po/ar.po
@@ -435,7 +435,7 @@ msgstr[4] "التحديثات المتوفرة."
 msgstr[5] "التحديثات المتوفرة."
 
 #, python-format
-msgid "%s%% Autoinstalling %s"
+msgid "Autoinstalling %s"
 msgstr ""
 
 #, fuzzy, python-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -381,8 +381,8 @@ msgstr[0] "%s актуализиран пакет е наличен"
 msgstr[1] "%s актуализирани пакети са налични"
 
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% Автоинсталиране %s"
+msgid "Autoinstalling %s"
+msgstr "Автоинсталиране %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/ca.po
+++ b/po/ca.po
@@ -404,8 +404,8 @@ msgstr[1] "paquets actualitzats% s disponible"
 
 #
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% Instalant %s"
+msgid "Autoinstalling %s"
+msgstr "Instalant %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/cs.po
+++ b/po/cs.po
@@ -415,8 +415,8 @@ msgstr[2] " %s dostupných aktualizací"
 
 #
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% - Automatická instalace - %s"
+msgid "Autoinstalling %s"
+msgstr "Automatická instalace - %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/da.po
+++ b/po/da.po
@@ -394,7 +394,7 @@ msgstr[1] "%s  opdateringer tilgængelige"
 
 #
 #, fuzzy, python-format
-msgid "%s%% Autoinstalling %s"
+msgid "Autoinstalling %s"
 msgstr "Installerer"
 
 #, python-format

--- a/po/de.po
+++ b/po/de.po
@@ -381,8 +381,8 @@ msgstr[0] "%s Aktualisierung verfügbar"
 msgstr[1] "%s Aktualisierungen verfügbar"
 
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% Automatische Installation %s"
+msgid "Autoinstalling %s"
+msgstr "Automatische Installation %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/el.po
+++ b/po/el.po
@@ -380,8 +380,8 @@ msgstr[0] "%s διαθέσιμο πακέτο ενημέρωσης"
 msgstr[1] "%s διαθέσιμα πακέτα ενημέρωσης"
 
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% Αυτόματη εγκατάσταση του %s"
+msgid "Autoinstalling %s"
+msgstr "Αυτόματη εγκατάσταση του %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/en.po
+++ b/po/en.po
@@ -370,7 +370,7 @@ msgstr[0] "%s updated package available"
 msgstr[1] "%s updated packages available"
 
 #, fuzzy, python-format
-msgid "%s%% Autoinstalling %s"
+msgid "Autoinstalling %s"
 msgstr "Installing"
 
 #, python-format

--- a/po/es.po
+++ b/po/es.po
@@ -402,8 +402,8 @@ msgstr[1] "%s actualizaciones disponibles."
 
 #
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "% s %% Autoinstalación% s"
+msgid "Autoinstalling %s"
+msgstr "Autoinstalación %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/et.po
+++ b/po/et.po
@@ -378,7 +378,7 @@ msgstr[0] " %s uuendatud pakett saadaval "
 msgstr[1] " %s uuendatud paketti saadaval "
 
 #, fuzzy, python-format
-msgid "%s%% Autoinstalling %s"
+msgid "Autoinstalling %s"
 msgstr "Paigaldamine"
 
 #, python-format

--- a/po/fa.po
+++ b/po/fa.po
@@ -361,7 +361,7 @@ msgid_plural "%s updated packages available"
 msgstr[0] "به روز رسانی های در دسترس"
 
 #, fuzzy, python-format
-msgid "%s%% Autoinstalling %s"
+msgid "Autoinstalling %s"
 msgstr "در حال نصب"
 
 #, python-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -395,8 +395,8 @@ msgstr[1] "%s päivitettyä ohjelmapakettia saatavilla"
 
 #
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% Asennetaan automaattisesti %s"
+msgid "Autoinstalling %s"
+msgstr "Asennetaan automaattisesti %s"
 
 #
 #, python-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -379,8 +379,8 @@ msgstr[0] "%s mise à jour disponible"
 msgstr[1] "%s mises à jour disponibles"
 
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% Autoinstallation %s"
+msgid "Autoinstalling %s"
+msgstr "Autoinstallation %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/fy.po
+++ b/po/fy.po
@@ -394,7 +394,7 @@ msgstr[1] ""
 
 #
 #, fuzzy, python-format
-msgid "%s%% Autoinstalling %s"
+msgid "Autoinstalling %s"
 msgstr "Oan it ynstallearjen"
 
 #, python-format

--- a/po/gl.po
+++ b/po/gl.po
@@ -403,8 +403,8 @@ msgstr[1] "%s actualizacións dispoñibles"
 
 #
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% Autoinstalando %s"
+msgid "Autoinstalling %s"
+msgstr "Autoinstalando %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/he.po
+++ b/po/he.po
@@ -387,7 +387,7 @@ msgstr[0] "עדכונים זמינים"
 msgstr[1] "עדכונים זמינים"
 
 #, fuzzy, python-format
-msgid "%s%% Autoinstalling %s"
+msgid "Autoinstalling %s"
 msgstr "מתקין"
 
 #, python-format

--- a/po/hr.po
+++ b/po/hr.po
@@ -393,8 +393,8 @@ msgstr[1] "%s dostupna paketa za ažuriranje"
 msgstr[2] "%s dostupnih paketa za ažuriranje"
 
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% Automatska instalacija %s"
+msgid "Autoinstalling %s"
+msgstr "Automatska instalacija %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/hu.po
+++ b/po/hu.po
@@ -380,8 +380,8 @@ msgstr[0] "%s frissítés elérhető"
 msgstr[1] "%s frissítés elérhető"
 
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% Automatikus telepítés %s"
+msgid "Autoinstalling %s"
+msgstr "Automatikus telepítés %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/id.po
+++ b/po/id.po
@@ -384,8 +384,8 @@ msgstr[0] "%s pembaruan paket tersedia"
 msgstr[1] "%s pembaruan paket-paket tersedia"
 
 #, fuzzy, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% pemasangan otomatis %s"
+msgid "Autoinstalling %s"
+msgstr "Pemasangan otomatis %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/is.po
+++ b/po/is.po
@@ -392,7 +392,7 @@ msgstr[1] " uppfærslur tiltækar."
 
 #
 #, fuzzy, python-format
-msgid "%s%% Autoinstalling %s"
+msgid "Autoinstalling %s"
 msgstr "Set inn"
 
 #, python-format

--- a/po/it.po
+++ b/po/it.po
@@ -388,8 +388,8 @@ msgstr[0] "Disponibile %s pacchetto aggiornato"
 msgstr[1] "Disponibili %s pacchetti aggiornati"
 
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% Autoinstalla %s"
+msgid "Autoinstalling %s"
+msgstr "Autoinstalla %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/ku.po
+++ b/po/ku.po
@@ -377,7 +377,7 @@ msgstr[0] "%s updated package available"
 msgstr[1] "%s updated packages available"
 
 #, fuzzy, python-format
-msgid "%s%% Autoinstalling %s"
+msgid "Autoinstalling %s"
 msgstr "Installing"
 
 #, python-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -392,8 +392,8 @@ msgstr[1] "galimas %s paketų atnaujinimas"
 msgstr[2] "galimas %s paketų atnaujinimas"
 
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% Automatinis diegimas %s"
+msgid "Autoinstalling %s"
+msgstr "Automatinis diegimas %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/lv.po
+++ b/po/lv.po
@@ -395,8 +395,8 @@ msgstr[1] "%s pakotņu atjauninājumi pieejami"
 msgstr[2] "%s pakotņu atjauninājumi pieejami"
 
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% Uzstāda %s"
+msgid "Autoinstalling %s"
+msgstr "Uzstāda %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/mk.po
+++ b/po/mk.po
@@ -381,8 +381,8 @@ msgstr[0] "%s достапен ажуриран пакет"
 msgstr[1] "%s достапни ажурирани пакети"
 
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% Автоматска инсталација %s"
+msgid "Autoinstalling %s"
+msgstr "Автоматска инсталација %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/nb.po
+++ b/po/nb.po
@@ -397,8 +397,8 @@ msgstr[1] "%s det finnes nye oppdateringer"
 
 #
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% autoinstallasjon %s"
+msgid "Autoinstalling %s"
+msgstr "Autoinstallasjon %s"
 
 #
 #, python-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -379,8 +379,8 @@ msgstr[0] "%s nieuw pakket beschikbaar"
 msgstr[1] "%s nieuwe pakketten beschikbaar"
 
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% (Auto)Installeert %s"
+msgid "Autoinstalling %s"
+msgstr "(Auto)Installeert %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/nn.po
+++ b/po/nn.po
@@ -381,7 +381,7 @@ msgstr[1] "%s oppdaterte programvarepakker er tilgjengelig"
 
 #
 #, fuzzy, python-format
-msgid "%s%% Autoinstalling %s"
+msgid "Autoinstalling %s"
 msgstr "Installerer"
 
 #

--- a/po/pl.po
+++ b/po/pl.po
@@ -392,8 +392,8 @@ msgstr[1] "%s zaktualizowane pakiety dostępne"
 msgstr[2] "%s zaktualizowanych pakietów dostępnych"
 
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% Automatyczna instalacja %s"
+msgid "Autoinstalling %s"
+msgstr "Automatyczna instalacja %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/pt.po
+++ b/po/pt.po
@@ -392,7 +392,7 @@ msgstr[1] "%s actualizações disponíveis."
 
 #
 #, fuzzy, python-format
-msgid "%s%% Autoinstalling %s"
+msgid "Autoinstalling %s"
 msgstr "A instalar"
 
 #, python-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -374,7 +374,7 @@ msgstr[0] "%s atualização disponível"
 msgstr[1] "%s atualizações disponíveis"
 
 #, fuzzy, python-format
-msgid "%s%% Autoinstalling %s"
+msgid "Autoinstalling %s"
 msgstr "Instalando..."
 
 #, python-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -371,7 +371,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, fuzzy, python-format
-msgid "%s%% Autoinstalling %s"
+msgid "Autoinstalling %s"
 msgstr "Instaleaza"
 
 #, python-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -391,8 +391,8 @@ msgstr[1] "%s обновленных пакета доступно"
 msgstr[2] "%s обновленных пакетов доступно"
 
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% Авто инсталляция %s"
+msgid "Autoinstalling %s"
+msgstr "Авто инсталляция %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/sk.po
+++ b/po/sk.po
@@ -392,8 +392,8 @@ msgstr[1] "%s aktualizované balíčky k dispozícii"
 msgstr[2] "%s aktualizovaných balíčkov k dispozícii"
 
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% Autoinštalácia %s"
+msgid "Autoinstalling %s"
+msgstr "Autoinštalácia %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/sl.po
+++ b/po/sl.po
@@ -420,7 +420,7 @@ msgstr[3] "%s nadgradenj na voljo."
 
 #
 #, fuzzy, python-format
-msgid "%s%% Autoinstalling %s"
+msgid "Autoinstalling %s"
 msgstr "Nameščam..."
 
 #

--- a/po/sr.po
+++ b/po/sr.po
@@ -408,7 +408,7 @@ msgstr[2] "ažuriranja dostupna."
 
 #
 #, fuzzy, python-format
-msgid "%s%% Autoinstalling %s"
+msgid "Autoinstalling %s"
 msgstr "Instaliram"
 
 #, python-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -389,7 +389,7 @@ msgstr[1] "%s uppdateringar tillgängliga."
 
 #
 #, fuzzy, python-format
-msgid "%s%% Autoinstalling %s"
+msgid "Autoinstalling %s"
 msgstr "Installerar"
 
 #, python-format

--- a/po/th.po
+++ b/po/th.po
@@ -375,7 +375,7 @@ msgstr[0] " มีรายการปรับปรุง"
 msgstr[1] " มีรายการปรับปรุง"
 
 #, fuzzy, python-format
-msgid "%s%% Autoinstalling %s"
+msgid "Autoinstalling %s"
 msgstr "กำลังติดตั้ง"
 
 #, python-format

--- a/po/tr.po
+++ b/po/tr.po
@@ -368,7 +368,7 @@ msgid_plural "%s updated packages available"
 msgstr[0] "%s güncellenebilir paket bulundu."
 
 #, fuzzy, python-format
-msgid "%s%% Autoinstalling %s"
+msgid "Autoinstalling %s"
 msgstr "Kuruluyor"
 
 #, python-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -391,8 +391,8 @@ msgstr[1] "%s оновлення пакетів доступно"
 msgstr[2] "%s оновлень пакетів доступно"
 
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% Автовстановлення %s"
+msgid "Autoinstalling %s"
+msgstr "Автовстановлення %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/vi.po
+++ b/po/vi.po
@@ -367,8 +367,8 @@ msgid_plural "%s updated packages available"
 msgstr[0] "%s gói cập nhật có sẵn"
 
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% Tự động cài đặt %s"
+msgid "Autoinstalling %s"
+msgstr "Tự động cài đặt %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -380,8 +380,8 @@ msgstr[0] "%s 个更新包可用"
 msgstr[1] "%s 个更新包可用"
 
 #, python-format
-msgid "%s%% Autoinstalling %s"
-msgstr "%s%% 自动安装 %s"
+msgid "Autoinstalling %s"
+msgstr "自动安装 %s"
 
 #, python-format
 msgid "%s%d min"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -368,7 +368,7 @@ msgstr[0] "%s pembaruan paket tersedia"
 msgstr[1] "%s pembaruan paket-paket tersedia"
 
 #, fuzzy, python-format
-msgid "%s%% Autoinstalling %s"
+msgid "Autoinstalling %s"
 msgstr "正在安裝"
 
 #, python-format


### PR DESCRIPTION
No need to offer the percentage (progress of installation, e.g. 50%) for translation... and this way the following warning is eliminated:

```
'msgid' format string with unnamed arguments cannot be properly localized:
The translator cannot reorder the arguments.
Please consider using a format string with named arguments,
and a mapping instead of a tuple for the arguments.
```