### PR TITLE
[Picon] add new skin attrib "usePicLoad" for use ePicLoad

### DIFF
--- a/lib/python/Components/Renderer/Picon.py
+++ b/lib/python/Components/Renderer/Picon.py
@@ -167,8 +167,13 @@ class Picon(Renderer):
 		if self.instance:
 			if self.showPicon or config.usage.show_picon_in_display.value:
 				pngname = ""
-				if what[0] != self.CHANGED_CLEAR:
+				if what[0] in (self.CHANGED_ALL, self.CHANGED_SPECIFIC):
 					pngname = getPiconName(self.source.text)
+				elif what[0] == self.CHANGED_CLEAR:
+					self.pngname = ""
+					if self.visible:
+					       self.instance.hide()
+					return
 				if not pngname: # no picon for service found
 					pngname = self.defaultpngname
 				if self.pngname != pngname:

--- a/lib/python/Components/Renderer/Picon.py
+++ b/lib/python/Components/Renderer/Picon.py
@@ -152,7 +152,6 @@ class Picon(Renderer):
 			elif attrib == "size":
 				self.piconsize = value
 		self.skinAttributes = attribs
-		self.changed((self.CHANGED_ALL,))
 		return Renderer.applySkin(self, desktop, parent)
 
 	GUI_WIDGET = ePixmap

--- a/lib/python/Components/Renderer/Picon.py
+++ b/lib/python/Components/Renderer/Picon.py
@@ -2,7 +2,7 @@ import os
 import re
 import unicodedata
 from Renderer import Renderer
-from enigma import ePixmap, eServiceCenter, eServiceReference, iServiceInformation
+from enigma import ePixmap, ePicLoad, eServiceCenter, eServiceReference, iServiceInformation
 from Tools.Alternatives import GetWithAlternative
 from Tools.Directories import pathExists, SCOPE_SKIN_IMAGE, SCOPE_CURRENT_SKIN, resolveFilename
 from Components.Harddisk import harddiskmanager
@@ -111,6 +111,10 @@ def getPiconName(serviceRef):
 class Picon(Renderer):
 	def __init__(self):
 		Renderer.__init__(self)
+		self.usePicLoad = False
+		self.PicLoad = ePicLoad()
+		self.PicLoad.PictureData.get().append(self.updatePicon)
+		self.piconsize = (0,0)
 		self.pngname = ""
 		self.lastPath = None
 		pngname = findPicon("picon_default")
@@ -142,11 +146,22 @@ class Picon(Renderer):
 			elif attrib == "isFrontDisplayPicon":
 				self.showPicon = value == "0"
 				attribs.remove((attrib, value))
+			elif attrib == "usePicLoad":
+				self.usePicLoad = value == "1"
+				attribs.remove((attrib, value))
+			elif attrib == "size":
+				self.piconsize = value
 		self.skinAttributes = attribs
 		self.changed((self.CHANGED_ALL,))
 		return Renderer.applySkin(self, desktop, parent)
 
 	GUI_WIDGET = ePixmap
+
+	def updatePicon(self, picInfo=None):
+		ptr = self.PicLoad.getData()
+		if ptr is not None and self.instance:
+			self.instance.setPixmap(ptr.__deref__())
+			self.instance.show()
 
 	def changed(self, what):
 		if self.instance:
@@ -158,9 +173,13 @@ class Picon(Renderer):
 					pngname = self.defaultpngname
 				if self.pngname != pngname:
 					if pngname:
-						self.instance.setScale(1)
-						self.instance.setPixmapFromFile(pngname)
-						self.instance.show()
+						if self.usePicLoad:
+							self.PicLoad.setPara((self.piconsize[0], self.piconsize[1], 0, 0, 1, 1, "#FF000000"))
+							self.PicLoad.startDecode(pngname)
+						else:
+							self.instance.setScale(1)
+							self.instance.setPixmapFromFile(pngname)
+							self.instance.show()
 					else:
 						self.instance.hide()
 					self.pngname = pngname

--- a/lib/python/Components/Renderer/Picon.py
+++ b/lib/python/Components/Renderer/Picon.py
@@ -169,10 +169,11 @@ class Picon(Renderer):
 				pngname = ""
 				if what[0] in (self.CHANGED_ALL, self.CHANGED_SPECIFIC):
 					pngname = getPiconName(self.source.text)
-				elif what[0] == self.CHANGED_CLEAR:
-					self.pngname = ""
-					if self.visible:
-					       self.instance.hide()
+				else:
+					if what[0] == self.CHANGED_CLEAR:
+						self.pngname = ""
+						if self.visible:
+					     		self.instance.hide()
 					return
 				if not pngname: # no picon for service found
 					pngname = self.defaultpngname


### PR DESCRIPTION
Need for some box(e.g. gigablue uhd ue/quad 4k) in lcd display.
- example:
<widget source="session.CurrentService" render="Picon"
isFrontDisplayPicon="1" usePicLoad= "1" zPosition="13"
position="224,394" size="242,142" transparent="1" alphatest="blend">

<convert type="ServiceName">Reference</convert>
  </widget>