### PR TITLE
[EventView.py] Fix typo in __code__

### DIFF
--- a/lib/python/Screens/EventView.py
+++ b/lib/python/Screens/EventView.py
@@ -312,7 +312,7 @@ class EventViewBase:
 			text = _("Select action")
 			menu = [(p.name, boundFunction(self.runPlugin, p)) for p in plugins.getPlugins(where=PluginDescriptor.WHERE_EVENTINFO)
 				if 'servicelist' not in p.__call__.__code__.co_varnames
-					if 'selectedevent' not in p.__call__.f__code__.co_varnames]
+					if 'selectedevent' not in p.__call__.__code__.co_varnames]
 			if len(menu) == 1:
 				menu and menu[0][1]()
 			elif len(menu) > 1:


### PR DESCRIPTION
Typo introduced with https://github.com/OpenPLi/enigma2/commit/c32e0b26818a980e16537107be983d4be58a9051#diff-b150fe1a6b86445b87508a3a0639cf845aeaa17a8e6c64d5a68a362dad10a006

Fixes crash:

```
Traceback (most recent call last):
  File "/usr/lib/enigma2/python/Components/ActionMap.py", line 58, in action
  File "/usr/lib/enigma2/python/Screens/EventView.py", line 313, in doContext
  File "/usr/lib/enigma2/python/Screens/EventView.py", line 315, in <listcomp>
AttributeError: 'function' object has no attribute 'f__code__'
```