### PR TITLE
GetEcmInfo.py: open "/tmp/share.info" in text mode

### DIFF
--- a/lib/python/Tools/GetEcmInfo.py
+++ b/lib/python/Tools/GetEcmInfo.py
@@ -79,7 +79,7 @@ class GetEcmInfo:
 					if info['decode'] == 'Network':
 						cardid = 'id:' + info.get('prov', '')
 						try:
-							share = open('/tmp/share.info', 'rb').readlines()
+							share = open('/tmp/share.info', 'r').readlines()
 							for line in share:
 								if cardid in line:
 									self.textvalue = line.strip()


### PR DESCRIPTION
"cardid" is a unicode string, so we have to open the file in text mode in order to search inside it.