### PR TITLE
VirtualKeyBoard.py: Don't decode to unicode

### DIFF
--- a/lib/python/Screens/VirtualKeyBoard.py
+++ b/lib/python/Screens/VirtualKeyBoard.py
@@ -515,7 +515,7 @@ class VirtualKeyBoard(Screen, HelpableScreen):
 		}, -2, description=_("Virtual KeyBoard Functions"))
 		self.lang = language.getLanguage()
 		self["prompt"] = Label(prompt)
-		self["text"] = Input(text=text, maxSize=maxSize, visible_width=visible_width, type=type, currPos=len(text.decode("utf-8", "ignore")) if currPos is None else currPos, allMarked=allMarked)
+		self["text"] = Input(text=text, maxSize=maxSize, visible_width=visible_width, type=type, currPos=len(text) if currPos is None else currPos, allMarked=allMarked)
 		self["list"] = VirtualKeyBoardList([])
 		self["mode"] = Label(_("INS"))
 		self["locale"] = Label(_("Locale") + ": " + self.lang)


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/lib/enigma2/python/Components/ActionMap.py", line 78, in action
    return ActionMap.action(self, contexts, action)
  File "/usr/lib/enigma2/python/Components/ActionMap.py", line 58, in action
    res = self.actions[action]()
  File "/usr/lib/enigma2/python/Screens/TimerEntry.py", line 271, in keyRight
    self.renameEntry()
  File "/usr/lib/enigma2/python/Screens/TimerEntry.py", line 284, in renameEntry
    self.session.openWithCallback(self.renameEntryCallback, VirtualKeyBoard, title=title_text, text=old_text)
  File "/usr/lib/enigma2/python/StartEnigma.py", line 303, in openWithCallback
    dlg = self.open(screen, *arguments, **kwargs)
  File "/usr/lib/enigma2/python/StartEnigma.py", line 313, in open
    dlg = self.current_dialog = self.instantiateDialog(screen, *arguments, **kwargs)
  File "/usr/lib/enigma2/python/StartEnigma.py", line 256, in instantiateDialog
    return self.doInstantiateDialog(screen, arguments, kwargs, self.desktop)
  File "/usr/lib/enigma2/python/StartEnigma.py", line 273, in doInstantiateDialog
    dlg = screen(self, *arguments, **kwargs)
  File "/usr/lib/enigma2/python/Screens/VirtualKeyBoard.py", line 518, in __init__
    self["text"] = Input(text=text, maxSize=maxSize, visible_width=visible_width, type=type, currPos=len(text.decode("utf-8", "ignore")) if currPos is None else currPos, allMarked=allMarked)
AttributeError: 'str' object has no attribute 'decode'
[ePyObject] (CallObject(<bound method NumberActionMap.action of <Components.ActionMap.NumberActionMap object at 0xb1be6268>>,('SetupActions', 'right')) failed)