### PR TITLE
RedirectOutput.py: Fix typo

### DIFF
--- a/lib/python/Tools/RedirectOutput.py
+++ b/lib/python/Tools/RedirectOutput.py
@@ -10,7 +10,7 @@ class EnigmaLog:
 
 	def write(self, data):
 		if isinstance(data, bytes):
-			data = data.decode(decoding="UTF-8", errors="ignore")
+			data = data.decode(encoding="UTF-8", errors="ignore")
 		self.line += data
 		if "\n" in data:
 			ePythonOutput(self.line, self.level)  # OpenPLi, OpenViX


### PR DESCRIPTION
intrduced with commit d69ea66180067e923c26c29f6a2e8d58d5cc261f