### PR TITLE
[NimManager] fix wrong internally_connectable vu solo2

### DIFF
--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -945,7 +945,7 @@ class NimManager:
 			if "has_outputs" not in entry:
 				entry["has_outputs"] = entry["name"] in SystemInfo["HasPhysicalLoopthrough"] # "Has_Outputs: yes" not in /proc/bus/nim_sockets NIM, but the physical loopthrough exist
 			if "frontend_device" in entry: # check if internally connectable
-				if os.path.exists("/proc/stb/frontend/%d/rf_switch" % entry["frontend_device"]) and (not id or entries[id]["name"] == entries[id - 1]["name"]):
+				if os.path.exists("/proc/stb/frontend/%d/rf_switch" % entry["frontend_device"]) and id > 0 and entries[id]["name"] == entries[id - 1]["name"]:
 					entry["internally_connectable"] = entry["frontend_device"] - 1
 				else:
 					entry["internally_connectable"] = None


### PR DESCRIPTION
1)nim_sockets vu solo2
NIM Socket 0:
Type: DVB-S2
Name: BCM7356 DVB-S2 NIM (internal)
Frontend_Device: 0
NIM Socket 1:
Type: DVB-S2
Name: BCM7356 DVB-S2 NIM (internal)
Frontend_Device: 1

So:
tuner A( Frontend_Device: 0) and tuner B( Frontend_Device: 1) is
/proc/stb/frontend/%d/rf_switch (wrong in drivers)

frontend_device = 0
entry["internally_connectable"] = entry["frontend_device"] - 1
entry["internally_connectable"] = -1 this invalid tuner number

2)And all the same, internal switching would not work in the image by
default, because a one way way is needed, information is here
https://forums.openpli.org/topic/29465-solo2-loop-out/page-2