### PR TITLE
[HardwareInfo] fix Zgemma h9twin(se) model name

### DIFF
--- a/lib/python/Tools/HardwareInfo.py
+++ b/lib/python/Tools/HardwareInfo.py
@@ -68,7 +68,10 @@ class HardwareInfo:
 		elif self.device_model == "et11000":
 			self.machine_name = "et1x000"
 		elif self.device_brandname == "Zgemma":
-			self.device_model = self.device_name
+			if self.device_model and self.device_name and "H9Twin" in self.device_model and "combo" in self.device_name:
+				self.device_model = self.device_model.lower()
+			else:
+				self.device_model = self.device_name
 			self.machine_name = self.device_name
 
 		if self.device_revision:

--- a/lib/python/Tools/HardwareInfo.py
+++ b/lib/python/Tools/HardwareInfo.py
@@ -69,7 +69,7 @@ class HardwareInfo:
 			self.machine_name = "et1x000"
 		elif self.device_brandname == "Zgemma":
 			if self.device_model and self.device_name and "H9Twin" in self.device_model and "combo" in self.device_name:
-				self.device_model = self.device_model.lower()
+				self.device_model = self.device_model.lower().replace(" ", "")
 			else:
 				self.device_model = self.device_name
 			self.machine_name = self.device_name


### PR DESCRIPTION
root@h9combo:~# cat /proc/stb/info/model
h9combo
root@h9combo:~# cat /proc/stb/info/boxtype
H9Twin