### PR TITLE
Fix ConfigListScreen inheritance order

### DIFF
--- a/lib/python/Plugins/Extensions/DVDBurn/ProjectSettings.py
+++ b/lib/python/Plugins/Extensions/DVDBurn/ProjectSettings.py
@@ -81,7 +81,7 @@ class FileBrowser(Screen, HelpableScreen):
 		self.close(None, False, None)
 
 
-class ProjectSettings(Screen, ConfigListScreen):
+class ProjectSettings(ConfigListScreen, Screen):
 	skin = """
 		<screen name="ProjectSettings" position="center,center" size="560,440" title="Collection settings" >
 			<ePixmap pixmap="buttons/red.png" position="0,0" size="140,40" alphatest="on" />

--- a/lib/python/Plugins/Extensions/GraphMultiEPG/GraphMultiEpgSetup.py
+++ b/lib/python/Plugins/Extensions/GraphMultiEPG/GraphMultiEpgSetup.py
@@ -9,7 +9,7 @@ from Components.ConfigList import ConfigListScreen
 addnotifier = None
 
 
-class GraphMultiEpgSetup(Screen, ConfigListScreen):
+class GraphMultiEpgSetup(ConfigListScreen, Screen):
 	skin = """
 		<screen name="GraphMultiEPGSetup" position="center,center" size="560,490" title="Electronic Program Guide Setup">
 			<ePixmap pixmap="buttons/red.png" position="0,0" size="140,40" alphatest="on" />

--- a/lib/python/Plugins/Extensions/MediaPlayer/settings.py
+++ b/lib/python/Plugins/Extensions/MediaPlayer/settings.py
@@ -56,7 +56,7 @@ class DirectoryBrowser(Screen, HelpableScreen):
 		self.close(False)
 
 
-class MediaPlayerSettings(Screen, ConfigListScreen):
+class MediaPlayerSettings(ConfigListScreen, Screen):
 
 	def __init__(self, session, parent):
 		Screen.__init__(self, session)

--- a/lib/python/Plugins/Extensions/PicturePlayer/ui.py
+++ b/lib/python/Plugins/Extensions/PicturePlayer/ui.py
@@ -145,7 +145,7 @@ class picshow(Screen):
 		self.close()
 
 
-class Pic_Setup(Screen, ConfigListScreen):
+class Pic_Setup(ConfigListScreen, Screen):
 
 	def __init__(self, session):
 		Screen.__init__(self, session)

--- a/lib/python/Plugins/SystemPlugins/DiseqcTester/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/DiseqcTester/plugin.py
@@ -502,7 +502,7 @@ class DiseqcTester(Screen, TuneTest, ResultParser):
 			self["CmdText"].setText(_("Press OK to get further details for %s") % str(self["progress_list"].getCurrent()[1]))
 
 
-class DiseqcTesterTestTypeSelection(Screen, ConfigListScreen):
+class DiseqcTesterTestTypeSelection(ConfigListScreen, Screen):
 
 	def __init__(self, session, feid):
 		Screen.__init__(self, session)

--- a/lib/python/Plugins/SystemPlugins/HdmiCEC/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/HdmiCEC/plugin.py
@@ -5,7 +5,7 @@ from Components.Label import Label
 from Components.Sources.StaticText import StaticText
 
 
-class HdmiCECSetupScreen(Screen, ConfigListScreen):
+class HdmiCECSetupScreen(ConfigListScreen, Screen):
 	def __init__(self, session):
 		Screen.__init__(self, session)
 		self.skinName = "Setup"
@@ -65,10 +65,6 @@ class HdmiCECSetupScreen(Screen, ConfigListScreen):
 			if config.hdmicec.debug.value != "0":
 				self.list.append(self.logpath_entry)
 		self["config"].list = self.list
-
-	def createSummary(self):
-		from Screens.Setup import SetupSummary
-		return SetupSummary
 
 	def getCurrentDescription(self):
 		return "%s\n%s\n\n%s" % (self.current_address, self.fixed_address, self["config"].getCurrent()[2]) if config.hdmicec.enabled.value else self["config"].getCurrent()[2]

