### PR TITLE
Allow unicode strings in user bouquet filenames

### DIFF
--- a/lib/python/Components/Renderer/Picon.py
+++ b/lib/python/Components/Renderer/Picon.py
@@ -1,11 +1,10 @@
 from __future__ import print_function
 import os
 import re
-import unicodedata
 from Components.Renderer.Renderer import Renderer
 from enigma import ePixmap, ePicLoad, eServiceCenter, eServiceReference, iServiceInformation
 from Tools.Alternatives import GetWithAlternative
-from Tools.Directories import pathExists, SCOPE_SKIN_IMAGE, SCOPE_CURRENT_SKIN, resolveFilename
+from Tools.Directories import pathExists, SCOPE_SKIN_IMAGE, SCOPE_CURRENT_SKIN, resolveFilename, sanitizeFilename
 from Components.Harddisk import harddiskmanager
 from ServiceReference import ServiceReference
 from Components.config import config
@@ -96,8 +95,7 @@ def getPiconName(serviceRef):
 		fields[2] = '1'
 		pngname = findPicon('_'.join(fields))
 	if not pngname: # picon by channel name
-		name = ServiceReference(serviceRef).getServiceName()
-		name = unicodedata.normalize('NFKD', str(name)).encode('ASCII', 'ignore').decode('ASCII', 'ignore')
+		name = sanitizeFilename(ServiceReference(serviceRef).getServiceName())
 		name = re.sub('[^a-z0-9]', '', name.replace('&', 'and').replace('+', 'plus').replace('*', 'star').lower())
 		if name:
 			pngname = findPicon(name)

--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -40,13 +40,12 @@ from ServiceReference import ServiceReference
 from Tools.BoundFunction import boundFunction
 from Tools.Notifications import RemovePopup
 from Tools.Alternatives import GetWithAlternative
-from Tools.Directories import fileExists, resolveFilename, SCOPE_PLUGINS
+from Tools.Directories import fileExists, resolveFilename, sanitizeFilename, SCOPE_PLUGINS
 from Plugins.Plugin import PluginDescriptor
 from Components.PluginComponent import plugins
 from Screens.ChoiceBox import ChoiceBox
 from Screens.EventView import EventViewEPGSelect
 import os
-import unicodedata
 from time import time
 profile("ChannelSelection.py after imports")
 
@@ -1020,7 +1019,7 @@ class ChannelSelectionEdit:
 		serviceHandler = eServiceCenter.getInstance()
 		mutableBouquetList = serviceHandler.list(self.bouquet_root).startEdit()
 		if mutableBouquetList:
-			name = unicodedata.normalize('NFKD', str(bName, 'utf_8', errors='ignore')).encode('ASCII', 'ignore').translate(None, '<>:"/\\|?*() ')
+			name = sanitizeFilename(bName)
 			while os.path.isfile((self.mode == MODE_TV and '/etc/enigma2/userbouquet.%s.tv' or '/etc/enigma2/userbouquet.%s.radio') % name):
 				name = name.rsplit('_', 1)
 				name = ('_').join((name[0], len(name) == 2 and name[1].isdigit() and str(int(name[1]) + 1) or '1'))

--- a/lib/python/Tools/Directories.py
+++ b/lib/python/Tools/Directories.py
@@ -5,8 +5,9 @@ import inspect
 import os
 
 from enigma import eEnv
-from re import compile
+from re import compile, split
 from stat import S_IMODE
+from unicodedata import normalize
 
 pathExists = os.path.exists
 isMount = os.path.ismount  # Only used in OpenATV /lib/python/Plugins/SystemPlugins/NFIFlash/downloader.py.
@@ -532,3 +533,50 @@ def mediafilesInUse(session):
 
 def shellquote(s):
 	return "'%s'" % s.replace("'", "'\\''")
+
+
+def sanitizeFilename(filename):
+	"""Return a fairly safe version of the filename.
+
+	We don't limit ourselves to ascii, because we want to keep municipality
+	names, etc, but we do want to get rid of anything potentially harmful,
+	and make sure we do not exceed Windows filename length limits.
+	Hence a less safe blacklist, rather than a whitelist.
+	"""
+	blacklist = ["\\", "/", ":", "*", "?", "\"", "<", ">", "|", "\0", "(", ")", " "]
+	reserved = [
+		"CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5",
+		"COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5",
+		"LPT6", "LPT7", "LPT8", "LPT9",
+	]  # Reserved words on Windows
+	filename = "".join(c for c in filename if c not in blacklist)
+	# Remove all charcters below code point 32
+	filename = "".join(c for c in filename if 31 < ord(c))
+	filename = normalize("NFKD", filename)
+	filename = filename.rstrip(". ")  # Windows does not allow these at end
+	filename = filename.strip()
+	if all([x == "." for x in filename]):
+		filename = "__" + filename
+	if filename in reserved:
+		filename = "__" + filename
+	if len(filename) == 0:
+		filename = "__"
+	if len(filename) > 255:
+		parts = split(r"/|\\", filename)[-1].split(".")
+		if len(parts) > 1:
+			ext = "." + parts.pop()
+			filename = filename[:-len(ext)]
+		else:
+			ext = ""
+		if filename == "":
+			filename = "__"
+		if len(ext) > 254:
+			ext = ext[254:]
+		maxl = 255 - len(ext)
+		filename = filename[:maxl]
+		filename = filename + ext
+		# Re-check last character (if there was no extension)
+		filename = filename.rstrip(". ")
+		if len(filename) == 0:
+			filename = "__"
+	return filename


### PR DESCRIPTION
Until now, only ascii characters were allowed in user bouquet file names and non ascii were stripped away, for example "userbouquet.mybouquet.tv." Since unicode is the default for python3 and we are in the 2022, this should be changed. In addition this could lead to weird naming when a user creates a bouquet using only non ascii characters as they are all filtered out by the old code. For example a bouquet name of "ελληνικά" would result in a corresponding user bouquet file name of "userbouquet..tv".

This PR will allow for all valid utf-8 characters to be used as bouquet file names, except from some special or blacklisted characters (in windows, etc.). The old code prevented these special characters as well.

The same restrictions and freedom is applied in names of picons, meaning picons can now contain utf-8 characters. In other words the picon name can match the service name (although the code might need some polish for this to work).

The whole file name check is moved to a new function in the "Directories.py" module. This function is taken from the "sanitize-filename" module in https://pypi.org/project/sanitize-filename/ with the addition of a couple of blacklisted characters (parenthesis and space) which were also blacklisted in the old code.

The "sanitizeFilename" function makes some more tests (like the maximum number of characters allowed in windows for a file name), which may seem overkill for our use case, but the point is to have reusable code that can applied to other files like recordings, etc.