### PR TITLE
SkinSelector.py: Fix skin resolution not showing

### DIFF
--- a/lib/python/Screens/SkinSelector.py
+++ b/lib/python/Screens/SkinSelector.py
@@ -120,7 +120,7 @@ class SkinSelector(Screen, HelpableScreen):
 									"8640": _("16K")
 								}
 								mm = mmap.mmap(fd.fileno(), 0, prot=mmap.PROT_READ)
-								skinheight = re.search("\<?resolution.*?\syres\s*=\s*\"(\d+)\"", mm).group(1)
+								skinheight = re.search(b"\<?resolution.*?\syres\s*=\s*\"(\d+)\"", mm).group(1)
 								resolution = skinheight and resolutions.get(skinheight, None)
 								mm.close()
 						except:


### PR DESCRIPTION
mmap() works with byte strings, so search for bytes in order to get the resolution