### PR TITLE
Properly call maxsize from sys module

### DIFF
--- a/lib/python/Components/HdmiCec.py
+++ b/lib/python/Components/HdmiCec.py
@@ -7,7 +7,6 @@ from enigma import eHdmiCEC, eActionMap
 from Tools.StbHardware import getFPWasTimerWakeup
 import NavigationInstance
 from enigma import eTimer
-from os import sys
 from sys import maxsize
 
 LOGPATH = "/hdd/"
@@ -127,7 +126,7 @@ class HdmiCec:
 		self.volumeForwardingEnabled = False
 		self.volumeForwardingDestination = 0
 		self.wakeup_from_tv = False
-		eActionMap.getInstance().bindAction('', -sys.maxsize - 1, self.keyEvent)
+		eActionMap.getInstance().bindAction('', -maxsize - 1, self.keyEvent)
 		config.hdmicec.volume_forwarding.addNotifier(self.configVolumeForwarding)
 		config.hdmicec.enabled.addNotifier(self.configVolumeForwarding)
 		if config.hdmicec.enabled.value:

--- a/lib/python/RecordTimer.py
+++ b/lib/python/RecordTimer.py
@@ -27,7 +27,6 @@ from ServiceReference import ServiceReference, isPlayableForCur
 
 from time import localtime, strftime, ctime, time
 from bisect import insort
-from os import sys
 from sys import maxsize
 
 # ok, for descriptions etc we have:
@@ -112,13 +111,13 @@ class RecordTimerEntry(timer.TimerEntry, object):
 	@staticmethod
 	def setWasInDeepStandby():
 		RecordTimerEntry.wasInDeepStandby = True
-		eActionMap.getInstance().bindAction('', -sys.maxsize - 1, RecordTimerEntry.keypress)
+		eActionMap.getInstance().bindAction('', -maxsize - 1, RecordTimerEntry.keypress)
 
 	@staticmethod
 	def setWasInStandby():
 		if not RecordTimerEntry.wasInStandby:
 			if not RecordTimerEntry.wasInDeepStandby:
-				eActionMap.getInstance().bindAction('', -sys.maxsize - 1, RecordTimerEntry.keypress)
+				eActionMap.getInstance().bindAction('', -maxsize - 1, RecordTimerEntry.keypress)
 			RecordTimerEntry.wasInDeepStandby = False
 			RecordTimerEntry.wasInStandby = True
 

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -46,7 +46,6 @@ from enigma import eTimer, eServiceCenter, eDVBServicePMTHandler, iServiceInform
 from time import time, localtime, strftime
 import os
 from bisect import insort
-from os import sys
 from sys import maxsize
 import itertools
 import datetime
@@ -214,8 +213,8 @@ class InfoBarUnhandledKey:
 		self.checkUnusedTimer = eTimer()
 		self.checkUnusedTimer.callback.append(self.checkUnused)
 		self.onLayoutFinish.append(self.unhandledKeyDialog.hide)
-		eActionMap.getInstance().bindAction('', -sys.maxsize - 1, self.actionA) #highest prio
-		eActionMap.getInstance().bindAction('', sys.maxsize, self.actionB) #lowest prio
+		eActionMap.getInstance().bindAction('', -maxsize - 1, self.actionA) #highest prio
+		eActionMap.getInstance().bindAction('', maxsize, self.actionB) #lowest prio
 		self.flags = (1 << 1)
 		self.uflags = 0
 
@@ -3048,7 +3047,7 @@ class InfoBarNotifications:
 				self.hide()
 				dlg.show()
 				self.notificationDialog = dlg
-				eActionMap.getInstance().bindAction('', -sys.maxsize - 1, self.keypressNotification)
+				eActionMap.getInstance().bindAction('', -maxsize - 1, self.keypressNotification)
 			else:
 				dlg = self.session.open(n[1], *n[2], **n[3])
 
@@ -3518,7 +3517,7 @@ class InfoBarPowersaver:
 		self.sleepTimer = eTimer()
 		self.sleepStartTime = 0
 		self.sleepTimer.callback.append(self.sleepTimerTimeout)
-		eActionMap.getInstance().bindAction('', -sys.maxsize - 1, self.keypress)
+		eActionMap.getInstance().bindAction('', -maxsize - 1, self.keypress)
 
 	def keypress(self, key, flag):
 		if flag:

--- a/lib/python/Screens/ScreenSaver.py
+++ b/lib/python/Screens/ScreenSaver.py
@@ -7,7 +7,6 @@ import Screens.Standby
 from enigma import ePoint, eTimer, iPlayableService, eActionMap
 import os
 import random
-from os import sys
 from sys import maxsize
 
 
@@ -52,7 +51,7 @@ class InfoBarScreenSaver:
 			if hasattr(self, "pvrStateDialog"):
 				self.pvrStateDialog.hide()
 			self.screensaver.show()
-			eActionMap.getInstance().bindAction('', -sys.maxsize - 1, self.keypressScreenSaver)
+			eActionMap.getInstance().bindAction('', -maxsize - 1, self.keypressScreenSaver)
 
 	def keypressScreenSaver(self, key, flag):
 		if flag:


### PR DESCRIPTION
After commit 2df14421705de1465ea50b1881b2c189d4462d9a the call to maxsize was done improperly, so commits 2711e0ff3139c8728e90391b37ac0636484cb422 0dc1bb8316f69edc5e9763796e8a80f4344c4a21 b33fc21e3f2670765907972c12701ccc1fd6705c and 1b176b6545d087d351e3491d3af582ae4bbc38e3 were done to fix the problem.

This commit fixes the initial problem, by basically reverting the flawed commits.