### PR TITLE
config.py: properly open config file

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -1868,7 +1868,7 @@ class Config(ConfigSubsection):
 			print("Config: Couldn't write %s" % filename)
 
 	def loadFromFile(self, filename, base_file=True):
-		self.unpickle(open(filename, "r"), base_file)
+		self.unpickle(open(filename, "r", encoding="UTF-8"), base_file)
 
 
 config = Config()


### PR DESCRIPTION
This fixes the following crash:

```
Traceback (most recent call last):
  File "/usr/lib/enigma2/python/StartEnigma.py", line 224, in processDelay
    callback(*retval)
  File "/usr/lib/enigma2/python/Screens/Menu.py", line 106, in menuClosedWithConfigFlush
    configfile.save()
  File "/usr/lib/enigma2/python/Components/config.py", line 1889, in save
    config.saveToFile(self.CONFIG_FILE)
  File "/usr/lib/enigma2/python/Components/config.py", line 1862, in saveToFile
    f.write(text)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 937-943: ordinal not in range(128)
[ePyObject] (CallObject(<bound method Session.processDelay of <__main__.Session object at 0xb23ca6d0>>,()) failed)
```