### PR TITLE
ChannelSelection.py: Don't encode to bytes

### DIFF
--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -1785,9 +1785,8 @@ class ChannelSelectionBase(Screen):
 					self.numberSelectionActions(number)
 			else:
 				unichar = self.numericalTextInput.getKey(number)
-				charstr = unichar.encode("utf-8")
-				if len(charstr) == 1:
-					self.servicelist.moveToChar(charstr[0])
+				if len(unichar) == 1:
+					self.servicelist.moveToChar(unichar[0])
 
 	def numberSelectionActions(self, number):
 		if not(hasattr(self, "movemode") and self.movemode):
@@ -1809,9 +1808,8 @@ class ChannelSelectionBase(Screen):
 
 	def keyAsciiCode(self):
 		unichar = chr(getPrevAsciiCode())
-		charstr = unichar.encode("utf-8")
-		if len(charstr) == 1:
-			self.servicelist.moveToChar(charstr[0])
+		if len(unichar) == 1:
+			self.servicelist.moveToChar(unichar[0])
 
 	def getRoot(self):
 		return self.servicelist.getRoot()


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/enigma2/python/Components/ActionMap.py", line 73, in action
    res = self.actions[action](int(action))
  File "/usr/lib/enigma2/python/Screens/ChannelSelection.py", line 1801, in keyNumberGlobal
    self.servicelist.moveToChar(charstr[0])
  File "/usr/lib/enigma2/python/Components/ServiceList.py", line 265, in moveToChar
    indexup = self.l.getNextBeginningWithChar(char.upper())
AttributeError: 'int' object has no attribute 'upper'
[ePyObject] (CallObject(<bound method NumberActionMap.action of <Components.ActionMap.NumberActionMap object at 0xb15ef628>>,('NumberActions', '1')) failed)
```