### PR TITLE
[Satfinder] add more config if not sat list

### DIFF
--- a/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
@@ -325,7 +325,7 @@ class Satfinder(ScanSetup, ServiceScan):
 				continue
 			if n.config_mode in ("loopthrough", "satposdepends", "nothing"):
 				continue
-			if n.isCompatible("DVB-S") and n.config_mode == "advanced" and len(nimmanager.getSatListForNim(n.slot)) < 1:
+			if n.isCompatible("DVB-S") and n.config_mode in ("simple", "equal", "advanced") and len(nimmanager.getSatListForNim(n.slot)) < 1:
 				continue
 			satfinder_nim_list.append((str(n.slot), n.friendly_full_description))
 		self.satfinder_scan_nims = ConfigSelection(choices=satfinder_nim_list)


### PR DESCRIPTION
File
"/usr/lib/enigma2/python/Plugins/SystemPlugins/Satfinder/plugin.py",
line 164, in createSetup
ValueError: invalid literal for int() with base
10: ''