### PR TITLE
Fix urllib.request imports

### DIFF
--- a/lib/python/Components/ImportChannels.py
+++ b/lib/python/Components/ImportChannels.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 import threading
-import urllib
 import os
 import shutil
 import tempfile
@@ -11,6 +10,7 @@ from Components.config import config, ConfigText
 from Tools.Notifications import AddNotificationWithID
 from base64 import encodebytes
 from urllib.parse import quote
+from urllib.request import Request, urlopen
 import xml.etree.ElementTree as et
 
 settingfiles = ('lamedb', 'bouquets.', 'userbouquet.', 'blacklist', 'whitelist', 'alternatives.')
@@ -34,10 +34,10 @@ class ImportChannels():
 			self.thread.start()
 
 	def getUrl(self, url, timeout=5):
-		request = urllib.request.Request(url)
+		request = Request(url)
 		if self.header:
 			request.add_header("Authorization", self.header)
-		return urllib.request.urlopen(request, timeout=timeout)
+		return urlopen(request, timeout=timeout)
 
 	def getTerrestrialUrl(self):
 		url = config.usage.remote_fallback_dvb_t.value

--- a/lib/python/Screens/FlashImage.py
+++ b/lib/python/Screens/FlashImage.py
@@ -16,7 +16,7 @@ from Tools.Downloader import downloadWithProgress
 from Tools.HardwareInfo import HardwareInfo
 from Tools.Multiboot import getImagelist, getCurrentImage, getCurrentImageMode, deleteImage, restoreImages
 import os
-import urllib
+from urllib.request import urlopen
 import json
 import time
 import zipfile
@@ -83,9 +83,9 @@ class SelectImage(Screen):
 		if not self.imagesList:
 			if not self.jsonlist:
 				try:
-					self.jsonlist = dict(json.load(urllib.request.urlopen('http://downloads.openpli.org/json/%s' % model)))
+					self.jsonlist = dict(json.load(urlopen('http://downloads.openpli.org/json/%s' % model)))
 					if config.usage.alternative_imagefeed.value:
-						self.jsonlist.update(dict(json.load(urllib.request.urlopen('%s%s' % (config.usage.alternative_imagefeed.value, model)))))
+						self.jsonlist.update(dict(json.load(urlopen('%s%s' % (config.usage.alternative_imagefeed.value, model)))))
 				except:
 					pass
 			self.imagesList = dict(self.jsonlist)


### PR DESCRIPTION
Imports were not done propely in commits 4689d33ab8980332cc0f42709c58e80e30a01f15 and 0a406a950d0026999a53a723b27df621fa9cff14 by @hains

This is wrong:
```
Python 3.10.1 (tags/v3.10.1:2cd268a, Dec  6 2021, 19:10:37) [MSC v.1929 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.

>>> import urllib
>>> f = urllib.request.urlopen('http://www.python.org/')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'urllib' has no attribute 'request'
```
while this is correct:

```
>>> import urllib.request
>>> f = urllib.request.urlopen('http://www.python.org/')
>>> print(f)
<http.client.HTTPResponse object at 0x0000022E206AAC20>
```

and this as well:

```
>>> from urllib.request import urlopen
>>> f = urlopen('http://www.python.org/')
>>> print(f)
<http.client.HTTPResponse object at 0x0000022E206AA470>
```