### PR TITLE
Removed some strings from the translation system

### DIFF
--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -1351,7 +1351,7 @@ def InitNimManager(nimmgr, update_slots=[]):
 		("diseqc_a_b", "DiSEqC A/B"), ("diseqc_a_b_c_d", "DiSEqC A/B/C/D"),
 		("positioner", _("Positioner")), ("positioner_select", _("Positioner (selecting satellites)"))]
 
-	positioner_mode_choices = [("usals", _("USALS")), ("manual", _("manual"))]
+	positioner_mode_choices = [("usals", "USALS"), ("manual", _("manual"))]
 
 	diseqc_satlist_choices = [(3600, _('automatic'), 1), (3601, _('nothing connected'), 1)] + nimmgr.satList
 
@@ -1365,9 +1365,9 @@ def InitNimManager(nimmgr, update_slots=[]):
 	advanced_voltage_choices = [("polarization", _("Polarization")), ("13V", _("13 V")), ("18V", _("18 V")), ("0V", _("Externally powered"))]
 	advanced_tonemode_choices = [("band", _("Band")), ("on", _("On")), ("off", _("Off"))]
 	advanced_lnb_toneburst_choices = [("none", _("None")), ("A", _("A")), ("B", _("B"))]
-	advanced_lnb_allsat_diseqcmode_choices = [("1_2", _("1.2"))]
-	advanced_lnb_satposdepends_diseqcmode_choices = [("none", _("None")), ("1_0", _("1.0")), ("1_1", _("1.1"))]
-	advanced_lnb_diseqcmode_choices = [("none", _("None")), ("1_0", _("1.0")), ("1_1", _("1.1")), ("1_2", _("1.2"))]
+	advanced_lnb_allsat_diseqcmode_choices = [("1_2", "1.2")]
+	advanced_lnb_satposdepends_diseqcmode_choices = [("none", _("None")), ("1_0", "1.0"), ("1_1", "1.1")]
+	advanced_lnb_diseqcmode_choices = [("none", _("None")), ("1_0", "1.0"), ("1_1", "1.1"), ("1_2", "1.2")]
 	advanced_lnb_commandOrder1_0_choices = [("ct", "DiSEqC 1.0, toneburst"), ("tc", "toneburst, DiSEqC 1.0")]
 	advanced_lnb_commandOrder_choices = [
 		("ct", "DiSEqC 1.0, toneburst"), ("tc", "toneburst, DiSEqC 1.0"),

--- a/lib/python/Components/ServiceScan.py
+++ b/lib/python/Components/ServiceScan.py
@@ -125,13 +125,13 @@ class ServiceScan:
 								tp.Bandwidth_1_712MHz: "Bw 1.712MHz", tp.Bandwidth_10MHz: "Bw 10MHz"
 							}.get(tp.bandwidth, ""))
 					elif tp_type == iDVBFrontend.feATSC:
