### PR TITLE
Code and translations cleanup

### DIFF
--- a/lib/python/Components/AVSwitch.py
+++ b/lib/python/Components/AVSwitch.py
@@ -68,31 +68,31 @@ class AVSwitch:
 def InitAVSwitch():
 	config.av = ConfigSubsection()
 	config.av.yuvenabled = ConfigBoolean(default=True)
-	colorformat_choices = {"cvbs": _("CVBS")}
+	colorformat_choices = {"cvbs": "CVBS"}
 
 	# when YUV, Scart or S-Video is not support by HW, don't let the user select it
 	if SystemInfo["HasYPbPr"]:
-		colorformat_choices["yuv"] = _("YPbPr")
+		colorformat_choices["yuv"] = "YPbPr"
 	if SystemInfo["HasScart"]:
-		colorformat_choices["rgb"] = _("RGB")
+		colorformat_choices["rgb"] = "RGB"
 	if SystemInfo["HasSVideo"]:
-		colorformat_choices["svideo"] = _("S-Video")
+		colorformat_choices["svideo"] = "S-Video"
 
 	config.av.colorformat = ConfigSelection(choices=colorformat_choices, default="cvbs")
 	config.av.aspectratio = ConfigSelection(choices={
 			"4_3_letterbox": _("4:3 Letterbox"),
 			"4_3_panscan": _("4:3 PanScan"),
-			"16_9": _("16:9"),
+			"16_9": "16:9",
 			"16_9_always": _("16:9 always"),
 			"16_10_letterbox": _("16:10 Letterbox"),
 			"16_10_panscan": _("16:10 PanScan"),
 			"16_9_letterbox": _("16:9 Letterbox")},
 			default="16_9")
 	config.av.aspect = ConfigSelection(choices={
-			"4_3": _("4:3"),
-			"16_9": _("16:9"),
-			"16_10": _("16:10"),
-			"auto": _("Automatic")},
+			"4_3": "4:3",
+			"16_9": "16:9",
+			"16_10": "16:10",
+			"auto": _("automatic")},
 			default="auto")
 	policy2_choices = {
 	# TRANSLATORS: (aspect ratio policy: black bars on top/bottom) in doubt, keep english term.
@@ -140,7 +140,7 @@ def InitAVSwitch():
 	except:
 		pass
 	config.av.policy_43 = ConfigSelection(choices=policy_choices, default="pillarbox")
-	config.av.tvsystem = ConfigSelection(choices={"pal": _("PAL"), "ntsc": _("NTSC"), "multinorm": _("multinorm")}, default="pal")
+	config.av.tvsystem = ConfigSelection(choices={"pal": "PAL", "ntsc": "NTSC", "multinorm": "multinorm"}, default="pal")
 	config.av.wss = ConfigEnableDisable(default=True)
 	config.av.generalAC3delay = ConfigSelectionNumber(-1000, 1000, 5, default=0)
 	config.av.generalPCMdelay = ConfigSelectionNumber(-1000, 1000, 5, default=0)
@@ -225,7 +225,7 @@ def InitAVSwitch():
 	if SystemInfo["HasAutoVolume"]:
 		def setAutoVolume(configElement):
 			open(SystemInfo["HasAutoVolume"], "w").write(configElement.value)
-		config.av.autovolume = ConfigSelection(default="none", choices=[("none", _("off")), ("hdmi", _("HDMI")), ("spdif", _("SPDIF")), ("dac", _("DAC"))])
+		config.av.autovolume = ConfigSelection(default="none", choices=[("none", _("off")), ("hdmi", "HDMI"), ("spdif", "SPDIF"), ("dac", "DAC")])
 		config.av.autovolume.addNotifier(setAutoVolume)
 
 	if SystemInfo["HasAutoVolumeLevel"]:
@@ -237,7 +237,7 @@ def InitAVSwitch():
 	if SystemInfo["Has3DSurround"]:
 		def set3DSurround(configElement):
 			open(SystemInfo["Has3DSurround"], "w").write(configElement.value)
-		config.av.surround_3d = ConfigSelection(default="none", choices=[("none", _("off")), ("hdmi", _("HDMI")), ("spdif", _("SPDIF")), ("dac", _("DAC"))])
+		config.av.surround_3d = ConfigSelection(default="none", choices=[("none", _("off")), ("hdmi", "HDMI"), ("spdif", "SPDIF"), ("dac", "DAC")])
 		config.av.surround_3d.addNotifier(set3DSurround)
 
 	if SystemInfo["Has3DSpeaker"]:
@@ -261,7 +261,7 @@ def InitAVSwitch():
 	if SystemInfo["HDMIAudioSource"]:
 		def setHDMIAudioSource(configElement):
 			open(SystemInfo["HDMIAudioSource"], "w").write(configElement.value)
-		config.av.hdmi_audio_source = ConfigSelection(default="pcm", choices=[("pcm", _("PCM")), ("spdif", _("SPDIF"))])
+		config.av.hdmi_audio_source = ConfigSelection(default="pcm", choices=[("pcm", "PCM"), ("spdif", "SPDIF")])
 		config.av.hdmi_audio_source.addNotifier(setHDMIAudioSource)
 
 	def setVolumeStepsize(configElement):

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -545,15 +545,15 @@ def InitUsageConfig():
 		def setHaveColorspace(configElement):
 			open(SystemInfo["HasColorspace"], "w").write(configElement.value)
 		if SystemInfo["HasColorspaceSimple"]:
-			config.av.hdmicolorspace = ConfigSelection(default="Edid(Auto)", choices={"Edid(Auto)": _("Auto"), "Hdmi_Rgb": _("RGB"), "444": _("YCbCr444"), "422": _("YCbCr422"), "420": _("YCbCr420")})
+			config.av.hdmicolorspace = ConfigSelection(default="Edid(Auto)", choices={"Edid(Auto)": _("auto"), "Hdmi_Rgb": "RGB", "444": "YCbCr 4:4:4", "422": "YCbCr 4:2:2", "420": "YCbCr 4:2:0"})
 		else:
-			config.av.hdmicolorspace = ConfigSelection(default="auto", choices={"auto": _("auto"), "rgb": _("rgb"), "420": _("420"), "422": _("422"), "444": _("444")})
+			config.av.hdmicolorspace = ConfigSelection(default="auto", choices={"auto": _("auto"), "rgb": "RGB", "420": "4:2:0", "422": "4:2:2", "444": "4:4:4"})
 		config.av.hdmicolorspace.addNotifier(setHaveColorspace)
 
 	if SystemInfo["HasColordepth"]:
 		def setHaveColordepth(configElement):
 			open(SystemInfo["HasColordepth"], "w").write(configElement.value)
-		config.av.hdmicolordepth = ConfigSelection(default="auto", choices={"auto": _("Auto"), "8bit": _("8bit"), "10bit": _("10bit"), "12bit": _("12bit")})
+		config.av.hdmicolordepth = ConfigSelection(default="auto", choices={"auto": _("auto"), "8bit": "8bit", "10bit": "10bit", "12bit": "12bit"})
 		config.av.hdmicolordepth.addNotifier(setHaveColordepth)
 
 	if SystemInfo["HasHDMIpreemphasis"]:
@@ -565,13 +565,13 @@ def InitUsageConfig():
 	if SystemInfo["HasColorimetry"]:
 		def setColorimetry(configElement):
 			open(SystemInfo["HasColorimetry"], "w").write(configElement.value)
-		config.av.hdmicolorimetry = ConfigSelection(default="auto", choices=[("auto", _("Auto")), ("bt2020ncl", _("BT 2020 NCL")), ("bt2020cl", _("BT 2020 CL")), ("bt709", _("BT 709"))])
+		config.av.hdmicolorimetry = ConfigSelection(default="auto", choices=[("auto", _("auto")), ("bt2020ncl", "BT 2020 NCL"), ("bt2020cl", "BT 2020 CL"), ("bt709", "BT 709")])
 		config.av.hdmicolorimetry.addNotifier(setColorimetry)
 
 	if SystemInfo["HasHdrType"]:
 		def setHdmiHdrType(configElement):
 			open(SystemInfo["HasHdrType"], "w").write(configElement.value)
-		config.av.hdmihdrtype = ConfigSelection(default="auto", choices={"auto": _("Auto"), "none": _("SDR"), "hdr10": _("HDR10"), "hlg": _("HLG"), "dolby": _("Dolby")})
+		config.av.hdmihdrtype = ConfigSelection(default="auto", choices={"auto": _("auto"), "none": "SDR", "hdr10": "HDR10", "hlg": "HLG", "dolby": "Dolby Vision"})
 		config.av.hdmihdrtype.addNotifier(setHdmiHdrType)
 
 	if SystemInfo["HDRSupport"]:

--- a/lib/python/Plugins/Extensions/DVDBurn/DVDTitle.py
+++ b/lib/python/Plugins/Extensions/DVDBurn/DVDTitle.py
@@ -15,7 +15,7 @@ class DVDTitle:
 		self.properties = ConfigSubsection()
 		self.properties.menutitle = ConfigText(fixed_size=False, visible_width=80)
 		self.properties.menusubtitle = ConfigText(fixed_size=False, visible_width=80)
-		self.properties.aspect = ConfigSelection(choices=[("4:3", _("4:3")), ("16:9", _("16:9"))])
+		self.properties.aspect = ConfigSelection(choices=[("4:3", "4:3"), ("16:9", "16:9")])
 		self.properties.widescreen = ConfigSelection(choices=[("nopanscan", "nopanscan"), ("noletterbox", "noletterbox")])
 		self.properties.autochapter = ConfigInteger(default=0, limits=(0, 60))
 		self.properties.audiotracks = ConfigSubList()

--- a/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
@@ -217,7 +217,7 @@ class UpdatePluginMenu(Screen):
 	def getUpdateInfos(self):
 		if iSoftwareTools.NetworkConnectionAvailable is True:
 			if iSoftwareTools.available_updates is not 0:
-				self.text = _("There are at least %s updates available.") % (str(iSoftwareTools.available_updates))
+				self.text = _("There are at least %d updates available.") % iSoftwareTools.available_updates
 			else:
 				self.text = "" #_("There are no updates available.")
 			if iSoftwareTools.list_updating is True:
@@ -648,7 +648,7 @@ class PluginManager(Screen, PackageInfoHandler):
 		if retval is not None:
 			if retval is True:
 				if iSoftwareTools.available_updates is not 0:
-					self["status"].setText(_("There are at least ") + str(iSoftwareTools.available_updates) + _(" updates available."))
+					self["status"].setText(_("There are at least %d updates available.") % iSoftwareTools.available_updates)
 				else:
 					self["status"].setText(_("There are no updates available."))
 				self.rebuildList()
@@ -656,7 +656,7 @@ class PluginManager(Screen, PackageInfoHandler):
 				if iSoftwareTools.lastDownloadDate is None:
 					self.setState('error')
 					if iSoftwareTools.NetworkConnectionAvailable:
-						self["status"].setText(_("Updatefeed not available."))
+						self["status"].setText(_("Update feed not available."))
 					else:
 						self["status"].setText(_("No network connection available."))
 				else:

--- a/lib/python/Screens/Hotkey.py
+++ b/lib/python/Screens/Hotkey.py
@@ -166,7 +166,7 @@ def getHotkeyFunctions():
 	hotkey.functions.append((_("Switch to radio mode"), "Infobar/showRadio", "InfoBar"))
 	hotkey.functions.append((_("Switch to TV mode"), "Infobar/showTv", "InfoBar"))
 	hotkey.functions.append((_("Toggle TV/RADIO mode"), "Infobar/toggleTvRadio", "InfoBar"))
-	hotkey.functions.append((_("Instant record"), "Infobar/instantRecord", "InfoBar"))
+	hotkey.functions.append((_("Instant recording"), "Infobar/instantRecord", "InfoBar"))
 	hotkey.functions.append((_("Start instant recording"), "Infobar/startInstantRecording", "InfoBar"))
 	hotkey.functions.append((_("Activate timeshift End"), "Infobar/activateTimeshiftEnd", "InfoBar"))
 	hotkey.functions.append((_("Activate timeshift end and pause"), "Infobar/activateTimeshiftEndAndPause", "InfoBar"))

--- a/lib/python/Screens/InfoBar.py
+++ b/lib/python/Screens/InfoBar.py
@@ -540,7 +540,7 @@ class MoviePlayer(InfoBarBase, InfoBarShowHide, InfoBarMenu, InfoBarSeek, InfoBa
 
 	def displayPlayedName(self, ref, index, n):
 		from Tools import Notifications
-		Notifications.AddPopup(text=_("%s/%s: %s") % (index, n, self.ref2HumanName(ref)), type=MessageBox.TYPE_INFO, timeout=5)
+		Notifications.AddPopup(text="%s/%s: %s" % (index, n, self.ref2HumanName(ref)), type=MessageBox.TYPE_INFO, timeout=5)
 
 	def ref2HumanName(self, ref):
 		return enigma.eServiceCenter.getInstance().info(ref).getName(ref)

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -2469,7 +2469,7 @@ class InfoBarInstantRecord:
 	def __init__(self):
 		self["InstantRecordActions"] = HelpableActionMap(self, "InfobarInstantRecord",
 			{
-				"instantRecord": (self.instantRecord, _("Instant recording...")),
+				"instantRecord": (self.instantRecord, _("Instant recording")),
 			})
 		self.SelectedInstantServiceRef = None
 		if isStandardInfoBar(self):

--- a/lib/python/Screens/InputBox.py
+++ b/lib/python/Screens/InputBox.py
@@ -111,9 +111,7 @@ class PinInput(InputBox):
 		if self.getTries() == 0:
 			if (self.triesEntry.time.value + (self.waitTime * 60)) > time():
 				remaining = (self.triesEntry.time.value + (self.waitTime * 60)) - time()
-				remainingMinutes = int(remaining / 60)
-				remainingSeconds = int(remaining % 60)
-				messageText = _("You have to wait %s!") % (str(remainingMinutes) + " " + _("minutes") + ", " + str(remainingSeconds) + " " + _("seconds"))
+				messageText = _("You have to wait %(min)d minutes, %(sec)d seconds!") % {"min": int(remaining / 60), "sec": int(remaining % 60)}
 				if service and simple:
 					AddPopup(messageText, type=MessageBox.TYPE_ERROR, timeout=5)
 					self.closePinCancel()

--- a/lib/python/Screens/ServiceInfo.py
+++ b/lib/python/Screens/ServiceInfo.py
@@ -267,8 +267,8 @@ class ServiceInfo(Screen):
 					subList += [(_("TXT Subtitles page & lang"), "%s - %s" % (subNumber, subLang), TYPE_TEXT)]
 
 				elif x[0] == 2: # File
-					types = (_("unknown"), _("Embedded"), _("SSA File"), _("ASS File"),
-							_("SRT File"), _("VOB File"), _("PGS File"))
+					types = (_("unknown"), _("embedded"), _("SSA file"), _("ASS file"),
+							_("SRT file"), _("VOB file"), _("PGS file"))
 					try:
 						description = types[x[2]]
 					except:

--- a/lib/python/Screens/TimerEdit.py
+++ b/lib/python/Screens/TimerEdit.py
@@ -184,7 +184,7 @@ class TimerEditList(Screen):
 					else:
 						text = ext_description
 			if not cur.conflict_detection:
-				text = _("\nConflict detection disabled!") + "\n\n" + text
+				text = _("Conflict detection disabled!") + "\n\n" + text
 			self["description"].setText(text)
 			stateRunning = cur.state in (1, 2)
 			if cur.state == 2 and self.key_red_choice != self.STOP:

--- a/po/ar.po
+++ b/po/ar.po
@@ -4920,8 +4920,8 @@ msgstr "تسجيل سريع"
 msgid "Instant recording location"
 msgstr "مكان التسجيلات السريعة"
 
-msgid "Instant recording..."
-msgstr "جاري التسجيل السريع..."
+msgid "Instant recording"
+msgstr "جاري التسجيل السريع"
 
 msgid "Interface: "
 msgstr "واجهه: "

--- a/po/ar.po
+++ b/po/ar.po
@@ -9783,8 +9783,8 @@ msgid "There are at least "
 msgstr "يوجد على الأقل "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "هناك على الأقل %s تحديثات متاحة."
+msgid "There are at least %d updates available."
+msgstr "هناك على الأقل %d تحديثات متاحة."
 
 msgid "There are currently no outstanding actions."
 msgstr "لا يوجد حاليا أي إجراءات معلقة."
@@ -10577,7 +10577,7 @@ msgstr "فشل التحديث. الخاص بك %s %s لم يكون لها اتص
 msgid "Update has completed."
 msgstr "اكتمل النسخ الاحتياطي."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "تغذية التحديث غير متوفرة."
 
 #, fuzzy

--- a/po/ar.po
+++ b/po/ar.po
@@ -24,7 +24,6 @@ msgstr ""
 
 #, fuzzy
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr "تم الاتصال"
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -4577,8 +4577,8 @@ msgstr "Незабавен запис"
 msgid "Instant recording location"
 msgstr "Място за незабавен запис"
 
-msgid "Instant recording..."
-msgstr "Незабавен запис..."
+msgid "Instant recording"
+msgstr "Незабавен запис"
 
 msgid "Interface: "
 msgstr "Интерфейс: "

--- a/po/bg.po
+++ b/po/bg.po
@@ -21,10 +21,8 @@ msgstr ""
 "След натискане на ОК, моля изчакайте!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Откриването на конфликти е изключено!"
 
 msgid ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -9126,8 +9126,8 @@ msgid "There are at least "
 msgstr "Има най-малко "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Има %s достъпни актуализации."
+msgid "There are at least %d updates available."
+msgstr "Има %d достъпни актуализации."
 
 msgid "There are currently no outstanding actions."
 msgstr "В момента няма належащи действия."
@@ -9843,7 +9843,7 @@ msgstr "Неуспешна актуализация. Приемникът ням
 msgid "Update has completed."
 msgstr "Актуализацията завърши."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Няма наличен фийд за актуализации."
 
 msgid "Updating"

--- a/po/ca.po
+++ b/po/ca.po
@@ -10213,8 +10213,8 @@ msgid "There are at least "
 msgstr "N’hi ha almenys"
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Hi ha almenys% s actualitzacions disponibles."
+msgid "There are at least %d updates available."
+msgstr "Hi ha almenys %d actualitzacions disponibles."
 
 #
 msgid "There are currently no outstanding actions."
@@ -11017,7 +11017,7 @@ msgid "Update has completed."
 msgstr "S’ha finalitzat l’actualització."
 
 #
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Actualització no disponible."
 
 #

--- a/po/ca.po
+++ b/po/ca.po
@@ -5081,8 +5081,8 @@ msgid "Instant recording location"
 msgstr "Canviar la gravació (durada)"
 
 #
-msgid "Instant recording..."
-msgstr "Enregistrament instantani …"
+msgid "Instant recording"
+msgstr "Enregistrament instantani"
 
 #
 msgid "Interface: "

--- a/po/ca.po
+++ b/po/ca.po
@@ -26,10 +26,8 @@ msgstr ""
 "Després de prémer d'acord, si us plau esperi!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 " de conflictes desactivat!"
 
 #

--- a/po/cs.po
+++ b/po/cs.po
@@ -10507,8 +10507,8 @@ msgstr "Existuje nejméně "
 
 #
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "K dispozici je nejméně %s aktualizací."
+msgid "There are at least %d updates available."
+msgstr "K dispozici je nejméně %d aktualizací."
 
 #
 msgid "There are currently no outstanding actions."
@@ -11325,7 +11325,7 @@ msgid "Update has completed."
 msgstr "Aktualizace je dokončena."
 
 #
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Zdroj aktualizací není k dispozici."
 
 #

--- a/po/cs.po
+++ b/po/cs.po
@@ -23,10 +23,8 @@ msgstr ""
 "Po stisknutí OK čekejte, prosím!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Detekce konfliktů zakázána!"
 
 #

--- a/po/cs.po
+++ b/po/cs.po
@@ -5232,8 +5232,8 @@ msgid "Instant recording location"
 msgstr "Okamžité nahrávání"
 
 #
-msgid "Instant recording..."
-msgstr "Okamžité nahrávání..."
+msgid "Instant recording"
+msgstr "Okamžité nahrávání"
 
 #
 msgid "Interface: "

--- a/po/da.po
+++ b/po/da.po
@@ -5196,8 +5196,8 @@ msgid "Instant recording location"
 msgstr "Umiddelbar optagelses placering"
 
 #
-msgid "Instant recording..."
-msgstr "Hurtig optagelse..."
+msgid "Instant recording"
+msgstr "Hurtig optagelse"
 
 #
 msgid "Interface: "

--- a/po/da.po
+++ b/po/da.po
@@ -24,10 +24,8 @@ msgstr ""
 "Efter tryk på OK, vent venligst!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Konflikt detektion deaktiveret!"
 
 #

--- a/po/da.po
+++ b/po/da.po
@@ -10493,8 +10493,8 @@ msgstr "Der er mindst"
 
 #
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Der er mindst %s opdateringer tilgængelige."
+msgid "There are at least %d updates available."
+msgstr "Der er mindst %d opdateringer tilgængelige."
 
 #
 msgid "There are currently no outstanding actions."
@@ -11349,7 +11349,7 @@ msgid "Update has completed."
 msgstr "Opdatering er færdiggjort."
 
 #
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Opdateringsservice er ikke tilgengælig."
 
 #

--- a/po/de.po
+++ b/po/de.po
@@ -9140,8 +9140,8 @@ msgid "There are at least "
 msgstr "Es sind mindestens "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Es sind mindestens %s Aktualisierungen verfügbar."
+msgid "There are at least %d updates available."
+msgstr "Es sind mindestens %d Aktualisierungen verfügbar."
 
 msgid "There are currently no outstanding actions."
 msgstr "Es sind keine Aktivitäten geplant."
@@ -9865,7 +9865,7 @@ msgstr "Aktualisierung fehlgeschlagen. Ihr Receiver hat keine Verbindung zum Int
 msgid "Update has completed."
 msgstr "Aktualisierung abgeschlossen."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Update-Feed nicht verfügbar."
 
 msgid "Updating"

--- a/po/de.po
+++ b/po/de.po
@@ -22,10 +22,8 @@ msgstr ""
 "Nachdem Sie OK gedrückt haben, bitte warten!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Konflikterkennung deaktiviert!"
 
 msgid ""

--- a/po/de.po
+++ b/po/de.po
@@ -4577,8 +4577,8 @@ msgstr "Sofortaufnahme"
 msgid "Instant recording location"
 msgstr "Sofortaufnahme-Verzeichnis"
 
-msgid "Instant recording..."
-msgstr "Sofortaufnahme…"
+msgid "Instant recording"
+msgstr "Sofortaufnahme"
 
 msgid "Interface: "
 msgstr "Interface: "

--- a/po/el.po
+++ b/po/el.po
@@ -9112,8 +9112,8 @@ msgid "There are at least "
 msgstr "Υπάρχουν τουλάχιστον "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Υπάρχουν τουλάχιστον %s διαθέσιμες ενημερώσεις."
+msgid "There are at least %d updates available."
+msgstr "Υπάρχουν τουλάχιστον %d διαθέσιμες ενημερώσεις."
 
 msgid "There are currently no outstanding actions."
 msgstr "Δεν υπάρχουν ενέργειες σε εκκρεμότητα."
@@ -9834,7 +9834,7 @@ msgstr "Η ενημέρωση απέτυχε. Ο δέκτης σας δεν έχ
 msgid "Update has completed."
 msgstr "Η ενημέρωση έχει ολοκληρωθεί."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Η πηγή ενημερώσεων δεν είναι διαθέσιμη."
 
 msgid "Updating"

--- a/po/el.po
+++ b/po/el.po
@@ -22,10 +22,8 @@ msgstr ""
 "Αφού πιέσετε ΟΚ, παρακαλώ περιμένετε!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Η ανίχνευση διενέξεων είναι ανενεργή!"
 
 msgid ""

--- a/po/el.po
+++ b/po/el.po
@@ -4562,8 +4562,8 @@ msgstr "Άμεση εγγραφή"
 msgid "Instant recording location"
 msgstr "Τοποθεσία άμεσης εγγραφής"
 
-msgid "Instant recording..."
-msgstr "Άμεση εγγραφή..."
+msgid "Instant recording"
+msgstr "Άμεση εγγραφή"
 
 msgid "Interface: "
 msgstr "Διεπαφή: "

--- a/po/en.po
+++ b/po/en.po
@@ -21,7 +21,6 @@ msgstr ""
 "After pressing OK, please wait!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
 

--- a/po/en.po
+++ b/po/en.po
@@ -4627,8 +4627,8 @@ msgstr ""
 msgid "Instant recording location"
 msgstr "Instant recording location"
 
-msgid "Instant recording..."
-msgstr "Instant recording..."
+msgid "Instant recording"
+msgstr "Instant recording"
 
 msgid "Interface: "
 msgstr "Interface: "

--- a/po/en.po
+++ b/po/en.po
@@ -9274,8 +9274,8 @@ msgid "There are at least "
 msgstr "There are at least "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "There are at least %s updates available."
+msgid "There are at least %d updates available."
+msgstr "There are at least %d updates available."
 
 msgid "There are currently no outstanding actions."
 msgstr "There are currently no outstanding actions."
@@ -10011,8 +10011,8 @@ msgstr "Update failed. Your receiver does not have a working internet connection
 msgid "Update has completed."
 msgstr "Update has completed."
 
-msgid "Updatefeed not available."
-msgstr "Updatefeed not available."
+msgid "Update feed not available."
+msgstr "Update feed not available."
 
 msgid "Updating"
 msgstr "Updating"

--- a/po/es.po
+++ b/po/es.po
@@ -25,10 +25,8 @@ msgstr ""
 "Después de pulsar OK, espere!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Desactivada la deteccion de conflictos!"
 
 #

--- a/po/es.po
+++ b/po/es.po
@@ -5076,8 +5076,8 @@ msgid "Instant recording location"
 msgstr "Ubicación de grabación instantánea"
 
 #
-msgid "Instant recording..."
-msgstr "Grabación instantánea …"
+msgid "Instant recording"
+msgstr "Grabación instantánea"
 
 #
 msgid "Interface: "

--- a/po/es.po
+++ b/po/es.po
@@ -10201,8 +10201,8 @@ msgstr "Hay al menos"
 
 #
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Hay por lo menos% s actualizaciones disponibles."
+msgid "There are at least %d updates available."
+msgstr "Hay por lo menos %d actualizaciones disponibles."
 
 #
 msgid "There are currently no outstanding actions."
@@ -11005,8 +11005,8 @@ msgstr "Error en la actualización. Su receptor no tiene una conexión a Interne
 msgid "Update has completed."
 msgstr "Se ha completado la actualización."
 
-msgid "Updatefeed not available."
-msgstr "Updatefeed no disponible."
+msgid "Update feed not available."
+msgstr "Update feed no disponible."
 
 #
 msgid "Updating"

--- a/po/et.po
+++ b/po/et.po
@@ -9232,8 +9232,8 @@ msgid "There are at least "
 msgstr "Seal on vähemalt "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Saadaval on vähemalt %s uuendust."
+msgid "There are at least %d updates available."
+msgstr "Saadaval on vähemalt %d uuendust."
 
 msgid "There are currently no outstanding actions."
 msgstr "Praegu ei ole täitmata tegevusi."
@@ -9986,7 +9986,7 @@ msgstr "Uuendamine nurjus. Vastuvõtjal puudub töötav internetiühendus."
 msgid "Update has completed."
 msgstr "Uuendamine on lõppenud."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Uuenduslink pole saadaval."
 
 msgid "Updating"

--- a/po/et.po
+++ b/po/et.po
@@ -4612,8 +4612,8 @@ msgstr "Kohene salvestus"
 msgid "Instant recording location"
 msgstr "Kohese salvestuse asukoht"
 
-msgid "Instant recording..."
-msgstr "Kohene salvestamine..."
+msgid "Instant recording"
+msgstr "Kohene salvestamine"
 
 msgid "Interface: "
 msgstr "Liides: "

--- a/po/et.po
+++ b/po/et.po
@@ -22,10 +22,8 @@ msgstr ""
 "Vajuta OK ja oota!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Konflikti avastamine keelatud!"
 
 msgid ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -4700,7 +4700,7 @@ msgid "Instant recording location"
 msgstr "مکان ضبط کردن فوری"
 
 #, fuzzy
-msgid "Instant recording..."
+msgid "Instant recording"
 msgstr "مکان ضبط کردن فوری"
 
 msgid "Interface: "

--- a/po/fa.po
+++ b/po/fa.po
@@ -9454,7 +9454,7 @@ msgstr ""
 
 #
 #, fuzzy, python-format
-msgid "There are at least %s updates available."
+msgid "There are at least %d updates available."
 msgstr "به روز رسانی های در دسترس"
 
 msgid "There are currently no outstanding actions."
@@ -10157,7 +10157,7 @@ msgstr ""
 msgid "Update has completed."
 msgstr ""
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr ""
 
 msgid "Updating"

--- a/po/fa.po
+++ b/po/fa.po
@@ -24,7 +24,6 @@ msgstr ""
 "بعد از فشار دادن دکمه OK لطفا صبر کنید"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -24,7 +24,6 @@ msgstr ""
 "Kun olet painanut OK-näppäintä, odota!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -5072,8 +5072,8 @@ msgstr "Pikatallennus..."
 msgid "Instant recording location"
 msgstr "Pikatallennuksen hakemisto"
 
-msgid "Instant recording..."
-msgstr "Pikatallennus..."
+msgid "Instant recording"
+msgstr "Pikatallennus"
 
 msgid "Interface: "
 msgstr "Liittymä: "

--- a/po/fi.po
+++ b/po/fi.po
@@ -10304,8 +10304,8 @@ msgid "There are at least "
 msgstr "Saatavilla ainakin "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Vähintään %s päivitystä saatavilla."
+msgid "There are at least %d updates available."
+msgstr "Vähintään %d päivitystä saatavilla."
 
 msgid "There are currently no outstanding actions."
 msgstr "Ei suorittamattomia tehtäviä."
@@ -11111,7 +11111,7 @@ msgstr "Päivitys epäonnistui. Vastaanottimellasi ei ole toimivaa internet yhte
 msgid "Update has completed."
 msgstr "Päivitys on valmis."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Päivityslähde ei ole saatavilla."
 
 #

--- a/po/fr.po
+++ b/po/fr.po
@@ -4569,8 +4569,8 @@ msgstr "Enregistrement immédiat"
 msgid "Instant recording location"
 msgstr "Emplacement des enregistrements immédiats"
 
-msgid "Instant recording..."
-msgstr "Enregistrement Immédiat..."
+msgid "Instant recording"
+msgstr "Enregistrement Immédiat"
 
 msgid "Interface: "
 msgstr "Interface: "

--- a/po/fr.po
+++ b/po/fr.po
@@ -9126,8 +9126,8 @@ msgid "There are at least "
 msgstr "Il y a au moins "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Il y a au moins %s mises à jour disponibles."
+msgid "There are at least %d updates available."
+msgstr "Il y a au moins %d mises à jour disponibles."
 
 msgid "There are currently no outstanding actions."
 msgstr "Il n'y a actuellement aucune action marquante."
@@ -9852,7 +9852,7 @@ msgstr "La mise à jour a échoué. Votre récepteur ne dispose pas de connexion
 msgid "Update has completed."
 msgstr "La mise à jour est terminée."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "MAJ feed non disponible."
 
 msgid "Updating"

--- a/po/fr.po
+++ b/po/fr.po
@@ -21,10 +21,8 @@ msgstr ""
 "Après avoir appuyé sur OK, veuillez patienter!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "La détection des conflits est désactivée!"
 
 msgid ""

--- a/po/fy.po
+++ b/po/fy.po
@@ -10609,7 +10609,7 @@ msgid "There are at least "
 msgstr ""
 
 #, python-format
-msgid "There are at least %s updates available."
+msgid "There are at least %d updates available."
 msgstr ""
 
 #
@@ -11447,7 +11447,7 @@ msgid "Update has completed."
 msgstr ""
 
 #
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr ""
 
 #

--- a/po/fy.po
+++ b/po/fy.po
@@ -27,7 +27,6 @@ msgid ""
 msgstr ""
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
 

--- a/po/fy.po
+++ b/po/fy.po
@@ -5233,8 +5233,8 @@ msgstr "feroarje opnim tiiden"
 
 #
 #, fuzzy
-msgid "Instant recording..."
-msgstr "In direct opnimmen..."
+msgid "Instant recording"
+msgstr "In direct opnimmen"
 
 #
 msgid "Interface: "

--- a/po/gl.po
+++ b/po/gl.po
@@ -25,10 +25,8 @@ msgstr ""
 "Despois de pulsar OK, espera!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Desactivada a detección de conflitos!"
 
 #

--- a/po/gl.po
+++ b/po/gl.po
@@ -5087,8 +5087,8 @@ msgid "Instant recording location"
 msgstr "Localización da gravación instantánea"
 
 #
-msgid "Instant recording..."
-msgstr "Gravación instantánea…"
+msgid "Instant recording"
+msgstr "Gravación instantánea"
 
 #
 msgid "Interface: "

--- a/po/gl.po
+++ b/po/gl.po
@@ -10211,8 +10211,8 @@ msgstr "Hai polo menos "
 
 #
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Hai polo menos %s actualizacións dispoñibles."
+msgid "There are at least %d updates available."
+msgstr "Hai polo menos %d actualizacións dispoñibles."
 
 #
 msgid "There are currently no outstanding actions."
@@ -11014,7 +11014,7 @@ msgstr "Fallou a actualización. O receptor non ten unha conexión a internet en
 msgid "Update has completed."
 msgstr "Completouse a instalación."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Fonte de actualizacións non dispoñible."
 
 #

--- a/po/he.po
+++ b/po/he.po
@@ -4918,8 +4918,8 @@ msgid "Instant recording location"
 msgstr "מיקום הקלטה מיידית"
 
 #, fuzzy
-msgid "Instant recording..."
-msgstr "...הקלטה מיידית"
+msgid "Instant recording"
+msgstr "הקלטה מיידית"
 
 msgid "Interface: "
 msgstr ":ממשק"

--- a/po/he.po
+++ b/po/he.po
@@ -29,7 +29,6 @@ msgstr ""
 "!אחרי לחיצה על אשר,נא המתן"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -9994,7 +9994,7 @@ msgid "There are at least "
 msgstr "There are at least "
 
 #, fuzzy, python-format
-msgid "There are at least %s updates available."
+msgid "There are at least %d updates available."
 msgstr ".אין עדכונים זמינים"
 
 #
@@ -10787,8 +10787,8 @@ msgid "Update has completed."
 msgstr ""
 
 #
-msgid "Updatefeed not available."
-msgstr "Updatefeed not available."
+msgid "Update feed not available."
+msgstr "Update feed not available."
 
 #
 msgid "Updating"

--- a/po/hr.po
+++ b/po/hr.po
@@ -4587,8 +4587,8 @@ msgstr "Trenutni zapis"
 msgid "Instant recording location"
 msgstr "Lokacija mjesta snimanja"
 
-msgid "Instant recording..."
-msgstr "Mjesto snimanja..."
+msgid "Instant recording"
+msgstr "Mjesto snimanja"
 
 msgid "Interface: "
 msgstr "Sučelje: "

--- a/po/hr.po
+++ b/po/hr.po
@@ -21,10 +21,8 @@ msgstr ""
 "Nakon pritiska na OK, molim pričekajte!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Otkrivanje sukoba je onemogućeno!"
 
 msgid ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -9140,8 +9140,8 @@ msgid "There are at least "
 msgstr "Postoje najmanje "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Dostupno je najmanje %s ažuriranja."
+msgid "There are at least %d updates available."
+msgstr "Dostupno je najmanje %d ažuriranja."
 
 msgid "There are currently no outstanding actions."
 msgstr "Trenutno nema otvorenih aktivnosti."
@@ -9863,7 +9863,7 @@ msgstr "Ažuriranje nije uspjelo. Vaš prijemnik nema aktivnu internetsku vezu."
 msgid "Update has completed."
 msgstr "Ažuriranje je dovršeno."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Ažuriranje feeda nije dostupno."
 
 msgid "Updating"

--- a/po/hu.po
+++ b/po/hu.po
@@ -21,10 +21,8 @@ msgstr ""
 "Az OK gomb lenyomása után kérem, várjon!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Az ütközések figyelése ki van kapcsolva!"
 
 msgid ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -4571,8 +4571,8 @@ msgstr "Azonnali felvétel"
 msgid "Instant recording location"
 msgstr "Azonnali felvételek helye"
 
-msgid "Instant recording..."
-msgstr "Felvétel azonnali indítása..."
+msgid "Instant recording"
+msgstr "Felvétel azonnali indítása"
 
 msgid "Interface: "
 msgstr "Interfész: "

--- a/po/hu.po
+++ b/po/hu.po
@@ -9131,8 +9131,8 @@ msgid "There are at least "
 msgstr "Legalább "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Legalább %s frissítés elérhető."
+msgid "There are at least %d updates available."
+msgstr "Legalább %d frissítés elérhető."
 
 msgid "There are currently no outstanding actions."
 msgstr "Semmilyen kiemelkedő esemény nem következik."
@@ -9854,7 +9854,7 @@ msgstr "A frissítés nem sikerült. A készüléknek nincs egy működőképes 
 msgid "Update has completed."
 msgstr "A frissítés elkészült."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Frissítő szerver nem elérhető."
 
 msgid "Updating"

--- a/po/id.po
+++ b/po/id.po
@@ -4725,8 +4725,8 @@ msgstr "Rekam segera"
 msgid "Instant recording location"
 msgstr "Lokasi perekaman segera"
 
-msgid "Instant recording..."
-msgstr "Perekaman segera..."
+msgid "Instant recording"
+msgstr "Perekaman segera"
 
 msgid "Interface: "
 msgstr "Antarmuka: "

--- a/po/id.po
+++ b/po/id.po
@@ -9413,8 +9413,8 @@ msgid "There are at least "
 msgstr "Setidaknya terdapat "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Setidaknya terdapat %s pembaruan tersedia."
+msgid "There are at least %d updates available."
+msgstr "Setidaknya terdapat %d pembaruan tersedia."
 
 msgid "There are currently no outstanding actions."
 msgstr "Saat ini tidak ada tindakan yg belum diselesaikan."
@@ -10163,7 +10163,7 @@ msgstr "Pembaruan gagal. Rx anda tanpa koneksi internet."
 msgid "Update has completed."
 msgstr "Pembaruan telah selesai."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Umpan pembaruan tidak tersedia."
 
 msgid "Updating"

--- a/po/id.po
+++ b/po/id.po
@@ -21,10 +21,8 @@ msgstr ""
 "Setelah tekan OK, silakan tunggu!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Deteksi konflik dimatikan!"
 
 msgid ""

--- a/po/is.po
+++ b/po/is.po
@@ -24,7 +24,6 @@ msgstr ""
 "Bíðið eftir að hafa ýtt á OK!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
 

--- a/po/is.po
+++ b/po/is.po
@@ -5060,8 +5060,8 @@ msgstr "Skyndi upptöku staðsetning"
 
 #
 #, fuzzy
-msgid "Instant recording..."
-msgstr "Skyndi upptaka..."
+msgid "Instant recording"
+msgstr "Skyndi upptaka"
 
 msgid "Interface: "
 msgstr "Netkort:"

--- a/po/is.po
+++ b/po/is.po
@@ -10438,7 +10438,7 @@ msgid "There are at least "
 msgstr "Það eru allavega "
 
 #, fuzzy, python-format
-msgid "There are at least %s updates available."
+msgid "There are at least %d updates available."
 msgstr "Það er engin uppfærsla tiltæk."
 
 msgid "There are currently no outstanding actions."
@@ -11259,7 +11259,7 @@ msgstr ""
 msgid "Update has completed."
 msgstr ""
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Uppfærslur á fæðirásum ekki tiltækar."
 
 #

--- a/po/it.po
+++ b/po/it.po
@@ -4601,8 +4601,8 @@ msgstr "Registrazione immediata"
 msgid "Instant recording location"
 msgstr "Percorso delle registrazioni immediate"
 
-msgid "Instant recording..."
-msgstr "Registrazione immediata..."
+msgid "Instant recording"
+msgstr "Registrazione immediata"
 
 msgid "Interface: "
 msgstr "Interfaccia: "

--- a/po/it.po
+++ b/po/it.po
@@ -28,10 +28,8 @@ msgstr ""
 "Dopo aver premuto OK, attendere!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "L'individuazione dei conflitti è disabilitata!"
 
 msgid ""

--- a/po/it.po
+++ b/po/it.po
@@ -9187,8 +9187,8 @@ msgid "There are at least "
 msgstr "Sono presenti almeno "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Sono presenti almeno %s aggiornamenti disponibili."
+msgid "There are at least %d updates available."
+msgstr "Sono presenti almeno %d aggiornamenti disponibili."
 
 msgid "There are currently no outstanding actions."
 msgstr "Nessuna azione in sospeso al momento."
@@ -9922,7 +9922,7 @@ msgstr "Aggiornamento non riuscito. Il ricevitore non è connesso ad Internet."
 msgid "Update has completed."
 msgstr "Aggiornamento completato."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Fonte degli aggiornamenti non disponibile."
 
 msgid "Updating"

--- a/po/ku.po
+++ b/po/ku.po
@@ -4633,8 +4633,8 @@ msgstr ""
 msgid "Instant recording location"
 msgstr "Instant recording location"
 
-msgid "Instant recording..."
-msgstr "Instant recording..."
+msgid "Instant recording"
+msgstr "Instant recording"
 
 msgid "Interface: "
 msgstr "Interface: "

--- a/po/ku.po
+++ b/po/ku.po
@@ -28,7 +28,6 @@ msgstr ""
 "Pay Ok bine bisekin!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
 

--- a/po/ku.po
+++ b/po/ku.po
@@ -9275,8 +9275,8 @@ msgid "There are at least "
 msgstr "There are at least "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "There are at least %s updates available."
+msgid "There are at least %d updates available."
+msgstr "There are at least %d updates available."
 
 msgid "There are currently no outstanding actions."
 msgstr "There are currently no outstanding actions."
@@ -10013,8 +10013,8 @@ msgstr "Update failed. Your receiver does not have a working internet connection
 msgid "Update has completed."
 msgstr "Update has completed."
 
-msgid "Updatefeed not available."
-msgstr "Updatefeed not available."
+msgid "Update feed not available."
+msgstr "Update feed not available."
 
 msgid "Updating"
 msgstr "Updating"

--- a/po/lt.po
+++ b/po/lt.po
@@ -22,10 +22,8 @@ msgstr ""
 "Paspaudę OK, palaukite!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Konfliktų aptikimas išjungtas!"
 
 msgid ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -9140,8 +9140,8 @@ msgid "There are at least "
 msgstr "Bent jau yra "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Yra bent %s galimi atnaujinimai."
+msgid "There are at least %d updates available."
+msgstr "Yra bent %d galimi atnaujinimai."
 
 msgid "There are currently no outstanding actions."
 msgstr "Šiuo metu nėra jokių neįvykdytų veiksmų."
@@ -9863,7 +9863,7 @@ msgstr "Atnaujinimo klaida. Jūsų imtuvas neturi interneto ryšio."
 msgid "Update has completed."
 msgstr "Atnaujinimas baigtas."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Atnaujinimo šaltinis nepasiekiamas."
 
 msgid "Updating"

--- a/po/lt.po
+++ b/po/lt.po
@@ -4585,8 +4585,8 @@ msgstr "Momentinis įrašymas"
 msgid "Instant recording location"
 msgstr "Momentinio įrašymo vieta"
 
-msgid "Instant recording..."
-msgstr "Momentinis įrašymas..."
+msgid "Instant recording"
+msgstr "Momentinis įrašymas"
 
 msgid "Interface: "
 msgstr "Sąsaja: "

--- a/po/lv.po
+++ b/po/lv.po
@@ -9142,8 +9142,8 @@ msgid "There are at least "
 msgstr "Vismaz "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Vismaz %s atjauninājumi pieejami."
+msgid "There are at least %d updates available."
+msgstr "Vismaz %d atjauninājumi pieejami."
 
 msgid "There are currently no outstanding actions."
 msgstr "Pašlaik nav aktuālu darbību."
@@ -9865,7 +9865,7 @@ msgstr "Atjaunināšana pārtraukta. Uztvērējam nestrādā interneta savienoju
 msgid "Update has completed."
 msgstr "Atjaunināšana pabeigta."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Barotnes nav pieejamas."
 
 msgid "Updating"

--- a/po/lv.po
+++ b/po/lv.po
@@ -23,10 +23,8 @@ msgstr ""
 "Pēc OK nospiešanas uzgaidiet!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Konfliktu noteikšana izslēgta!"
 
 msgid ""

--- a/po/lv.po
+++ b/po/lv.po
@@ -4590,8 +4590,8 @@ msgstr "Ieraksts"
 msgid "Instant recording location"
 msgstr "Ieraksta vieta"
 
-msgid "Instant recording..."
-msgstr "Ieraksts..."
+msgid "Instant recording"
+msgstr "Ieraksts"
 
 msgid "Interface: "
 msgstr "Interfeiss: "

--- a/po/mk.po
+++ b/po/mk.po
@@ -21,10 +21,8 @@ msgstr ""
 "Откако ќе притиснете ОК, почекајте!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Откривањето на конфликти е деактивирано!"
 
 msgid ""

--- a/po/mk.po
+++ b/po/mk.po
@@ -4576,8 +4576,8 @@ msgstr "Инстант снимки"
 msgid "Instant recording location"
 msgstr "Локација за инстант снимки"
 
-msgid "Instant recording..."
-msgstr "Инстант снимање ..."
+msgid "Instant recording"
+msgstr "Инстант снимање"
 
 msgid "Interface: "
 msgstr "Интерфејс: "

--- a/po/mk.po
+++ b/po/mk.po
@@ -9118,8 +9118,8 @@ msgid "There are at least "
 msgstr "Има најмалку "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Има најмалку %s достапни ажурирања."
+msgid "There are at least %d updates available."
+msgstr "Има најмалку %d достапни ажурирања."
 
 msgid "There are currently no outstanding actions."
 msgstr "Не се планираат активности."
@@ -9840,7 +9840,7 @@ msgstr "Ажурирањето не успеа. Вашиот приемник н
 msgid "Update has completed."
 msgstr "Ажурирањето е завршено."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Ажурирање не е достапно."
 
 msgid "Updating"

--- a/po/nb.po
+++ b/po/nb.po
@@ -26,10 +26,8 @@ msgstr ""
 "Etter å ha trykket OK, vennligst vent!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Konflikt deteksjon frakoblet!"
 
 #

--- a/po/nb.po
+++ b/po/nb.po
@@ -10161,8 +10161,8 @@ msgid "There are at least "
 msgstr "Det er minst "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Det er minst %s oppdateringer tilgjengelig."
+msgid "There are at least %d updates available."
+msgstr "Det er minst %d oppdateringer tilgjengelig."
 
 #
 msgid "There are currently no outstanding actions."
@@ -10968,7 +10968,7 @@ msgstr "Oppdateringen mislyktes. Internett forbindelsen til mottakeren fungerer 
 msgid "Update has completed."
 msgstr "Oppdateringen er ferdig."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Oppdateringssted er ikke tilgjengelig."
 
 msgid "Updating"

--- a/po/nb.po
+++ b/po/nb.po
@@ -5068,8 +5068,8 @@ msgid "Instant recording location"
 msgstr "Mappe for direkteopptak"
 
 #
-msgid "Instant recording..."
-msgstr "Direkteopptak..."
+msgid "Instant recording"
+msgstr "Direkte opptak"
 
 #
 msgid "Interface: "

--- a/po/nl.po
+++ b/po/nl.po
@@ -4775,8 +4775,8 @@ msgstr "Directe opname"
 msgid "Instant recording location"
 msgstr "Opname-locatie directe opnames"
 
-msgid "Instant recording..."
-msgstr "Directe opname..."
+msgid "Instant recording"
+msgstr "Directe opname"
 
 msgid "Interface: "
 msgstr "Interface: "

--- a/po/nl.po
+++ b/po/nl.po
@@ -21,10 +21,8 @@ msgstr ""
 "Na indrukken van Ok, een moment geduld aub!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Detectie van conflicten is uitgeschakeld!"
 
 msgid ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -9387,8 +9387,8 @@ msgid "There are at least "
 msgstr "Er zijn ten minste "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Er zijn minimaal %s updates beschikbaar."
+msgid "There are at least %d updates available."
+msgstr "Er zijn minimaal %d updates beschikbaar."
 
 msgid "There are currently no outstanding actions."
 msgstr "Er zijn geen uitstaande acties."
@@ -10121,8 +10121,8 @@ msgstr "Update mislukt. Uw ontvanger heeft geen actieve internetaansluiting."
 msgid "Update has completed."
 msgstr "De update is gereed."
 
-msgid "Updatefeed not available."
-msgstr "Updatefeed niet beschikbaar."
+msgid "Update feed not available."
+msgstr "Update feed niet beschikbaar."
 
 msgid "Updating"
 msgstr "Bezig met update"

--- a/po/nn.po
+++ b/po/nn.po
@@ -5043,8 +5043,8 @@ msgid "Instant recording location"
 msgstr "Plassering for direkteopptak"
 
 #
-msgid "Instant recording..."
-msgstr "Direkte opptak..."
+msgid "Instant recording"
+msgstr "Direkte opptak"
 
 #
 msgid "Interface: "

--- a/po/nn.po
+++ b/po/nn.po
@@ -26,7 +26,6 @@ msgstr ""
 "Etter å ha trykket OK, vennligst vent!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
 

--- a/po/nn.po
+++ b/po/nn.po
@@ -10114,8 +10114,8 @@ msgid "There are at least "
 msgstr "Det finnes minst"
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Det er minst %s oppdateringer tilgjengelig."
+msgid "There are at least %d updates available."
+msgstr "Det er minst %d oppdateringer tilgjengelig."
 
 #
 msgid "There are currently no outstanding actions."
@@ -10929,7 +10929,7 @@ msgstr "Oppdateringen mislyktes. Mottakeren mangler internettforbindelse."
 msgid "Update has completed."
 msgstr "Oppdateringen er ferdig."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Oppdateringsstedet er ikke tilgjengelig."
 
 #

--- a/po/pl.po
+++ b/po/pl.po
@@ -9145,8 +9145,8 @@ msgid "There are at least "
 msgstr "Jest co najmniej"
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Dostępnych co najmniej  %s aktualizacji."
+msgid "There are at least %d updates available."
+msgstr "Dostępnych co najmniej %d aktualizacji."
 
 msgid "There are currently no outstanding actions."
 msgstr "Obecnie nie ma zaległych działań."
@@ -9868,7 +9868,7 @@ msgstr "Aktualizacja nie powiodła się. Brak działającego połączenia intern
 msgid "Update has completed."
 msgstr "Aktualizacja zakończona."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Aktualizacje nie dostępne."
 
 msgid "Updating"

--- a/po/pl.po
+++ b/po/pl.po
@@ -21,10 +21,8 @@ msgstr ""
 "Po naciśnięciu OK czekaj!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Wykrywanie konfliktów wyłączone!"
 
 msgid ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -4586,8 +4586,8 @@ msgstr "Natychmiastowe nagranie - menu"
 msgid "Instant recording location"
 msgstr "Lokalizacja 'natychmiastowego' nagrania"
 
-msgid "Instant recording..."
-msgstr "Natychmiastowe nagranie..."
+msgid "Instant recording"
+msgstr "Natychmiastowe nagranie"
 
 msgid "Interface: "
 msgstr "Interfejs: "

--- a/po/pt.po
+++ b/po/pt.po
@@ -10708,8 +10708,8 @@ msgstr "Existem pelo menos "
 
 #
 #, fuzzy, python-format
-msgid "There are at least %s updates available."
-msgstr "Existem pelo menos %s actualizações disponíveis."
+msgid "There are at least %d updates available."
+msgstr "Existem pelo menos %d actualizações disponíveis."
 
 #
 msgid "There are currently no outstanding actions."
@@ -11552,7 +11552,7 @@ msgid "Update has completed."
 msgstr "A actualização foi concluída."
 
 #
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Servidor de actualizações não disponível"
 
 #

--- a/po/pt.po
+++ b/po/pt.po
@@ -5256,8 +5256,8 @@ msgstr "Localização das gravações instantâneas"
 
 #
 #, fuzzy
-msgid "Instant recording..."
-msgstr "Gravação instantânea..."
+msgid "Instant recording"
+msgstr "Gravação instantânea"
 
 msgid "Interface: "
 msgstr "Interface: "

--- a/po/pt.po
+++ b/po/pt.po
@@ -24,7 +24,6 @@ msgstr ""
 "Depois de pressionar OK, aguarde por favor!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -25,7 +25,6 @@ msgstr ""
 "Após pressionar OK, aguarde..."
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -9263,8 +9263,8 @@ msgid "There are at least "
 msgstr "Existem ao menos"
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Existem ao menos %s atualizações disponíveis."
+msgid "There are at least %d updates available."
+msgstr "Existem ao menos %d atualizações disponíveis."
 
 msgid "There are currently no outstanding actions."
 msgstr "Atualmente não existem ações pendentes."
@@ -10001,7 +10001,7 @@ msgstr "Falha na atualização. O receptor não está conectado à internet."
 msgid "Update has completed."
 msgstr "Atualização concluída."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Servidor de atualizações não disponível."
 
 msgid "Updating"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -4622,7 +4622,7 @@ msgstr ""
 msgid "Instant recording location"
 msgstr "Diretório das gravações instantâneas"
 
-msgid "Instant recording..."
+msgid "Instant recording"
 msgstr "Gravação instantânea"
 
 msgid "Interface: "

--- a/po/ro.po
+++ b/po/ro.po
@@ -9454,7 +9454,7 @@ msgid "There are at least "
 msgstr ""
 
 #, python-format
-msgid "There are at least %s updates available."
+msgid "There are at least %d updates available."
 msgstr ""
 
 msgid "There are currently no outstanding actions."
@@ -10199,7 +10199,7 @@ msgstr ""
 msgid "Update has completed."
 msgstr ""
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr ""
 
 msgid "Updating"

--- a/po/ro.po
+++ b/po/ro.po
@@ -4697,7 +4697,7 @@ msgid "Instant recording location"
 msgstr "schimba inregistrare (durata)"
 
 #, fuzzy
-msgid "Instant recording..."
+msgid "Instant recording"
 msgstr "Inregistrare instant"
 
 msgid "Interface: "

--- a/po/ro.po
+++ b/po/ro.po
@@ -25,7 +25,6 @@ msgstr ""
 "Dupa apasarea OK, va rog asteptati!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -21,10 +21,8 @@ msgstr ""
 "После нажатия кнопки ОК, пожалуйста, подождите!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Обнаружение конфликтов отключено!"
 
 msgid ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -4585,8 +4585,8 @@ msgstr "Меню немедленной записи"
 msgid "Instant recording location"
 msgstr "Место немедленной записи"
 
-msgid "Instant recording..."
-msgstr "Немедленные записи..."
+msgid "Instant recording"
+msgstr "Немедленные записи"
 
 msgid "Interface: "
 msgstr "Интерфейс: "

--- a/po/ru.po
+++ b/po/ru.po
@@ -9137,8 +9137,8 @@ msgid "There are at least "
 msgstr "Найдено по крайней мере "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "%s доступных обновлений для вашего ресивера."
+msgid "There are at least %d updates available."
+msgstr "%d доступных обновлений для вашего ресивера."
 
 msgid "There are currently no outstanding actions."
 msgstr "В текущий момент нет выдающихся действий."
@@ -9860,7 +9860,7 @@ msgstr "Обновление не удалось. В Вашем ресивере
 msgid "Update has completed."
 msgstr "Обновление завершено."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Обновления с фида не доступны."
 
 msgid "Updating"

--- a/po/sk.po
+++ b/po/sk.po
@@ -4585,8 +4585,8 @@ msgstr "Okamžité nahrávanie"
 msgid "Instant recording location"
 msgstr "Umiestnenie okamžitej nahrávky"
 
-msgid "Instant recording..."
-msgstr "Okamžité nahrávanie..."
+msgid "Instant recording"
+msgstr "Okamžité nahrávanie"
 
 msgid "Interface: "
 msgstr "Rozhranie: "

--- a/po/sk.po
+++ b/po/sk.po
@@ -9140,8 +9140,8 @@ msgid "There are at least "
 msgstr "Existuje najmenej "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "K dispozícií je najmenej %s aktualizácií."
+msgid "There are at least %d updates available."
+msgstr "K dispozícií je najmenej %d aktualizácií."
 
 msgid "There are currently no outstanding actions."
 msgstr "Momentálne nie sú žiadne nevykonané akcie."
@@ -9863,7 +9863,7 @@ msgstr "Aktualizácia zlyhala. Váš prijímač nemá funkčné pripojenie k int
 msgid "Update has completed."
 msgstr "Aktualizácia bola dokončená."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Zdroj aktualizácií nie je k dispozícií."
 
 msgid "Updating"

--- a/po/sk.po
+++ b/po/sk.po
@@ -22,10 +22,8 @@ msgstr ""
 "Po stlačení tlačidla OK prosím čakajte!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Zisťovanie konfliktov zakázané!"
 
 msgid ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -22,7 +22,6 @@ msgstr ""
 "Po pritisku na OK, počakajte!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -5303,7 +5303,7 @@ msgid "Instant recording location"
 msgstr "Lokacija takojšnjega snemanja"
 
 #
-msgid "Instant recording..."
+msgid "Instant recording"
 msgstr "Takojšnje snemanje"
 
 #

--- a/po/sl.po
+++ b/po/sl.po
@@ -10688,8 +10688,8 @@ msgstr "Obstaja vsaj"
 
 #
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Na voljo je %s nadgradenj."
+msgid "There are at least %d updates available."
+msgstr "Na voljo je %d nadgradenj."
 
 #
 msgid "There are currently no outstanding actions."
@@ -11522,7 +11522,7 @@ msgid "Update has completed."
 msgstr "Posodobitev se je uspešno zaključila."
 
 #
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Server je trenutno nedosegljiv."
 
 #

--- a/po/sr.po
+++ b/po/sr.po
@@ -27,7 +27,6 @@ msgstr ""
 "Posle stiskanja OK,molim pričekajte"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -10758,7 +10758,7 @@ msgstr "Postoji najmanje"
 
 #
 #, fuzzy, python-format
-msgid "There are at least %s updates available."
+msgid "There are at least %d updates available."
 msgstr "Nema dostupnih ažuriranja."
 
 #
@@ -11597,7 +11597,7 @@ msgid "Update has completed."
 msgstr ""
 
 #
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Fid ažuriranja nije dostupan."
 
 #

--- a/po/sr.po
+++ b/po/sr.po
@@ -5304,8 +5304,8 @@ msgstr "Lokacija instant snimanja"
 
 #
 #, fuzzy
-msgid "Instant recording..."
-msgstr "Trenutno snimanje..."
+msgid "Instant recording"
+msgstr "Trenutno snimanje"
 
 #
 msgid "Interface: "

--- a/po/sv.po
+++ b/po/sv.po
@@ -10456,8 +10456,8 @@ msgstr "Det finns minst "
 
 #
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Det finns minst %s uppdateringar tillgängliga."
+msgid "There are at least %d updates available."
+msgstr "Det finns minst %d uppdateringar tillgängliga."
 
 #
 msgid "There are currently no outstanding actions."
@@ -11313,7 +11313,7 @@ msgid "Update has completed."
 msgstr "Uppdatering har slutförts."
 
 #
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Uppdateringsfeed ej tillgänglig."
 
 #

--- a/po/sv.po
+++ b/po/sv.po
@@ -5181,8 +5181,8 @@ msgid "Instant recording location"
 msgstr "Direktinspelningens plats"
 
 #
-msgid "Instant recording..."
-msgstr "Direktinspelning..."
+msgid "Instant recording"
+msgstr "Direktinspelning"
 
 #
 msgid "Interface: "

--- a/po/sv.po
+++ b/po/sv.po
@@ -24,10 +24,8 @@ msgstr ""
 "Efter att ha tryckt OK, var god vänta!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Konfliktdetektering avstängd!"
 
 #

--- a/po/th.po
+++ b/po/th.po
@@ -9498,7 +9498,7 @@ msgid "There are at least "
 msgstr "อย่างน้อยต้องมี"
 
 #, fuzzy, python-format
-msgid "There are at least %s updates available."
+msgid "There are at least %d updates available."
 msgstr " มีรายการปรับปรุง"
 
 msgid "There are currently no outstanding actions."
@@ -10245,7 +10245,7 @@ msgstr ""
 msgid "Update has completed."
 msgstr ""
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr ""
 
 msgid "Updating"

--- a/po/th.po
+++ b/po/th.po
@@ -4720,8 +4720,8 @@ msgid "Instant recording location"
 msgstr "เปลี่ยนแปลงการบันทึก (ช่วงเวลา)"
 
 #, fuzzy
-msgid "Instant recording..."
-msgstr "บันทึกรายการ..."
+msgid "Instant recording"
+msgstr "บันทึกรายการ"
 
 msgid "Interface: "
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -27,7 +27,6 @@ msgstr ""
 "กดปุ่ม OK แล้วรอสักครู่"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -9313,8 +9313,8 @@ msgid "There are at least "
 msgstr "En az "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Yeni %s güncellemeler bulundu."
+msgid "There are at least %d updates available."
+msgstr "Yeni %d güncellemeler bulundu."
 
 msgid "There are currently no outstanding actions."
 msgstr "Seçilmiş bir görev yok."
@@ -10069,7 +10069,7 @@ msgstr "Güncelleme başarısız oldu. Alıcınızda bir İnternet bağlantısı
 msgid "Update has completed."
 msgstr "Güncelleme tamamladı."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Güncelleme sunucusu kullanılamıyor."
 
 msgid "Updating"

--- a/po/tr.po
+++ b/po/tr.po
@@ -4656,8 +4656,8 @@ msgstr "Hızlı kayıt"
 msgid "Instant recording location"
 msgstr "Hızlı kayıt yeri"
 
-msgid "Instant recording..."
-msgstr "Hızlı kayıt..."
+msgid "Instant recording"
+msgstr "Hızlı kayıt"
 
 msgid "Interface: "
 msgstr "Arayüz: "

--- a/po/tr.po
+++ b/po/tr.po
@@ -27,7 +27,6 @@ msgstr ""
 "Lütfen OK'a bastıktan sonra bekleyin!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -9139,8 +9139,8 @@ msgid "There are at least "
 msgstr "Є принаймні "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Доступно щонайменше %s оновлень."
+msgid "There are at least %d updates available."
+msgstr "Доступно щонайменше %d оновлень."
 
 msgid "There are currently no outstanding actions."
 msgstr "В даний час немає невиконаних дій."
@@ -9862,7 +9862,7 @@ msgstr "Оновлення не вдалося. У Вашому приймачі
 msgid "Update has completed."
 msgstr "Оновлення завершено."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Канал Оновленя не доступний."
 
 msgid "Updating"

--- a/po/uk.po
+++ b/po/uk.po
@@ -21,10 +21,8 @@ msgstr ""
 "Після натиснення OK, зачекайте!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Виявлення конфліктів відключено!"
 
 msgid ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -4584,8 +4584,8 @@ msgstr "Негайний запис"
 msgid "Instant recording location"
 msgstr "Розташування миттєвих записів"
 
-msgid "Instant recording..."
-msgstr "Негайний запис..."
+msgid "Instant recording"
+msgstr "Негайний запис"
 
 msgid "Interface: "
 msgstr "Інтерфейс: "

--- a/po/vi.po
+++ b/po/vi.po
@@ -21,10 +21,8 @@ msgstr ""
 "Sau khi nhấn OK, vui lòng đợi!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "Phát hiện xung đột bị vô hiệu hóa!"
 
 msgid ""

--- a/po/vi.po
+++ b/po/vi.po
@@ -9100,8 +9100,8 @@ msgid "There are at least "
 msgstr "Có ít nhất "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "Có ít nhất%s cập nhật có sẵn."
+msgid "There are at least %d updates available."
+msgstr "Có ít nhất %d cập nhật có sẵn."
 
 msgid "There are currently no outstanding actions."
 msgstr "Hiện tại không có hành động nổi bật."
@@ -9821,7 +9821,7 @@ msgstr "Cập nhật thất bại. Đầu thu của bạn không có kết nối
 msgid "Update has completed."
 msgstr "Cập nhật đã hoàn thành."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "Cập nhật nguồn cấp dữ liệu không có sẵn."
 
 msgid "Updating"

--- a/po/vi.po
+++ b/po/vi.po
@@ -4555,8 +4555,8 @@ msgstr "Ghi lại ngay lập tức"
 msgid "Instant recording location"
 msgstr "Vị trí ghi âm tức thì"
 
-msgid "Instant recording..."
-msgstr "Ghi âm tức thì ..."
+msgid "Instant recording"
+msgstr "Ghi âm tức thì"
 
 msgid "Interface: "
 msgstr "Giao diện: "

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -9117,8 +9117,8 @@ msgid "There are at least "
 msgstr "至少有 "
 
 #, python-format
-msgid "There are at least %s updates available."
-msgstr "有一个最近更新 %s 可用."
+msgid "There are at least %d updates available."
+msgstr "有一个最近更新 %d 可用."
 
 msgid "There are currently no outstanding actions."
 msgstr "目前没有异常."
@@ -9839,7 +9839,7 @@ msgstr "更新失败.接收机没有可用的互联网连接."
 msgid "Update has completed."
 msgstr "升级已完成."
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr "更新资源无效."
 
 msgid "Updating"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4566,8 +4566,8 @@ msgstr "即时录制"
 msgid "Instant recording location"
 msgstr "即时录制位置"
 
-msgid "Instant recording..."
-msgstr "即时录制..."
+msgid "Instant recording"
+msgstr "即时录制"
 
 msgid "Interface: "
 msgstr "网卡: "

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -22,10 +22,8 @@ msgstr ""
 "按OK键确定后,请稍等!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
-"\n"
 "冲突检测禁用!"
 
 msgid ""

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -4581,7 +4581,7 @@ msgstr ""
 msgid "Instant recording location"
 msgstr ""
 
-msgid "Instant recording..."
+msgid "Instant recording"
 msgstr ""
 
 msgid "Interface: "

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -9197,7 +9197,7 @@ msgid "There are at least "
 msgstr "這裏至少有 "
 
 #, python-format
-msgid "There are at least %s updates available."
+msgid "There are at least %d updates available."
 msgstr ""
 
 msgid "There are currently no outstanding actions."
@@ -9920,7 +9920,7 @@ msgstr ""
 msgid "Update has completed."
 msgstr ""
 
-msgid "Updatefeed not available."
+msgid "Update feed not available."
 msgstr ""
 
 msgid "Updating"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -20,7 +20,6 @@ msgstr ""
 "按OK鍵確定後, 請稍等!"
 
 msgid ""
-"\n"
 "Conflict detection disabled!"
 msgstr ""
 


### PR DESCRIPTION
This is a set of changes aiming to simplify the code a little bit and make the translation process easier. Some strings have been removed from the translation system, while others have been reformatted to be simpler to translate. See each individual commit for more details.

This PR can be merged as a squash commit or as separate commits. Your choice.