### PR TITLE
[FlashImage] [FlashImage] fix multi search folder

### DIFF
--- a/lib/python/Screens/FlashImage.py
+++ b/lib/python/Screens/FlashImage.py
@@ -97,10 +97,10 @@ class SelectImage(Screen):
 					getImages(media, [os.path.join(media, x) for x in os.listdir(media) if os.path.splitext(x)[1] == ".zip" and model in x])
 					for folder in ["images", "downloaded_images", "imagebackups"]:
 						if folder in os.listdir(media):
-							medias = os.path.join(media, folder)
-							if os.path.isdir(medias) and not os.path.islink(medias) and not os.path.ismount(medias):
-								getImages(medias, [os.path.join(medias, x) for x in os.listdir(medias) if os.path.splitext(x)[1] == ".zip" and model in x])
-								for dir in [dir for dir in [os.path.join(medias, dir) for dir in os.listdir(medias)] if os.path.isdir(dir) and os.path.splitext(dir)[1] == ".unzipped"]:
+							subfolder = os.path.join(media, folder)
+							if os.path.isdir(subfolder) and not os.path.islink(subfolder) and not os.path.ismount(subfolder):
+								getImages(medias, [os.path.join(subfolder, x) for x in os.listdir(subfolder) if os.path.splitext(x)[1] == ".zip" and model in x])
+								for dir in [dir for dir in [os.path.join(subfolder, dir) for dir in os.listdir(subfolder)] if os.path.isdir(dir) and os.path.splitext(dir)[1] == ".unzipped"]:
 									shutil.rmtree(dir)
 				except:
 					pass

--- a/lib/python/Screens/FlashImage.py
+++ b/lib/python/Screens/FlashImage.py
@@ -67,14 +67,16 @@ class SelectImage(Screen):
 
 	def getImagesList(self):
 
-		def getImages(path, files, folder=None):
+		def getImages(path, files):
 			for file in [x for x in files if os.path.splitext(x)[1] == ".zip" and model in x]:
 				try:
-					folder = "Image backups" if folder == "imagebackups" else "Downloaded Images"
 					if checkimagefiles([x.split(os.sep)[-1] for x in zipfile.ZipFile(file).namelist()]):
-						if folder not in self.imagesList:
-							self.imagesList[folder] = {}
-						self.imagesList[folder][file] = {'link': file, 'name': file.split(os.sep)[-1]}
+						imagetyp = _("Downloaded Images")
+						if 'backup' in file.split(os.sep)[-1]:
+							imagetyp = _("Fullbackup Images")
+						if imagetyp not in self.imagesList:
+							self.imagesList[imagetyp] = {}
+						self.imagesList[imagetyp][file] = {'link': file, 'name': file.split(os.sep)[-1]}
 				except:
 					pass
 
@@ -95,10 +97,10 @@ class SelectImage(Screen):
 					getImages(media, [os.path.join(media, x) for x in os.listdir(media) if os.path.splitext(x)[1] == ".zip" and model in x])
 					for folder in ["images", "downloaded_images", "imagebackups"]:
 						if folder in os.listdir(media):
-							media = os.path.join(media, folder)
-							if os.path.isdir(media) and not os.path.islink(media) and not os.path.ismount(media):
-								getImages(media, [os.path.join(media, x) for x in os.listdir(media) if os.path.splitext(x)[1] == ".zip" and model in x], folder)
-								for dir in [dir for dir in [os.path.join(media, dir) for dir in os.listdir(media)] if os.path.isdir(dir) and os.path.splitext(dir)[1] == ".unzipped"]:
+							medias = os.path.join(media, folder)
+							if os.path.isdir(medias) and not os.path.islink(medias) and not os.path.ismount(medias):
+								getImages(medias, [os.path.join(medias, x) for x in os.listdir(medias) if os.path.splitext(x)[1] == ".zip" and model in x])
+								for dir in [dir for dir in [os.path.join(medias, dir) for dir in os.listdir(medias)] if os.path.isdir(dir) and os.path.splitext(dir)[1] == ".unzipped"]:
 									shutil.rmtree(dir)
 				except:
 					pass


### PR DESCRIPTION
When use two folder "downloaded_images"(zip image) and imagebackups"(zip
image) visible only one folder and one zip file.
Can't use 'media' variable twice in a loop.