### PR TITLE
[cablescan] test fx stop scan when no aswer in tableReady

### DIFF
--- a/lib/dvb/cablescan.cpp
+++ b/lib/dvb/cablescan.cpp
@@ -79,6 +79,7 @@ void eCableScan::stateChanged(iDVBChannel *ch)
 	}
 
 	channelState = state;
+	eDebug("[eCableScan] state %d", state);
 
 	if (state == iDVBChannel::state_ok)
 	{
@@ -92,6 +93,10 @@ void eCableScan::stateChanged(iDVBChannel *ch)
 			m_NIT->start(m_demux, eDVBNITSpec(networkId));
 		}
 	}
+	else if (state == iDVBChannel::state_failed)
+	{
+		nextChannel();
+ 	}
 }
 
 void eCableScan::NITReady(int error)


### PR DESCRIPTION
See info:
https://forums.openpli.org/topic/85352-is-cable-scan-broken