### PR TITLE
Fix descriptions not showing -- Urgent

### DIFF
--- a/lib/python/Plugins/SystemPlugins/HdmiCEC/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/HdmiCEC/plugin.py
@@ -34,7 +34,8 @@ class HdmiCECSetupScreen(Screen, ConfigListScreen):
 
 		self.list = []
 		self.logpath_entry = None
-		ConfigListScreen.__init__(self, self.list, session=self.session, on_change = self.changedEntry)
+		ConfigListScreen.__init__(self, self.list, session=self.session, on_change=self.createSetup)
+		self["config"].onSelectionChanged.append(self.updateDescription)
 		self.createSetup()
 		self.updateAddress()
 
@@ -66,19 +67,6 @@ class HdmiCECSetupScreen(Screen, ConfigListScreen):
 				self.list.append(self.logpath_entry)
 		self["config"].list = self.list
 		self["config"].l.setList(self.list)
-
-	def changedEntry(self):
-		self.createSetup()
-
-	# for summary:
-	def getCurrentEntry(self):
-		self.updateDescription()
-		return ConfigListScreen.getCurrentEntry(self)
-
-	def createSummary(self):
-		from Screens.Setup import SetupSummary
-		return SetupSummary
-	###
 
 	def updateDescription(self):
 		text = "%s\n%s\n\n%s" % (self.current_address, self.fixed_address, self.getCurrentDescription()) if config.hdmicec.enabled.value else self.getCurrentDescription()

--- a/lib/python/Plugins/SystemPlugins/Videomode/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Videomode/plugin.py
@@ -182,17 +182,22 @@ class VideoSetup(Screen, ConfigListScreen):
 			self.keySave()
 
 	# for summary:
+	def changedEntry(self):
+		for x in self.onChangedEntry:
+			x()
+
 	def getCurrentEntry(self):
-		self.updateDescription()
-		return ConfigListScreen.getCurrentEntry(self)
+		return self["config"].getCurrent()[0]
+
+	def getCurrentValue(self):
+		return str(self["config"].getCurrent()[1].getText())
+
+	def getCurrentDescription(self):
+		return self["config"].getCurrent() and len(self["config"].getCurrent()) > 2 and self["config"].getCurrent()[2] or ""
 
 	def createSummary(self):
 		from Screens.Setup import SetupSummary
 		return SetupSummary
-	###
-
-	def updateDescription(self):
-		self["description"].setText("%s" % self.getCurrentDescription())
 
 
 class VideomodeHotplug:

--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -62,6 +62,8 @@ class SetupSummary(Screen):
 	def selectionChanged(self):
 		self["SetupEntry"].text = self.parent.getCurrentEntry()
 		self["SetupValue"].text = self.parent.getCurrentValue()
+		if hasattr(self.parent, "getCurrentDescription") and "description" in self.parent:
+			self.parent["description"].text = self.parent.getCurrentDescription()
 
 
 class Setup(ConfigListScreen, Screen):
@@ -101,12 +103,9 @@ class Setup(ConfigListScreen, Screen):
 
 		ConfigListScreen.__init__(self, self.list, session=session, on_change=self.changedEntry)
 		self.createSetupList()
-		if self.selectionChanged not in self["config"].onSelectionChanged:
-			self["config"].onSelectionChanged.append(self.selectionChanged)
-		self.setTitle(_(self.setup_title))
+		self["config"].onSelectionChanged.append(self.__onSelectionChanged)
 
-	def selectionChanged(self):
-		self["description"].text = self.getCurrentDescription() if len(self["config"].getList()) else ""
+		self.setTitle(_(self.setup_title))
 
 	def createSetupList(self):
 		currentItem = self["config"].getCurrent()


### PR DESCRIPTION
This PR fixes broken descriptions in ConfigListScreen without changing the SetupSummary class and making it incompatible with most plugins out there.

Many screens that inherit from ConfigListScreen, used to just define `self["description"] = Label("")` and have descriptions properly displayed and updated for every configList entry. This is done by a hook in the SetupSummary class (which is called inside the createSummary method in ConfigListScreen). By moving this hook from SetupSummary to the Setup class with commit 93e1f6784f225b2e85eb9a0619df123f2460b30b in plugins like Videomode the descriptions were disappeared. Then commit https://github.com/OpenPLi/enigma2/commit/643d12de290732844295a6b6ab2aa34378e4e710 was done to bring them back, by redefining the same methods already defined from parent classes. Apart from the obvious problem (code replication), this was not done (it's not possible) for every other plugin out there!!!

In this PR, both of the above commits are reverted and a proper fix for the HdmiCECSetup screen is applied. The special thing about descriptions is this screen is that we want some extra text to be displayed along with the description is each configList entry). 

This bug is almost 3 months old, but I just noticed it yesterday. But report here: https://github.com/OpenPLi/enigma2/commit/93e1f6784f225b2e85eb9a0619df123f2460b30b#commitcomment-65416190

Note: The current code in the the setup and config/confgilist/confgilistscreen classes is like spaghetti. Competitive images have made significant updates the past couple of years in this code, but these updates haven't find their way to openpli. I plan to bring these updates here, after the python3 transition is made. So, for now do now make any significant changes to this code. Thanks.