### PR TITLE
Cleanup unused and redundant code

### DIFF
--- a/lib/python/Plugins/Extensions/GraphMultiEPG/GraphMultiEpgSetup.py
+++ b/lib/python/Plugins/Extensions/GraphMultiEPG/GraphMultiEpgSetup.py
@@ -4,7 +4,7 @@ from Components.Pixmap import Pixmap
 from Components.Label import Label
 from Components.PluginComponent import plugins
 from Components.config import config, getConfigListEntry
-from Components.ConfigList import ConfigList, ConfigListScreen
+from Components.ConfigList import ConfigListScreen
 
 addnotifier = None
 
@@ -14,19 +14,18 @@ class GraphMultiEpgSetup(Screen, ConfigListScreen):
 		<screen name="GraphMultiEPGSetup" position="center,center" size="560,490" title="Electronic Program Guide Setup">
 			<ePixmap pixmap="buttons/red.png" position="0,0" size="140,40" alphatest="on" />
 			<ePixmap pixmap="buttons/green.png" position="140,0" size="140,40" alphatest="on" />
-			<ePixmap pixmap="buttons/yellow.png" position="280,0" size="140,40" alphatest="on" />
-			<ePixmap pixmap="buttons/blue.png" position="420,0" size="140,40" alphatest="on" />
-			<widget name="canceltext" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1" />
-			<widget name="oktext" position="140,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
+			<widget name="key_red" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1" />
+			<widget name="key_green" position="140,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
 			<widget name="config" position="10,50" size="550,430" />
 		</screen>"""
 
 	def __init__(self, session, args=None):
 		Screen.__init__(self, session)
 		self.setTitle(_("GraphMultiEpg Settings"))
+		self.skinName = ["GraphMultiEpgSetup", "Setup"]
 
-		self["key_green"] = self["oktext"] = Label(_("OK"))
-		self["key_red"] = self["canceltext"] = Label(_("Cancel"))
+		self["key_red"] = Label(_("Cancel"))
+		self["key_green"] = Label(_("Save"))
 
 		self["actions"] = ActionMap(["SetupActions", "MenuActions", "ColorActions"],
 		{
@@ -38,12 +37,6 @@ class GraphMultiEpgSetup(Screen, ConfigListScreen):
 			"menu": self.closeRecursive,
 		}, -1)
 
-		self.onChangedEntry = []
-		self.list = []
-		ConfigListScreen.__init__(self, self.list, session=session)
-		self.createSetup()
-
-	def createSetup(self):
 		global addnotifier
 		self.list = []
 		self.list.append(getConfigListEntry(_("Event font size (relative to skin size)"), config.misc.graph_mepg.ev_fontsize))
@@ -66,5 +59,4 @@ class GraphMultiEpgSetup(Screen, ConfigListScreen):
 		if addnotifier is None:
 			addnotifier = config.misc.graph_mepg.extension_menu.addNotifier(plugins.reloadPlugins, initial_call=False)
 
-		self["config"].list = self.list
-		self["config"].l.setList(self.list)
+		ConfigListScreen.__init__(self, self.list, session)

--- a/lib/python/Plugins/Extensions/MediaPlayer/settings.py
+++ b/lib/python/Plugins/Extensions/MediaPlayer/settings.py
@@ -67,7 +67,7 @@ class MediaPlayerSettings(Screen, ConfigListScreen):
 		self["key_red"] = StaticText(_("Cancel"))
 		self["key_green"] = StaticText(_("Save"))
 
-		ConfigListScreen.__init__(self, [], session=session, on_change=self.changedEntry)
+		ConfigListScreen.__init__(self, [], session)
 		self.parent = parent
 		self.initConfigList()
 		config.mediaplayer.saveDirOnExit.addNotifier(self.initConfigList)
@@ -79,8 +79,6 @@ class MediaPlayerSettings(Screen, ConfigListScreen):
 			"cancel": self.keyCancel,
 			"ok": self.ok,
 		}, -2)
-
-		self.onLayoutFinish.append(self.createSummary)
 
 	def initConfigList(self, element=None):
 		print "[initConfigList]", element

--- a/lib/python/Plugins/Extensions/PicturePlayer/ui.py
+++ b/lib/python/Plugins/Extensions/PicturePlayer/ui.py
@@ -144,8 +144,6 @@ class picshow(Screen):
 		config.pic.save()
 		self.close()
 
-#------------------------------------------------------------------------------------------
-
 
 class Pic_Setup(Screen, ConfigListScreen):
 
@@ -154,8 +152,6 @@ class Pic_Setup(Screen, ConfigListScreen):
 		# for the skin: first try MediaPlayerSettings, then Setup, this allows individual skinning
 		self.skinName = ["PicturePlayerSetup", "Setup"]
 		self.setTitle(_("Settings"))
-		self.onChangedEntry = []
-		ConfigListScreen.__init__(self, [], session=session, on_change=self.changedEntry)
 		self["actions"] = ActionMap(["SetupActions", "MenuActions"],
 			{
 				"cancel": self.keyCancel,
@@ -164,10 +160,8 @@ class Pic_Setup(Screen, ConfigListScreen):
 				"menu": self.closeRecursive,
 			}, -2)
 		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("OK"))
-		self.createSetup()
+		self["key_green"] = StaticText(_("Save"))
 
-	def createSetup(self):
 		setup_list = [
 			getConfigListEntry(_("Slide show interval (sec.)"), config.pic.slidetime),
 			getConfigListEntry(_("Scaling mode"), config.pic.resize),
@@ -181,31 +175,7 @@ class Pic_Setup(Screen, ConfigListScreen):
 			getConfigListEntry(_("Auto EXIF Orientation rotation/flipping"), config.pic.autoOrientation),
 			getConfigListEntry(_("Stop play TV"), config.pic.stopPlayTv),
 		]
-		self["config"].list = setup_list
-		self["config"].l.setList(setup_list)
-
-	def keyLeft(self):
-		ConfigListScreen.keyLeft(self)
-
-	def keyRight(self):
-		ConfigListScreen.keyRight(self)
-
-	# for summary:
-	def changedEntry(self):
-		for x in self.onChangedEntry:
-			x()
-
-	def getCurrentEntry(self):
-		return self["config"].getCurrent()[0]
-
-	def getCurrentValue(self):
-		return str(self["config"].getCurrent()[1].getText())
-
-	def createSummary(self):
-		from Screens.Setup import SetupSummary
-		return SetupSummary
-
-#---------------------------------------------------------------------------
+		ConfigListScreen.__init__(self, setup_list, session)
 
 
 class Pic_Exif(Screen):
@@ -245,8 +215,6 @@ class Pic_Exif(Screen):
 				name = exiflist[x].split('/')[-1]
 				list.append((exifdesc[x], name))
 		self["menu"] = List(list)
-
-#----------------------------------------------------------------------------------------
 
 
 T_INDEX = 0
@@ -436,8 +404,6 @@ class Pic_Thumb(Screen):
 	def Exit(self):
 		del self.picload
 		self.close(self.index + self.dirlistcount)
-
-#---------------------------------------------------------------------------
 
 
 class Pic_Full_View(Screen):

--- a/lib/python/Plugins/SystemPlugins/CableScan/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/CableScan/plugin.py
@@ -154,9 +154,7 @@ class CableScanScreen(ConfigListScreen, Screen):
 		self.list.append(getConfigListEntry(_("HD list"), config.plugins.CableScan.hdlist))
 		self.list.append(getConfigListEntry(_("Enable auto cable scan"), config.plugins.CableScan.auto))
 
-		ConfigListScreen.__init__(self, self.list)
-		self["config"].list = self.list
-		self["config"].l.setList(self.list)
+		ConfigListScreen.__init__(self, self.list, session)
 		self["introduction"] = Label(_("Configure your network settings and press OK to scan"))
 
 	def restoreService(self):

--- a/lib/python/Plugins/SystemPlugins/DiseqcTester/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/DiseqcTester/plugin.py
@@ -509,10 +509,7 @@ class DiseqcTesterTestTypeSelection(Screen, ConfigListScreen):
 		# for the skin: first try 'DiseqcTesterTestTypeSelection', then 'Setup', this allows individual skinning
 		self.skinName = ["DiseqcTesterTestTypeSelection", "Setup"]
 		self.setTitle(_("DiSEqC-tester settings"))
-		self.onChangedEntry = []
 		self.feid = feid
-		self.list = []
-		ConfigListScreen.__init__(self, self.list, session=self.session, on_change=self.changedEntry)
 
 		self["actions"] = ActionMap(["SetupActions", "MenuActions"],
 			{
@@ -525,9 +522,8 @@ class DiseqcTesterTestTypeSelection(Screen, ConfigListScreen):
 		self["key_red"] = StaticText(_("Cancel"))
 		self["key_green"] = StaticText(_("OK"))
 
-		self.createSetup()
+		self.list = []
 
-	def createSetup(self):
 		self.testtype = ConfigSelection(choices={"quick": _("Quick"), "random": _("Random"), "complete": _("Complete")}, default="quick")
 		self.testtypeEntry = getConfigListEntry(_("Test type"), self.testtype)
 		self.list.append(self.testtypeEntry)
@@ -544,8 +540,8 @@ class DiseqcTesterTestTypeSelection(Screen, ConfigListScreen):
 		self.logEntry = getConfigListEntry(_("Log results to /tmp"), self.log)
 		self.list.append(self.logEntry)
 
-		self["config"].list = self.list
-		self["config"].l.setList(self.list)
+		ConfigListScreen.__init__(self, self.list, session)
+
 
 	def keyOK(self):
 		print self.testtype.getValue()
@@ -560,21 +556,6 @@ class DiseqcTesterTestTypeSelection(Screen, ConfigListScreen):
 
 	def keyCancel(self):
 		self.close()
-
-	# for summary:
-	def changedEntry(self):
-		for x in self.onChangedEntry:
-			x()
-
-	def getCurrentEntry(self):
-		return self["config"].getCurrent()[0]
-
-	def getCurrentValue(self):
-		return str(self["config"].getCurrent()[1].getText())
-
-	def createSummary(self):
-		from Screens.Setup import SetupSummary
-		return SetupSummary
 
 
 class DiseqcTesterNimSelection(NimSelection):

--- a/lib/python/Plugins/SystemPlugins/FastScan/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/FastScan/plugin.py
@@ -197,7 +197,7 @@ class FastScanScreen(ConfigListScreen, Screen):
 		for provider in providers:
 			self.config_autoproviders[provider[0]] = ConfigYesNo(default=provider[0] in auto_providers)
 		self.list = []
-		ConfigListScreen.__init__(self, self.list)
+		ConfigListScreen.__init__(self, self.list, session, self.createSetup)
 		self.createSetup()
 		self.finished_cb = None
 		self["introduction"] = Label(_("Select your provider, and press OK to start the scan"))
@@ -223,15 +223,6 @@ class FastScanScreen(ConfigListScreen, Screen):
 					if nimmanager.getNimListForSat(transponders[provider[1][0]][3]):
 						self.list.append(getConfigListEntry(_("Enable auto fastscan for %s") % provider[0], self.config_autoproviders[provider[0]]))
 		self["config"].list = self.list
-		self["config"].l.setList(self.list)
-
-	def keyLeft(self):
-		ConfigListScreen.keyLeft(self)
-		self.createSetup()
-
-	def keyRight(self):
-		ConfigListScreen.keyRight(self)
-		self.createSetup()
 
 	def saveConfiguration(self):
 		if self.scan_provider.value:

--- a/lib/python/Plugins/SystemPlugins/OSDPositionSetup/overscanwizard.py
+++ b/lib/python/Plugins/SystemPlugins/OSDPositionSetup/overscanwizard.py
@@ -41,8 +41,7 @@ class OverscanWizard(Screen, ConfigListScreen):
 
 		self.step = 1
 		self.list = []
-		ConfigListScreen.__init__(self, self.list, session=self.session, on_change=self.changedEntry)
-		self.onChangedEntry = []
+		ConfigListScreen.__init__(self, self.list, session)
 		self.setScreen()
 
 		self.Timer = eTimer()
@@ -130,7 +129,6 @@ class OverscanWizard(Screen, ConfigListScreen):
 			self["introduction"].setText(_("The user interface of the receiver will now restart to select the selected skin"))
 			quitMainloop(3)
 		self["config"].list = self.list
-		self["config"].l.setList(self.list)
 		if self["config"].instance:
 			self.__layoutFinished()
 
@@ -139,20 +137,6 @@ class OverscanWizard(Screen, ConfigListScreen):
 		self.setTitle(_("Overscan wizard") + " (%s)" % self.countdown)
 		if not(self.countdown):
 			self.keyCancel()
-
-	def changedEntry(self):
-		for x in self.onChangedEntry:
-			x()
-
-	def getCurrentEntry(self):
-		return self["config"].getCurrent() and self["config"].getCurrent()[0] or ""
-
-	def getCurrentValue(self):
-		return self["config"].getCurrent() and len(self["config"].getCurrent()) > 1 and str(self["config"].getCurrent()[1].getText()) or ""
-
-	def createSummary(self):
-		from Screens.Setup import SetupSummary
-		return SetupSummary
 
 	def keyLeft(self):
 		ConfigListScreen.keyLeft(self)
@@ -200,7 +184,7 @@ class OverscanWizard(Screen, ConfigListScreen):
 			self.dst_left.value = self.dst_right.value
 		if self.dst_top.value > self.dst_bottom.value:
 			self.dst_top.value = self.dst_bottom.value
-		self["config"].l.setList(self.list)
+		self["config"].list(self.list)
 		setPosition(int(self.dst_left.value), int(self.dst_right.value) - int(self.dst_left.value), int(self.dst_top.value), int(self.dst_bottom.value) - int(self.dst_top.value))
 
 	def keyCancel(self):


### PR DESCRIPTION
This is the first part of cleanup in the "Setup" alike classes (i.e. classes that have "Screen" and "ConfigListScreen" as parents).

If in doubt of any change, please ask. They are tested and work fine. All deleted code is just redundant.