### PR TITLE
[Ci] try/except show ci message screen

### DIFF
--- a/lib/python/Screens/Ci.py
+++ b/lib/python/Screens/Ci.py
@@ -347,7 +347,10 @@ class CiMessageHandler:
 								show_ui = False
 								self.auto_close = False
 					if show_ui and not forceNotShowCiMessages and not Screens.Standby.inStandby:
-						self.dlgs[slot] = self.session.openWithCallback(self.dlgClosed, MMIDialog, slot, 3, screen_data=screen_data)
+						try:
+							self.dlgs[slot] = self.session.openWithCallback(self.dlgClosed, MMIDialog, slot, 3, screen_data=screen_data)
+						except:
+							pass
 
 	def dlgClosed(self, slot):
 		if slot in self.dlgs:


### PR DESCRIPTION
File "/usr/lib/enigma2/python/Screens/Ci.py", line 350, in
ciStateChanged
  File "/usr/lib/enigma2/python/StartEnigma.py", line
302, in openWithCallback
    dlg = self.open(screen, *arguments,
**kwargs)
  File "/usr/lib/enigma2/python/StartEnigma.py", line 308, in
open
    raise RuntimeError("modal open are allowed only from a screen
which is modal!")
RuntimeError: modal open are allowed only from a
screen which is modal!