### PR TITLE
opkg.py: Decode data to unicode

### DIFF
--- a/lib/python/Components/Opkg.py
+++ b/lib/python/Components/Opkg.py
@@ -178,6 +178,7 @@ class OpkgComponent:
 		self.cmd.dataAvail.remove(self.cmdData)
 
 	def cmdData(self, data):
+		data = data.decode()
 		print("data:", data)
 		if self.cache is None:
 			self.cache = data


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/enigma2/python/Components/Opkg.py", line 188, in cmdData
    splitcache = self.cache.split('\n')
TypeError: a bytes-like object is required, not 'str'
[ePyObject] (CallObject(<bound method OpkgComponent.cmdData of <Components.Opkg.OpkgComponent object at 0xb1649208>>,(b"Downloading http://downloads.openpli.org/feeds/openpli-8-release/3rd-party-armv7vehf-neon-vfpv4/Packages.gz.\nUpdated source 'openpli-3rd-party-armv7vehf-neon-vfpv4'.\nDownloading http://downloads.openpli.org/feeds/openpli-8-release/3rd-party/Packages.gz.\nUpdated source 'openpli-3rd-party'.\nDownloading http://downloads.openpli.org/feeds/openpli-8-release/3rd-party-osmio4k/Packages.gz.\nUpdated source 'openpli-3rd-party-osmio4k'.\nDownloading http://downloads.openpli.org/feeds/openpli-python3/all/Packages.gz.\nUpdated source 'openpli-all'.\nDownloading http://downloads.openpli.org/feeds/openpli-python3/armv7vehf-neon-vfpv4/Packages.gz.\nUpdated source 'openpli-armv7vehf-neon-vfpv4'.\nDownloading http://downloads.openpli.org/feeds/openpli-python3/osmio4k/Packages.gz.\nUpdated source 'openpli-osmio4k'.\nDownloading http://downloads.openpli.org/feeds/openpli-8-release/picons/Packages.gz.\nUpdated source 'openpli-picons'.\n",)) failed)
```