### PR TITLE
Harddisk: Create "movie" directory after formatting a device

### DIFF
--- a/lib/python/Components/Harddisk.py
+++ b/lib/python/Components/Harddisk.py
@@ -310,6 +310,9 @@ class Harddisk:
 			h.write(zero)
 		h.close()
 
+	def createMovieDir(self):
+		os.mkdir(os.path.join(self.mount_path, 'movie'))
+
 	def createInitializeJob(self):
 		job = Task.Job(_("Initializing storage device..."))
 		size = self.diskSize()
@@ -407,6 +410,10 @@ class Harddisk:
 
 		task = Task.ConditionTask(job, _("Waiting for mount"), timeoutCount=20)
 		task.check = self.mountDevice
+		task.weighting = 1
+
+		task = Task.PythonTask(job, _("Create directory") + ": movie")
+		task.work = self.createMovieDir
 		task.weighting = 1
 
 		return job


### PR DESCRIPTION
Untested, please test before merging...

Put your recordings into a convenient location, so you don't get to see
the "backup" and "epg.dat" entries. Easy enough to delete if you don't
want it, creating it is more work and not intuitive as the "movie" name
is sort of magic - the box will automatically use it when present.