### PR TITLE
Input.py: Don't decode to unicode

### DIFF
--- a/lib/python/Components/Input.py
+++ b/lib/python/Components/Input.py
@@ -152,8 +152,6 @@ class Input(VariableText, GUIComponent, NumericalTextInput):
 		self.update()
 
 	def insertChar(self, ch, pos=False, owr=False, ins=False):
-		if isinstance(ch, str):
-			ch = ch.decode("utf-8", "ignore")
 		if not pos:
 			pos = self.currPos
 		if ins and not self.maxSize:


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/lib/enigma2/python/Components/ActionMap.py", line 78, in action
    return ActionMap.action(self, contexts, action)
  File "/usr/lib/enigma2/python/Components/ActionMap.py", line 58, in action
    res = self.actions[action]()
  File "/usr/lib/enigma2/python/Screens/VirtualKeyBoard.py", line 1033, in processSelect
    self['text'].char(text)
  File "/usr/lib/enigma2/python/Components/Input.py", line 265, in char
    self.insertChar(char)
  File "/usr/lib/enigma2/python/Components/Input.py", line 156, in insertChar
    ch = ch.decode("utf-8", "ignore")
AttributeError: 'str' object has no attribute 'decode'