-						network = _("ATSC")
+						network = "ATSC"
 						tp = transponder.getATSC()
 						freqMHz = "%0.1f MHz" % (tp.frequency / 1000000.)
 						tp_text = ("%s %s %s %s") % (
 							{
-								tp.System_ATSC: _("ATSC"),
-								tp.System_DVB_C_ANNEX_B: _("DVB-C ANNEX B")
+								tp.System_ATSC: "ATSC",
+								tp.System_DVB_C_ANNEX_B: "DVB-C ANNEX B"
 							}.get(tp.system, ""),
 							{
 								tp.Modulation_Auto: _("Auto"),

--- a/lib/python/Components/TimerList.py
+++ b/lib/python/Components/TimerList.py
@@ -205,9 +205,9 @@ class TimerList(GUIComponent, object):
 			return "%s" % _("Stream") + alternative
 		op = int(refstr.split(':', 10)[6][:-4] or "0", 16)
 		if op == 0xeeee:
-			return "%s" % _("DVB-T") + alternative
+			return "%s" % "DVB-T" + alternative
 		if op == 0xffff:
-			return "%s" % _("DVB-C") + alternative
+			return "%s" % "DVB-C" + alternative
 		direction = 'E'
 		if op > 1800:
 			op = 3600 - op

--- a/lib/python/Plugins/SystemPlugins/PositionerSetup/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/PositionerSetup/plugin.py
@@ -1482,8 +1482,8 @@ class TunerScreen(ConfigListScreen, Screen):
 
 		self.scan_sat = ConfigSubsection()
 		self.scan_sat.system = ConfigSelection(default=defaultSat["system"], choices=[
-			(eDVBFrontendParametersSatellite.System_DVB_S, _("DVB-S")),
-			(eDVBFrontendParametersSatellite.System_DVB_S2, _("DVB-S2"))])
+			(eDVBFrontendParametersSatellite.System_DVB_S, "DVB-S"),
+			(eDVBFrontendParametersSatellite.System_DVB_S2, "DVB-S2")])
 		self.scan_sat.frequency = ConfigInteger(default=defaultSat["frequency"], limits=(1, 99999))
 		self.scan_sat.inversion = ConfigSelection(default=defaultSat["inversion"], choices=[
 			(eDVBFrontendParametersSatellite.Inversion_Off, _("Off")),

--- a/lib/python/Screens/NetworkSetup.py
+++ b/lib/python/Screens/NetworkSetup.py
@@ -410,11 +410,11 @@ class AdapterSetup(Screen, ConfigListScreen, HelpableScreen):
 			self.ws = wpaSupplicant()
 			self.encryptionlist = []
 			self.encryptionlist.append(("Unencrypted", _("Unencrypted")))
-			self.encryptionlist.append(("WEP", _("WEP")))
-			self.encryptionlist.append(("WPA", _("WPA")))
+			self.encryptionlist.append(("WEP", "WEP"))
+			self.encryptionlist.append(("WPA", "WPA"))
 			if not os.path.exists("/tmp/bcm/" + self.iface):
-				self.encryptionlist.append(("WPA/WPA2", _("WPA or WPA2")))
-			self.encryptionlist.append(("WPA2", _("WPA2")))
+				self.encryptionlist.append(("WPA/WPA2", "WPA/WPA2"))
+			self.encryptionlist.append(("WPA2", "WPA2"))
 			self.weplist = []
 			self.weplist.append("ASCII")
 			self.weplist.append("HEX")

--- a/lib/python/Screens/Satconfig.py
+++ b/lib/python/Screens/Satconfig.py
@@ -456,8 +456,8 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 				self.list.append(getConfigListEntry(self.indent % _("Tone mode"), Sat.tonemode, _("Select 'band' if using a 'universal' LNB, otherwise consult your LNB spec sheet.")))
 
 			if lnbnum < 65 or lnbnum == 71:
-				if self.nim.isFBCLink() and ("1_2", _("1.2")) in currLnb.diseqcMode.choices.choices:
-					currLnb.diseqcMode.setChoices([("none", _("None")), ("1_0", _("1.0")), ("1_1", _("1.1"))], "none")
+				if self.nim.isFBCLink() and ("1_2", "1.2") in currLnb.diseqcMode.choices.choices:
+					currLnb.diseqcMode.setChoices([("none", _("none")), ("1_0", "1.0"), ("1_1", "1.1")], "none")
 				self.advancedDiseqcMode = getConfigListEntry(self.indent % _("DiSEqC mode"), currLnb.diseqcMode, _("Select '1.0' for standard committed switches, '1.1' for uncommitted switches, and '1.2' for systems using a positioner."))
 				self.list.append(self.advancedDiseqcMode)
 			if currLnb.diseqcMode.value != "none":
@@ -920,7 +920,7 @@ class NimSelection(Screen):
 					text = ("%s: %s\n%s" % (_("Modes") if "/" in enabledTuners else _("Mode"), enabledTuners if enabledTuners == 'ATSC' else "DVB-%s" % enabledTuners, text)) if enabledTuners else _("Disabled")
 				if not x.isSupported():
 					text = _("Tuner is not supported")
-				if x.isCompatible("DVB-T") and (_("DVB-T") in (text + x.friendly_full_description) or _("/T") in (text + x.friendly_full_description)) and _("Disabled") not in text and hasattr(nimConfig, "terrestrial_5V") and nimConfig.terrestrial_5V.value:
+				if x.isCompatible("DVB-T") and ("DVB-T" in (text + x.friendly_full_description) or "/T" in (text + x.friendly_full_description)) and _("Disabled") not in text and hasattr(nimConfig, "terrestrial_5V") and nimConfig.terrestrial_5V.value:
 					text += _(" (+5 volt terrestrial)")
 				self.list.append((slotid, x.friendly_full_description, text or nimConfig.configMode.value, x))
 		self["nimlist"].setList(self.list)

--- a/lib/python/Screens/ScanSetup.py
+++ b/lib/python/Screens/ScanSetup.py
@@ -1009,7 +1009,7 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 
 			modes = [x[:5] for x in n.getTunerTypesEnabled()]
 			self.nim_type_dict[n.slot] = {"modes": modes,
-				"selection": ConfigSelection(choices=[(x, {"DVB-S": _("Satellite"), "DVB-T": _("Terrestrial"), "DVB-C": _("Cable"), "ATSC": _("ATSC")}.get(x, "")) for x in modes])}
+				"selection": ConfigSelection(choices=[(x, {"DVB-S": _("Satellite"), "DVB-T": _("Terrestrial"), "DVB-C": _("Cable"), "ATSC": "ATSC"}.get(x, "")) for x in modes])}
 			if ttype in modes:
 				self.nim_type_dict[n.slot]["selection"].value = ttype
 
@@ -1033,8 +1033,8 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 
 		# sat
 		self.scan_sat.system = ConfigSelection(default=defaultSat["system"], choices=[
-			(eDVBFrontendParametersSatellite.System_DVB_S, _("DVB-S")),
-			(eDVBFrontendParametersSatellite.System_DVB_S2, _("DVB-S2"))])
+			(eDVBFrontendParametersSatellite.System_DVB_S, "DVB-S"),
+			(eDVBFrontendParametersSatellite.System_DVB_S2, "DVB-S2")])
 		self.scan_sat.frequency = ConfigInteger(default=defaultSat["frequency"], limits=(1, 99999))
 		self.scan_sat.inversion = ConfigSelection(default=defaultSat["inversion"], choices=[
 			(eDVBFrontendParametersSatellite.Inversion_Off, _("Off")),
@@ -1124,8 +1124,8 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 			(eDVBFrontendParametersCable.FEC_None, _("None"))])
 		self.scan_cab.symbolrate = ConfigInteger(default=defaultCab["symbolrate"], limits=(1, 99999))
 		self.scan_cab.system = ConfigSelection(default=defaultCab["system"], choices=[
-			(eDVBFrontendParametersCable.System_DVB_C_ANNEX_A, _("DVB-C")),
-			(eDVBFrontendParametersCable.System_DVB_C_ANNEX_C, _("DVB-C ANNEX C"))])
+			(eDVBFrontendParametersCable.System_DVB_C_ANNEX_A, "DVB-C"),
+			(eDVBFrontendParametersCable.System_DVB_C_ANNEX_C, "DVB-C ANNEX C")])
 
 		# terrestial
 		self.scan_ter.frequency = ConfigFloat(default=[defaultTer["frequency"] / 1000, defaultTer["frequency"] % 1000], limits=[(50, 999), (0, 999)])
