### PR TITLE
SkinSelector:py: Properly fix resolution not showing

### DIFF
--- a/lib/python/Screens/SkinSelector.py
+++ b/lib/python/Screens/SkinSelector.py
@@ -109,7 +109,7 @@ class SkinSelector(Screen, HelpableScreen):
 					resolution = None
 					if skinFile == "skin.xml":
 						try:
-							with open(skinPath, "r") as fd:
+							with open(skinPath, "rb") as fd:
 								resolutions = {
 									"480": _("NTSC"),
 									"576": _("PAL"),
@@ -121,7 +121,7 @@ class SkinSelector(Screen, HelpableScreen):
 								}
 								mm = mmap.mmap(fd.fileno(), 0, prot=mmap.PROT_READ)
 								skinheight = re.search(b"\<?resolution.*?\syres\s*=\s*\"(\d+)\"", mm).group(1)
-								resolution = skinheight and resolutions.get(skinheight, None)
+								resolution = skinheight and resolutions.get(skinheight.decode(), None)
 								mm.close()
 						except:
 							pass


### PR DESCRIPTION
Since we are working with bytes now, we have to decode to text in order to get the resolution from the dictionary.

Also, open the skin file directly in binary mode to avoid unnecessary convertions from text to bytes in mmap().