### PR TITLE
[PluginBrowser.py] Hide "text" widget instead of setting it to ""

### DIFF
--- a/lib/python/Screens/PluginBrowser.py
+++ b/lib/python/Screens/PluginBrowser.py
@@ -456,15 +456,15 @@ class PluginDownloadBrowser(Screen):
 			if pluginlist:
 				pluginlist.sort()
 				self.updateList()
+				self["text"].instance.hide()
 				self["list"].instance.show()
-				self["text"].setText("")
 			else:
 				self["text"].setText(_("No new plugins found"))
 		else:
 			if self.pluginlist:
 				self.updateList()
+				self["text"].instance.hide()
 				self["list"].instance.show()
-				self["text"].setText("")
 			else:
 				self["text"].setText(_("No new plugins found"))
 


### PR DESCRIPTION
This is a better fix than commit 03aee6ca108d5edac2ccd954271bc98032a6cde3 since it does not require skins that place the "text" and "list" widgets on top of each other to set a zPosition for them.