### PR TITLE
[EpgList] Reworked string

### DIFF
--- a/lib/python/Components/EpgList.py
+++ b/lib/python/Components/EpgList.py
@@ -300,7 +300,7 @@ class EPGList(GUIComponent):
 					prefix = ""
 				res.extend((
 					(eListboxPythonMultiContent.TYPE_PROGRESS, r2.x, r2.y, r2.w, r2.h, percent),
-					(eListboxPythonMultiContent.TYPE_TEXT, r3.x, r3.y, self.gap(self.tw), r3.h, 1, RT_HALIGN_RIGHT | RT_VALIGN_CENTER, _("%s%d min") % (prefix, remaining)),
+					(eListboxPythonMultiContent.TYPE_TEXT, r3.x, r3.y, self.gap(self.tw), r3.h, 1, RT_HALIGN_RIGHT | RT_VALIGN_CENTER, prefix + _("%d min") % remaining),
 					(eListboxPythonMultiContent.TYPE_TEXT, r3.x + self.tw, r3.y, r3.w, r3.h, 0, RT_HALIGN_LEFT | RT_VALIGN_CENTER, EventName)
 				))
 		return res


### PR DESCRIPTION
The "prefix" can be either "" (empty string) or "+", thus by removing it from the translations we fix the following warning when updating the .po files:

'msgid' format string with unnamed arguments cannot be properly localized:
The translator cannot reorder the arguments.
Please consider using a format string with named arguments,
and a mapping instead of a tuple for the arguments.

In addition, we have one less string to translate.
The new string is already used in enigma2, so no update needed in the translations.