### PR TITLE
TuneTest.py: Fix SyntaxWarning

### DIFF
--- a/lib/python/Components/TuneTest.py
+++ b/lib/python/Components/TuneTest.py
@@ -142,7 +142,7 @@ class TuneTest:
 
 	def gotTsidOnid(self, tsid, onid):
 		print("******** got tsid, onid:", tsid, onid)
-		if tsid is not -1 and onid is not -1:
+		if tsid != -1 and onid != -1:
 			self.pidStatus = self.INTERNAL_PID_STATUS_SUCCESSFUL
 			self.tsid = tsid
 			self.onid = onid


### PR DESCRIPTION
```
/usr/lib/enigma2/python/Components/TuneTest.py:145: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if tsid is not -1 and onid is not -1:
/usr/lib/enigma2/python/Components/TuneTest.py:145: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if tsid is not -1 and onid is not -1:
```