### PR TITLE
[InfoBarGenerics] add service name to subservices

### DIFF
--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -183,9 +183,8 @@ def getActiveSubservicesForCurrentChannel(service):
 				if title and "Sendepause" not in title:
 					starttime = datetime.datetime.fromtimestamp(event[0]).strftime('%H:%M')
 					endtime = datetime.datetime.fromtimestamp(event[0] + event[1]).strftime('%H:%M')
-					servicename = ServiceReference(subservice).getServiceName()
 					schedule = str(starttime) + "-" + str(endtime)
-					activeSubservices.append((servicename + " " + "[ " + schedule + " ]  - " + " " + title, subservice))
+					activeSubservices.append(("%s [%s] %s" % (ServiceReference(subservice).getServiceName(), schedule, title), subservice))
 	if not activeSubservices:
 		subservices = service and service.subServices()
 		if subservices:

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -183,8 +183,9 @@ def getActiveSubservicesForCurrentChannel(service):
 				if title and "Sendepause" not in title:
 					starttime = datetime.datetime.fromtimestamp(event[0]).strftime('%H:%M')
 					endtime = datetime.datetime.fromtimestamp(event[0] + event[1]).strftime('%H:%M')
-					current_show_name = "%s %s-%s" % (title, str(starttime), str(endtime))
-					activeSubservices.append((current_show_name, subservice))
+					servicename = ServiceReference(subservice).getServiceName()
+					schedule = str(starttime) + "-" + str(endtime)
+					activeSubservices.append((servicename + " " + "[ " + schedule + " ]  - " + " " + title, subservice))
 	if not activeSubservices:
 		subservices = service and service.subServices()
 		if subservices:


### PR DESCRIPTION
thanks @Huevos

Item will now read...
servicename, event time, event
title

Having the event time in second position means...
1) no addition
delimiter is needed, keeping things as short as possible,
2) event time
won't get forced of the screen by extra long event titles.