### PR TITLE
Use existing renderer for gb led settings

### DIFF
--- a/lib/python/Components/Renderer/FrontpanelLed.py
+++ b/lib/python/Components/Renderer/FrontpanelLed.py
@@ -2,12 +2,42 @@ from Components.Element import Element
 
 # this is not a GUI renderer.
 
+#                      |  two leds  | single led |
+# recordstate  standby   red green
+#    false      false    off   on     off
+#    true       false    blnk  on     blnk
+#    false      true      on   off    off
+#    true       true     blnk  off    blnk
+PATTERN_ON = (20, 0xffffffff, 0xffffffff)
+PATTERN_OFF = (20, 0, 0)
+PATTERN_BLINK = (20, 0x55555555, 0xa7fccf7a)
+
+
+class LedPatterns():
+	def __init__(self):
+		self.__led0_patterns = [PATTERN_OFF, PATTERN_BLINK, PATTERN_ON, PATTERN_BLINK]
+		self.__led1_patterns = [PATTERN_ON, PATTERN_ON, PATTERN_OFF, PATTERN_OFF]
+
+	def setLedPatterns(self, which, patterns):
+		if which == 0:
+			self.__led0_patterns = patterns
+		else:
+			self.__led1_patterns = patterns
+
+	def getLedPatterns(self, which):
+		if which == 0:
+			return self.__led0_patterns
+		return self.__led1_patterns
+
+
+ledPatterns = LedPatterns()
+
 
 class FrontpanelLed(Element):
-	def __init__(self, which=0, patterns=[(20, 0, 0xffffffff), (20, 0x55555555, 0x84fc8c04)], boolean=True):
+	def __init__(self, which=0, patterns=[PATTERN_ON, PATTERN_BLINK], boolean=True, get_patterns=None):
 		self.which = which
 		self.boolean = boolean
-		self.patterns = patterns
+		self.patterns = get_patterns if get_patterns else patterns
 		Element.__init__(self)
 
 	def changed(self, *args, **kwargs):
@@ -16,7 +46,7 @@ class FrontpanelLed(Element):
 		else:
 			val = self.source.value
 
-		(speed, pattern, pattern_4bit) = self.patterns[val]
+		(speed, pattern, pattern_4bit) = self.patterns[val] if self.patterns != True else ledPatterns.getLedPatterns(self.which)[val]
 
 		try:
 			open("/proc/stb/fp/led%d_pattern" % self.which, "w").write("%08x" % pattern)

--- a/lib/python/Screens/SessionGlobals.py
+++ b/lib/python/Screens/SessionGlobals.py
@@ -8,7 +8,7 @@ from Components.Sources.TunerInfo import TunerInfo
 from Components.Sources.Boolean import Boolean
 from Components.Sources.RecordState import RecordState
 from Components.Converter.Combine import Combine
-from Components.Renderer.FrontpanelLed import FrontpanelLed
+from Components.Renderer.FrontpanelLed import FrontpanelLed, PATTERN_OFF, PATTERN_BLINK
 
 
 class SessionGlobals(Screen):
@@ -26,25 +26,15 @@ class SessionGlobals(Screen):
 
 		from Components.SystemInfo import SystemInfo
 
-		combine = Combine(func=lambda s: {(False, False): 0, (False, True): 1, (True, False): 2, (True, True): 3}[(s[0].boolean, s[1].boolean)])
-		combine.connect(self["Standby"])
-		combine.connect(self["RecordState"])
-
-		#                      |  two leds  | single led |
-		# recordstate  standby   red green
-		#    false      false    off   on     off
-		#    true       false    blnk  on     blnk
-		#    false      true      on   off    off
-		#    true       true     blnk  off    blnk
-
-		PATTERN_ON = (20, 0xffffffff, 0xffffffff)
-		PATTERN_OFF = (20, 0, 0)
-		PATTERN_BLINK = (20, 0x55555555, 0xa7fccf7a)
-
 		nr_leds = SystemInfo.get("NumFrontpanelLEDs", 0)
 
-		if nr_leds == 1:
-			FrontpanelLed(which=0, boolean=False, patterns=[PATTERN_OFF, PATTERN_BLINK, PATTERN_OFF, PATTERN_BLINK]).connect(combine)
-		elif nr_leds == 2:
-			FrontpanelLed(which=0, boolean=False, patterns=[PATTERN_OFF, PATTERN_BLINK, PATTERN_ON, PATTERN_BLINK]).connect(combine)
-			FrontpanelLed(which=1, boolean=False, patterns=[PATTERN_ON, PATTERN_ON, PATTERN_OFF, PATTERN_OFF]).connect(combine)
+		if nr_leds > 0:
+			combine = Combine(func=lambda s: {(False, False): 0, (False, True): 1, (True, False): 2, (True, True): 3}[(s[0].boolean, s[1].boolean)])
+			combine.connect(self["Standby"])
+			combine.connect(self["RecordState"])
+
+			if nr_leds == 1:
+				FrontpanelLed(which=0, boolean=False, patterns=[PATTERN_OFF, PATTERN_BLINK, PATTERN_OFF, PATTERN_BLINK]).connect(combine)
+			elif nr_leds == 2:
+				FrontpanelLed(which=0, boolean=False, get_patterns=True).connect(combine)
+				FrontpanelLed(which=1, boolean=False, get_patterns=True).connect(combine)


### PR DESCRIPTION
In the enigma from the beginning there is a renderer FrontpanelLed which is used for led control.
Therefore, we can use it and do not need to additionally write values in the proc on startup.
This also introduces the ability to set led profiles for use in different modes for frontpanel led control.