### PR TITLE
Set description in ConfigListScreen

### DIFF
--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -206,6 +206,8 @@ class ConfigListScreen:
 		elif "VKeyIcon" in self:
 			self["VirtualKB"].setEnabled(False)
 			self["VKeyIcon"].boolean = False
+		if "description" in self:
+			self["description"].text = self.getCurrentDescription()
 
 	def KeyText(self):
 		self["config"].hideHelp()

--- a/lib/python/Plugins/SystemPlugins/HdmiCEC/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/HdmiCEC/plugin.py
@@ -34,7 +34,7 @@ class HdmiCECSetupScreen(Screen, ConfigListScreen):
 
 		self.list = []
 		self.logpath_entry = None
-		ConfigListScreen.__init__(self, self.list, session=self.session, on_change = self.changedEntry)
+		ConfigListScreen.__init__(self, self.list, session=self.session, on_change=self.createSetup)
 		self.createSetup()
 		self.updateAddress()
 
@@ -65,24 +65,13 @@ class HdmiCECSetupScreen(Screen, ConfigListScreen):
 			if config.hdmicec.debug.value != "0":
 				self.list.append(self.logpath_entry)
 		self["config"].list = self.list
-		self["config"].l.setList(self.list)
-
-	def changedEntry(self):
-		self.createSetup()
-
-	# for summary:
-	def getCurrentEntry(self):
-		self.updateDescription()
-		return ConfigListScreen.getCurrentEntry(self)
 
 	def createSummary(self):
 		from Screens.Setup import SetupSummary
 		return SetupSummary
-	###
 
-	def updateDescription(self):
-		text = "%s\n%s\n\n%s" % (self.current_address, self.fixed_address, self.getCurrentDescription()) if config.hdmicec.enabled.value else self.getCurrentDescription()
-		self["description"].setText(text)
+	def getCurrentDescription(self):
+		return "%s\n%s\n\n%s" % (self.current_address, self.fixed_address, self["config"].getCurrent()[2]) if config.hdmicec.enabled.value else self["config"].getCurrent()[2]
 
 	def keyGo(self):
 		for x in self["config"].list:
@@ -118,7 +107,7 @@ class HdmiCECSetupScreen(Screen, ConfigListScreen):
 			self.fixed_address = _("Press yellow button to set CEC address again")
 		else:
 			self.fixed_address = _("Using fixed address") + ":\t" + config.hdmicec.fixed_physical_address.value
-		self.updateDescription()
+		self["description"].text = self.getCurrentDescription()
 
 	def logPath(self, res):
 		if res is not None:

--- a/lib/python/Plugins/SystemPlugins/Videomode/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Videomode/plugin.py
@@ -26,7 +26,7 @@ class VideoSetup(Screen, ConfigListScreen):
 		self.onHide.append(self.stopHotplug)
 
 		self.list = []
-		ConfigListScreen.__init__(self, self.list, session=session, on_change=self.changedEntry)
+		ConfigListScreen.__init__(self, self.list, session=session, on_change=self.createSetup)
 
 		from Components.ActionMap import ActionMap
 		self["actions"] = ActionMap(["SetupActions", "MenuActions"],
@@ -145,7 +145,6 @@ class VideoSetup(Screen, ConfigListScreen):
 			self.list.append(getConfigListEntry(_("Scaler sharpness"), config.av.scaler_sharpness, _("Configure the sharpness of the video scaling.")))
 
 		self["config"].list = self.list
-		self["config"].l.setList(self.list)
 
 	def keyLeft(self):
 		ConfigListScreen.keyLeft(self)
@@ -181,18 +180,9 @@ class VideoSetup(Screen, ConfigListScreen):
 		else:
 			self.keySave()
 
-	# for summary:
-	def getCurrentEntry(self):
-		self.updateDescription()
-		return ConfigListScreen.getCurrentEntry(self)
-
 	def createSummary(self):
 		from Screens.Setup import SetupSummary
 		return SetupSummary
-	###
-
-	def updateDescription(self):
-		self["description"].setText("%s" % self.getCurrentDescription())
 
 
 class VideomodeHotplug:

--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -101,12 +101,7 @@ class Setup(ConfigListScreen, Screen):
 
 		ConfigListScreen.__init__(self, self.list, session=session, on_change=self.changedEntry)
 		self.createSetupList()
-		if self.selectionChanged not in self["config"].onSelectionChanged:
-			self["config"].onSelectionChanged.append(self.selectionChanged)
-		self.setTitle(_(self.setup_title))
-
-	def selectionChanged(self):
-		self["description"].text = self.getCurrentDescription() if len(self["config"].getList()) else ""
+		self.title = _(self.setup_title)
 
 	def createSetupList(self):
 		currentItem = self["config"].getCurrent()


### PR DESCRIPTION
This update description on config selection change in ConfigListScreen.
There are many screeen where there is only a defined description but they rely on SetupSummary to display it.
Now the description display in the parent screen has been removed from SetupSummary and this no longer works.
Therefore introduces a description display in ConfigListScreen.
See also: https://github.com/OpenPLi/enigma2/pull/3335