### PR TITLE
Wlan.py: Decode line to unicode

### DIFF
--- a/lib/python/Plugins/SystemPlugins/WirelessLan/Wlan.py
+++ b/lib/python/Plugins/SystemPlugins/WirelessLan/Wlan.py
@@ -373,7 +373,7 @@ class Status:
 		iface = extra_args
 		data = {'essid': False, 'frequency': False, 'accesspoint': False, 'bitrate': False, 'encryption': False, 'quality': False, 'signal': False}
 		for line in result.splitlines():
-			line = line.strip()
+			line = line.strip().decode()
 			if "ESSID" in line:
 				if "off/any" in line:
 					ssid = "off"


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/lib/enigma2/python/Components/Console.py", line 48, in finishedCB
    callback(data, retval, self.extra_args)
  File "/usr/lib/enigma2/python/Plugins/SystemPlugins/WirelessLan/Wlan.py", line 377, in iwconfigFinished
    if "ESSID" in line:
TypeError: a bytes-like object is required, not 'str'
[ePyObject] (CallObject(<traceback object at 0xb199e048>,(0,)) failed)