--- a/lib/python/Plugins/SystemPlugins/OSD3DSetup/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/OSD3DSetup/plugin.py
@@ -14,7 +14,7 @@ config.plugins.OSD3DSetup.mode = ConfigSelection(choices=modelist, default="auto
 config.plugins.OSD3DSetup.znorm = ConfigInteger(default=0)
 
 
-class OSD3DSetupScreen(Screen, ConfigListScreen):
+class OSD3DSetupScreen(ConfigListScreen, Screen):
 	def __init__(self, session):
 		Screen.__init__(self, session)
 
@@ -47,7 +47,6 @@ class OSD3DSetupScreen(Screen, ConfigListScreen):
 		self.list.append(getConfigListEntry(_("3d mode"), self.mode))
 		self.list.append(getConfigListEntry(_("Depth"), self.znorm))
 		self["config"].list = self.list
-		self["config"].l.setList(self.list)
 
 	def keyLeft(self):
 		ConfigListScreen.keyLeft(self)

--- a/lib/python/Plugins/SystemPlugins/SatelliteEquipmentControl/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/SatelliteEquipmentControl/plugin.py
@@ -9,7 +9,7 @@ from Components.NimManager import nimmanager as nimmgr
 from Components.Sources.StaticText import StaticText
 
 
-class SecParameterSetup(Screen, ConfigListScreen):
+class SecParameterSetup(ConfigListScreen, Screen):
 	def __init__(self, session):
 		Screen.__init__(self, session)
 		self.skinName = ["SecParameterSetup", "Setup"]
@@ -55,7 +55,6 @@ class SecParameterSetup(Screen, ConfigListScreen):
 
 	def createSetup(self):
 		self["config"].list = self.secList
-		self["config"].l.setList(self.secList)
 
 	def resetDefaults(self):
 		for secItem in self.secList:

--- a/lib/python/Plugins/SystemPlugins/SoftwareManager/BackupRestore.py
+++ b/lib/python/Plugins/SystemPlugins/SoftwareManager/BackupRestore.py
@@ -31,7 +31,7 @@ def getBackupFilename():
 	return "enigma2settingsbackup.tar.gz"
 
 
-class BackupScreen(Screen, ConfigListScreen):
+class BackupScreen(ConfigListScreen, Screen):
 	skin = """
 		<screen position="135,144" size="350,310" title="Backup is running" >
 		<widget name="config" position="10,10" size="330,250" transparent="1" scrollbarMode="showOnDemand" />

--- a/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
@@ -323,7 +323,7 @@ class UpdatePluginMenu(Screen):
 			self.session.open(RestoreScreen, runRestore=True)
 
 
-class SoftwareManagerSetup(Screen, ConfigListScreen):
+class SoftwareManagerSetup(ConfigListScreen, Screen):
 
 	skin = """
 		<screen name="SoftwareManagerSetup" position="center,center" size="560,440" title="SoftwareManager setup">
@@ -422,22 +422,6 @@ class SoftwareManagerSetup(Screen, ConfigListScreen):
 			self.session.openWithCallback(self.cancelConfirm, MessageBox, _("Really close without saving settings?"), MessageBox.TYPE_YESNO, timeout=20, default=True)
 		else:
 			self.close()
-
-	# for summary:
-	def changedEntry(self):
-		for x in self.onChangedEntry:
-			x()
-		self.selectionChanged()
-
-	def getCurrentEntry(self):
-		return self["config"].getCurrent()[0]
-
-	def getCurrentValue(self):
-		return str(self["config"].getCurrent()[1].value)
-
-	def createSummary(self):
-		from Screens.Setup import SetupSummary
-		return SetupSummary
 
 
 class SoftwareManagerInfo(Screen):

--- a/lib/python/Plugins/SystemPlugins/TempFanControl/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/TempFanControl/plugin.py
@@ -12,7 +12,7 @@ from Components.FanControl import fancontrol
 import skin
 
 
-class TempFanControl(Screen, ConfigListScreen):
+class TempFanControl(ConfigListScreen, Screen):
 	skin = """
 		<screen position="center,center" size="570,420" title="Temperature and fan control" >
 			<ePixmap pixmap="buttons/red.png" position="0,0" size="140,40" alphatest="on" />

--- a/lib/python/Plugins/SystemPlugins/VideoClippingSetup/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/VideoClippingSetup/plugin.py
@@ -9,7 +9,7 @@ config.plugins.VideoClippingSetup.clip_top = ConfigInteger(default=0)
 config.plugins.VideoClippingSetup.clip_height = ConfigInteger(default=576)
 
 
-class VideoClippingCoordinates(Screen, ConfigListScreen):
+class VideoClippingCoordinates(ConfigListScreen, Screen):
 	skin = """
 	<screen position="0,0" size="e,e" title="Video clipping setup" backgroundColor="transparent">
 		<widget name="config" position="c-175,c-75" size="350,150" foregroundColor="black" backgroundColor="transparent" />
@@ -60,7 +60,6 @@ class VideoClippingCoordinates(Screen, ConfigListScreen):
 		self.list.append(getConfigListEntry(_("top"), self.clip_top))
 		self.list.append(getConfigListEntry(_("height"), self.clip_height))
 		self["config"].list = self.list
-		self["config"].l.setList(self.list)
 
 	def adjustStep(self):
 		self.clip_left.increment = self.clip_step.value

--- a/lib/python/Plugins/SystemPlugins/VideoEnhancement/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/VideoEnhancement/plugin.py
@@ -10,7 +10,7 @@ import os
 import skin
 
 
-class VideoEnhancementSetup(Screen, ConfigListScreen):
+class VideoEnhancementSetup(ConfigListScreen, Screen):
 
 	skin = """
 		<screen name="VideoEnhancementSetup" position="center,center" size="560,440" title="VideoEnhancementSetup">
@@ -245,23 +245,8 @@ class VideoEnhancementSetup(Screen, ConfigListScreen):
 	def keyBlue(self):
 		self.session.openWithCallback(self.keyBlueConfirm, MessageBox, _("Reset video enhancement settings to system defaults?"), MessageBox.TYPE_YESNO, timeout=20, default=False)
 
-	# for summary:
-	def changedEntry(self):
-		for x in self.onChangedEntry:
-			x()
 
-	def getCurrentEntry(self):
-		return self["config"].getCurrent()[0]
-
-	def getCurrentValue(self):
-		return str(self["config"].getCurrent()[1].getText())
-
-	def createSummary(self):
-		from Screens.Setup import SetupSummary
-		return SetupSummary
-
-
-class VideoEnhancementPreview(Screen, ConfigListScreen):
+class VideoEnhancementPreview(ConfigListScreen, Screen):
 	skin = """
 		<screen name="VideoEnhancementPreview" position="center,e-170" size="560,170" title="VideoEnhancementPreview">
 			<ePixmap pixmap="buttons/red.png" position="0,0" size="140,40" alphatest="on" />
@@ -357,22 +342,6 @@ class VideoEnhancementPreview(Screen, ConfigListScreen):
 			else:
 				pass
 		self.close()
-
-	# for summary:
-	def changedEntry(self):
-		for x in self.onChangedEntry:
-			x()
-		self.selectionChanged()
-
-	def getCurrentEntry(self):
-		return self["config"].getCurrent()[0]
-
-	def getCurrentValue(self):
-		return str(self["config"].getCurrent()[1].getText())
-
-	def createSummary(self):
-		from Screens.Setup import SetupSummary
-		return SetupSummary
 
 
 def videoEnhancementSetupMain(session, **kwargs):

--- a/lib/python/Plugins/SystemPlugins/Videomode/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Videomode/plugin.py
@@ -11,7 +11,7 @@ from VideoHardware import video_hw
 config.misc.videowizardenabled = ConfigBoolean(default=True)
 
 
-class VideoSetup(Screen, ConfigListScreen):
+class VideoSetup(ConfigListScreen, Screen):
 
 	def __init__(self, session, hw):
 		Screen.__init__(self, session)
@@ -179,10 +179,6 @@ class VideoSetup(Screen, ConfigListScreen):
 			self.session.openWithCallback(self.confirm, MessageBox, _("Is this video mode ok?"), MessageBox.TYPE_YESNO, timeout=20, default=False)
 		else:
 			self.keySave()
-
-	def createSummary(self):
-		from Screens.Setup import SetupSummary
-		return SetupSummary
 
 
 class VideomodeHotplug:

--- a/lib/python/Screens/AudioSelection.py
+++ b/lib/python/Screens/AudioSelection.py
@@ -19,7 +19,7 @@ FOCUS_CONFIG, FOCUS_STREAMS = range(2)
 [PAGE_AUDIO, PAGE_SUBTITLES] = ["audio", "subtitles"]
 
 
-class AudioSelection(Screen, ConfigListScreen):
+class AudioSelection(ConfigListScreen, Screen):
 	def __init__(self, session, infobar=None, page=PAGE_AUDIO):
 		Screen.__init__(self, session)
 
@@ -229,7 +229,6 @@ class AudioSelection(Screen, ConfigListScreen):
 				conflist.append(getConfigListEntry(_("Subtitle Quickmenu"), ConfigNothing()))
 
 		self["config"].list = conflist
-		self["config"].l.setList(conflist)
 
 		self["streams"].list = streams
 		self["streams"].setIndex(selectedidx)

--- a/lib/python/Screens/AutoDiseqc.py
+++ b/lib/python/Screens/AutoDiseqc.py
@@ -8,7 +8,7 @@ from Components.TuneTest import Tuner
 from enigma import eDVBFrontendParametersSatellite, eDVBResourceManager, eTimer
 
 
-class AutoDiseqc(Screen, ConfigListScreen):
+class AutoDiseqc(ConfigListScreen, Screen):
 	skin = """
 		<screen position="c-250,c-100" size="500,250" title=" ">
 			<widget source="statusbar" render="Label" position="10,5" zPosition="10" size="e-10,60" halign="center" valign="center" font="Regular;22" transparent="1" shadowColor="black" shadowOffset="-1,-1" />
@@ -266,7 +266,6 @@ class AutoDiseqc(Screen, ConfigListScreen):
 		ConfigListScreen.__init__(self, self.list, session=self.session)
 
 		self["config"].list = self.list
-		self["config"].l.setList(self.list)
 
 		self["key_red"] = StaticText(_("Abort"))
 

--- a/lib/python/Screens/Ci.py
+++ b/lib/python/Screens/Ci.py
@@ -519,7 +519,7 @@ class CiSelection(Screen):
 		self.close()
 
 
-class PermanentPinEntry(Screen, ConfigListScreen):
+class PermanentPinEntry(ConfigListScreen, Screen):
 	def __init__(self, session, pin, pin_slot):
 		Screen.__init__(self, session)
 		self.skinName = ["ParentalControlChangePin", "Setup"]
@@ -563,20 +563,3 @@ class PermanentPinEntry(Screen, ConfigListScreen):
 
 	def cancel(self):
 		self.close(None)
-
-	def keyNumberGlobal(self, number):
-		ConfigListScreen.keyNumberGlobal(self, number)
-
-	def changedEntry(self):
-		for x in self.onChangedEntry:
-			x()
-
-	def getCurrentEntry(self):
-		return self["config"].getCurrent()[0]
-
-	def getCurrentValue(self):
-		return str(self["config"].getCurrent()[1].getText())
-
-	def createSummary(self):
-		from Screens.Setup import SetupSummary
-		return SetupSummary

--- a/lib/python/Screens/InputDeviceSetup.py
+++ b/lib/python/Screens/InputDeviceSetup.py
@@ -11,7 +11,7 @@ from Tools.Directories import resolveFilename, SCOPE_CURRENT_SKIN
 from Tools.LoadPixmap import LoadPixmap
 
 
-class InputDeviceSelection(Screen, HelpableScreen):
+class InputDeviceSelection(HelpableScreen, Screen):
 	skin = """
 	<screen name="InputDeviceSelection" position="center,center" size="560,400">
 		<ePixmap pixmap="buttons/red.png" position="0,0" size="140,40" alphatest="on"/>
@@ -132,7 +132,7 @@ class InputDeviceSelection(Screen, HelpableScreen):
 		self.updateList()
 
 
-class InputDeviceSetup(Screen, ConfigListScreen):
+class InputDeviceSetup(ConfigListScreen, Screen):
 
 	skin = """
 		<screen name="InputDeviceSetup" position="center,center" size="560,440">
@@ -272,25 +272,14 @@ class InputDeviceSetup(Screen, ConfigListScreen):
 			self.session.openWithCallback(self.cancelConfirm, MessageBox, _("Really close without saving settings?"), MessageBox.TYPE_YESNO, timeout=20, default=True)
 		else:
 			self.close()
-	# for summary:
 
 	def changedEntry(self):
 		for x in self.onChangedEntry:
 			x()
 		self.selectionChanged()
 
-	def getCurrentEntry(self):
-		return self["config"].getCurrent()[0]
 
-	def getCurrentValue(self):
-		return str(self["config"].getCurrent()[1].value)
-
-	def createSummary(self):
-		from Screens.Setup import SetupSummary
-		return SetupSummary
-
-
-class RemoteControlType(Screen, ConfigListScreen):
+class RemoteControlType(ConfigListScreen, Screen):
 	rcList = [
 			("0", _("Default")),
 			("4", _("DMM normal")),

--- a/lib/python/Screens/InstallWizard.py
+++ b/lib/python/Screens/InstallWizard.py
@@ -13,7 +13,7 @@ config.misc.installwizard.opkgloaded = ConfigBoolean(default=False)
 config.misc.installwizard.channellistdownloaded = ConfigBoolean(default=False)
 
 
-class InstallWizard(Screen, ConfigListScreen):
+class InstallWizard(ConfigListScreen, Screen):
 
 	STATE_UPDATE = 0
 	STATE_CHOISE_CHANNELLIST = 1
@@ -105,7 +105,6 @@ class InstallWizard(Screen, ConfigListScreen):
 			if nimmanager.getEnabledNimListOfType("DVB-C"):
 				self.list.append(getConfigListEntry(_("Do a cable service scan now"), self.cablescan))
 		self["config"].list = self.list
-		self["config"].l.setList(self.list)
 
 	def keyLeft(self):
 		if self.index == 0:

--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -314,21 +314,6 @@ class MovieBrowserConfiguration(ConfigListScreen, Screen):
 	def descriptions(self):
 		self["description"].setText(self["config"].getCurrent() and len(self["config"].getCurrent()) > 2 and self["config"].getCurrent()[2] or "")
 
-	# for summary:
-	def changedEntry(self):
-		for x in self.onChangedEntry:
-			x()
-
-	def getCurrentEntry(self):
-		return self["config"].getCurrent()[0]
-
-	def getCurrentValue(self):
-		return str(self["config"].getCurrent()[1].getText())
-
-	def createSummary(self):
-		from Screens.Setup import SetupSummary
-		return SetupSummary
-
 	def save(self):
 		self.saveAll()
 		cfg = self.cfg

--- a/lib/python/Screens/NetworkSetup.py
+++ b/lib/python/Screens/NetworkSetup.py
@@ -209,7 +209,7 @@ class NetworkAdapterSelection(Screen, HelpableScreen):
 					self.session.openWithCallback(self.AdapterSetupClosed, NetworkWizard, selection[0])
 
 
-class NameserverSetup(Screen, ConfigListScreen, HelpableScreen):
+class NameserverSetup(ConfigListScreen, HelpableScreen, Screen):
 	def __init__(self, session):
 		Screen.__init__(self, session)
 		HelpableScreen.__init__(self)
@@ -259,7 +259,6 @@ class NameserverSetup(Screen, ConfigListScreen, HelpableScreen):
 			i += 1
 
 		self["config"].list = self.list
-		self["config"].l.setList(self.list)
 
 	def ok(self):
 		iNetwork.clearNameservers()
@@ -292,7 +291,7 @@ class NameserverSetup(Screen, ConfigListScreen, HelpableScreen):
 			self.createSetup()
 
 
-class AdapterSetup(Screen, ConfigListScreen, HelpableScreen):
+class AdapterSetup(ConfigListScreen, HelpableScreen, Screen):
 	def __init__(self, session, networkinfo, essid=None):
 		Screen.__init__(self, session)
 		HelpableScreen.__init__(self)
@@ -485,7 +484,6 @@ class AdapterSetup(Screen, ConfigListScreen, HelpableScreen):
 									self.list.append(self.encryptionType)
 							self.list.append(self.encryptionKey)
 		self["config"].list = self.list
-		self["config"].l.setList(self.list)
 
 	def KeyBlue(self):
 		self.session.openWithCallback(self.NameserverSetupClosed, NameserverSetup)

--- a/lib/python/Screens/ParentalControlSetup.py
+++ b/lib/python/Screens/ParentalControlSetup.py
@@ -27,7 +27,7 @@ class ProtectedScreen:
 		self.close(None)
 
 
-class ParentalControlSetup(Screen, ConfigListScreen, ProtectedScreen):
+class ParentalControlSetup(ConfigListScreen, ProtectedScreen, Screen):
 	def __init__(self, session):
 		Screen.__init__(self, session)
 		ProtectedScreen.__init__(self)
@@ -90,7 +90,6 @@ class ParentalControlSetup(Screen, ConfigListScreen, ProtectedScreen):
 			self.changePin = getConfigListEntry(_("Enable parental protection"), NoSave(ConfigNothing()))
 			self.list.append(self.changePin)
 		self["config"].list = self.list
-		self["config"].setList(self.list)
 
 	def keyOK(self):
 		if self["config"].l.getCurrentSelection() == self.changePin:
@@ -144,21 +143,6 @@ class ParentalControlSetup(Screen, ConfigListScreen, ProtectedScreen):
 
 	def keyNumberGlobal(self, number):
 		pass
-
-	# for summary:
-	def changedEntry(self):
-		for x in self.onChangedEntry:
-			x()
-
-	def getCurrentEntry(self):
-		return self["config"].getCurrent()[0]
-
-	def getCurrentValue(self):
-		return str(self["config"].getCurrent()[1].getText())
-
-	def createSummary(self):
-		from Screens.Setup import SetupSummary
-		return SetupSummary
 
 	def oldPinEntered(self, answer):
 		if answer:

--- a/lib/python/Screens/RecordPaths.py
+++ b/lib/python/Screens/RecordPaths.py
@@ -9,7 +9,7 @@ from Tools.Directories import fileExists
 from Components.UsageConfig import preferredPath
 
 
-class RecordPathsSettings(Screen, ConfigListScreen):
+class RecordPathsSettings(ConfigListScreen, Screen):
 	skin = """
 		<screen name="RecordPathsSettings" position="160,150" size="450,200" title="Recording paths">
 			<ePixmap pixmap="buttons/red.png" position="10,0" size="140,40" alphatest="on" />

--- a/lib/python/Screens/Satconfig.py
+++ b/lib/python/Screens/Satconfig.py
@@ -22,7 +22,7 @@ from time import mktime, localtime, time
 from datetime import datetime
 
 
-class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
+class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 	def createSimpleSetup(self, list, mode):
 		nim = self.nimConfig
 

--- a/lib/python/Screens/TaskView.py
+++ b/lib/python/Screens/TaskView.py
@@ -12,7 +12,7 @@ from Screens.MessageBox import MessageBox
 import Screens.Standby
 
 
-class JobView(InfoBarNotifications, Screen, ConfigListScreen):
+class JobView(InfoBarNotifications, ConfigListScreen, Screen):
 	def __init__(self, session, job, parent=None, cancelable=True, backgroundable=True, afterEventChangeable=True):
 		Screen.__init__(self, session, parent)
 		InfoBarNotifications.__init__(self)

--- a/lib/python/Screens/TimeDateInput.py
+++ b/lib/python/Screens/TimeDateInput.py
@@ -7,7 +7,7 @@ import time
 import datetime
 
 
-class TimeDateInput(Screen, ConfigListScreen):
+class TimeDateInput(ConfigListScreen, Screen):
 	def __init__(self, session, config_time=None, config_date=None):
 		Screen.__init__(self, session)
 		self.setTitle(_("Date/time input"))

--- a/lib/python/Screens/TimerEntry.py
+++ b/lib/python/Screens/TimerEntry.py
@@ -25,7 +25,7 @@ from datetime import datetime
 import urllib
 
 
-class TimerEntry(Screen, ConfigListScreen):
+class TimerEntry(ConfigListScreen, Screen):
 	def __init__(self, session, timer):
 		Screen.__init__(self, session)
 		self.timer = timer
@@ -245,7 +245,6 @@ class TimerEntry(Screen, ConfigListScreen):
 			self.list.append(getConfigListEntry(_("Recording type"), self.timerentry_recordingtype))
 
 		self[widget].list = self.list
-		self[widget].l.setList(self.list)
 
 	def newConfig(self):
 		print "[TimerEdit] newConfig", self["config"].getCurrent()


### PR DESCRIPTION
To fix Summary screens and delete dublicate methods in subclasses.
In many places Screen inherit after ConfigListScreen and therefore its empty method createSummary override the correct method createSummary in ConfigListScreen and Summary screens do not work, or in screens are created unnecessarily duplicate method createSummary.
This allows you to delete unnecessary methods and fix Summary screens where they have not worked so far.