### PR TITLE
TimerEdit.py: cmp() is removed from python3

### DIFF
--- a/lib/python/Screens/TimerEdit.py
+++ b/lib/python/Screens/TimerEdit.py
@@ -245,8 +245,8 @@ class TimerEditList(Screen):
 
 		def eol_compare(x, y):
 			if x[0].state != y[0].state and x[0].state == RealTimerEntry.StateEnded or y[0].state == RealTimerEntry.StateEnded:
-				return cmp(x[0].state, y[0].state)
-			return cmp(x[0].begin, y[0].begin)
+				return (x[0].state > y[0].state) - (x[0].state < y[0].state)
+			return (x[0].begin > y[0].begin) - (x[0].begin < y[0].begin)
 
 		self.list = []
 		if self.fallbackTimer.list:


### PR DESCRIPTION
The cmp() function has been removed from python3. This fixes the following crash when having 2 or more completed timers:

```
Traceback (most recent call last):
  File "/usr/lib/enigma2/python/StartEnigma.py", line 224, in processDelay
    callback(*retval)
  File "/usr/lib/enigma2/python/Screens/TimerEdit.py", line 390, in finishedAdd
    simulTimerList = self.session.nav.RecordTimer.record(entry)
  File "/usr/lib/enigma2/python/RecordTimer.py", line 1129, in record
    self.addTimerEntry(entry)
  File "/usr/lib/enigma2/python/timer.py", line 190, in addTimerEntry
    self.calcNextActivation()
  File "/usr/lib/enigma2/python/timer.py", line 229, in calcNextActivation
    self.processActivation()
  File "/usr/lib/enigma2/python/timer.py", line 302, in processActivation
    self.doActivate(timer_list[0])
  File "/usr/lib/enigma2/python/RecordTimer.py", line 911, in doActivate
    self.stateChanged(w)
  File "/usr/lib/enigma2/python/timer.py", line 162, in stateChanged
    f(entry)
  File "/usr/lib/enigma2/python/Screens/TimerEdit.py", line 408, in onStateChange
    self.refill()
  File "/usr/lib/enigma2/python/Screens/TimerEdit.py", line 308, in refill
    self.fillTimerList()
  File "/usr/lib/enigma2/python/Screens/TimerEdit.py", line 259, in fillTimerList
    self.list.sort(key=functools.cmp_to_key(eol_compare))
  File "/usr/lib/enigma2/python/Screens/TimerEdit.py", line 248, in eol_compare
    return cmp(x[0].state, y[0].state)
NameError: name 'cmp' is not defined
```

No more cmp() calls exist across enigma2.