### PR TITLE
gRGB::operator const std::string () const conversion incorrect

### DIFF
--- a/lib/gdi/gpixmap.h
+++ b/lib/gdi/gpixmap.h
@@ -107,7 +107,9 @@ struct gRGB
 		escapecolor.resize(10);
 		for (int i = 9; i >= 2; i--)
 		{
-			escapecolor[i] = 0x40 | (val & 0xf);
+			int hexbits = val & 0xf;
+			escapecolor[i] = hexbits < 10	? '0' + hexbits
+							: 'a' - 10 + hexbits;
 			val >>= 4;
 		}
 		return escapecolor;


### PR DESCRIPTION
gRGB::operator const std::string () const should now correctly
decode numbers to hex strings.

I have not been able to test this fix in context, only with the
method body in a test harness. An alternative fix is:

escapecolor[i] = "0123456789abcdef"[val & 0xf];

or similar, but that may be slightly less efficient.

This fix should also help address, or even fix, Bug #319 - Subtitle
colours go black.

(cherry picked from commit 37503289183fcc7b27338f7f998d68246d1c42d6)