### PR TITLE
[eDVBScan] Set SDT filter for 0x42 tables only

### DIFF
--- a/lib/dvb/scan.cpp
+++ b/lib/dvb/scan.cpp
@@ -351,7 +351,7 @@ RESULT eDVBScan::startFilter()
 			if (m_SDT->start(m_demux, eDVBSDTSpec()))
 				return -1;
 		}
-		else if (m_SDT->start(m_demux, eDVBSDTSpec(tsid, true)))
+		else if (m_SDT->start(m_demux, eDVBSDTSpec(tsid, false)))
 			return -1;
 		CONNECT(m_SDT->tableReady, eDVBScan::SDTready);
 	}


### PR DESCRIPTION
Searching for both 0x42 (actual) and 0x46 (other) SDT tables results to problems with transponders carrying both tables for the transponder's tsid.

This was done back in 2006 with https://github.com/OpenPLi/enigma2/commit/a2eb4cb31c5df65b943b68a9aa0a376655631143 to fix Dish Network transponders that carried no 0x42 tables, but only 0x46 carrying the service names.

Dish Network does not work through enigma2 anymore, so the hack is not necessary.
Furthermore it creates problems with RAI transponder @13E and maybe more.
See https://forums.openpli.org/topic/87162-rai-channel-name-problems/