### PR TITLE
Start enigma after build in workflow test

### DIFF
--- a/.github/workflows/enigma2.yml
+++ b/.github/workflows/enigma2.yml
@@ -19,6 +19,9 @@ jobs:
         sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
         sudo apt-get -q update
         sudo apt install g++-${{ matrix.gcc }}
+    - name: install python packages
+      run: |
+        pip install netifaces pyopenssl python-wifi service_identity twisted
     - name: install dev packages
       run: |
         sudo apt-get -q update
@@ -70,6 +73,9 @@ jobs:
         make
         sudo make install
         popd
+    - name: patch enigma cpp files
+      run: |
+        sed -i 's/eFatal/eDebug/g' lib/gdi/gfbdc.cpp
     - name: build enigma2
       env: 
         CC: "gcc-${{ matrix.gcc }}"
@@ -80,4 +86,26 @@ jobs:
         ./configure --with-libsdl=no --with-boxtype=nobox --enable-dependency-tracking ac_cv_prog_c_openmp=-fopenmp --with-textlcd
         make
         python -m compileall .
+    - name: patch enigma py files
+      run: |
+        sed -i 's/reloadWindowStyles()  #/# reloadWindowStyles()  #/g' lib/python/skin.py
+        sed -i 's/setResolution(xres, yres/setResolution(xres, yres, 8/g' lib/python/skin.py
+        sed -i '1 i\globals()["__builtins__"]["ngettext"] = ngettext' lib/python/Tools/Profile.py
+        sed -i '1 i\from gettext import ngettext' lib/python/Tools/Profile.py
+        sed -i 's/reactor.run/pass  # reactor.run/g' lib/python/StartEnigma.py
+        sed -i 's/enigma.quitMainloop(5)/enigma.quitMainloop(1)/' lib/python/StartEnigma.py
+        sed -i 's/import enigma/import enigma\nenigma.quitMainloop(1)/' lib/python/StartEnigma.py
+        echo 'enigma.quitMainloop(0)' >> lib/python/StartEnigma.py
+    - name: install enigma
+      run: |
+        sudo make install
+        sudo mkdir -p '/usr/local/etc/enigma2'
+        sudo sh -c "echo 'config.misc.do_overscanwizard=false' > /usr/local/etc/enigma2/settings"
+        sudo sh -c "echo 'config.misc.firstrun=false' >> /usr/local/etc/enigma2/settings"
+        sudo sh -c "echo 'config.misc.initialchannelselection=false' >> /usr/local/etc/enigma2/settings"
+        sudo sh -c "echo 'config.misc.languageselected=false' >> /usr/local/etc/enigma2/settings"
+        sudo sh -c "echo 'config.misc.videowizardenabled=false' >> /usr/local/etc/enigma2/settings"
+    - name: start enigma2
+      run: |
+        sudo LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib ENIGMA_DEBUG_LVL=5 enigma2
         echo done!


### PR DESCRIPTION
Now source files are compiled on test and this allows you to check for syntax errors.
But this does not allow check for example type or attribute errors, that may appear when an enigma run.
Therefore on test after the compile install and start enigma.
That will not check all errors in sources, but can prevent the possibility get gsod already on enigma startup.
The run doesn't happen on a real image, so a small surce patch is required for enigma startup.