@@ -1197,8 +1197,8 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 			(eDVBFrontendParametersTerrestrial.Hierarchy_Auto, _("Auto"))])
 		self.scan_ter.system = ConfigSelection(default=defaultTer["system"], choices=[
 			(eDVBFrontendParametersTerrestrial.System_DVB_T_T2, _("Auto")),
-			(eDVBFrontendParametersTerrestrial.System_DVB_T, _("DVB-T")),
-			(eDVBFrontendParametersTerrestrial.System_DVB_T2, _("DVB-T2"))])
+			(eDVBFrontendParametersTerrestrial.System_DVB_T, "DVB-T"),
+			(eDVBFrontendParametersTerrestrial.System_DVB_T2, "DVB-T2")])
 		self.scan_ter.plp_id = ConfigInteger(default=defaultTer["plp_id"], limits=(0, 255))
 
 		# ATSC
@@ -1217,8 +1217,8 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 			(eDVBFrontendParametersATSC.Modulation_VSB_8, "8VSB"),
 			(eDVBFrontendParametersATSC.Modulation_VSB_16, "16VSB")])
 		self.scan_ats.system = ConfigSelection(default=defaultATSC["system"], choices=[
-			(eDVBFrontendParametersATSC.System_ATSC, _("ATSC")),
-			(eDVBFrontendParametersATSC.System_DVB_C_ANNEX_B, _("DVB-C ANNEX B"))])
+			(eDVBFrontendParametersATSC.System_ATSC, "ATSC"),
+			(eDVBFrontendParametersATSC.System_DVB_C_ANNEX_B, "DVB-C ANNEX B")])
 
 		self.scan_scansat = {}
 		for sat in nimmanager.satList:


### PR DESCRIPTION
Terms like "USALS", "DVB-S", "DVB-S2", "DVB-T", "DVB-T2", "DVB-C", "ATSC", DiseqC versions, "WEP", "WPA", etc should not be translated at all.