### PR TITLE
Remove unnecessary l.setList call for config list

### DIFF
--- a/lib/python/Plugins/SystemPlugins/PositionerSetup/ui.py
+++ b/lib/python/Plugins/SystemPlugins/PositionerSetup/ui.py
@@ -1403,7 +1403,6 @@ class ONIDTSIDScreen(ConfigListScreen, Screen):
 		self.list.append(getConfigListEntry(_("ONID"), self.transponderOnid))
 		self.list.append(getConfigListEntry(_("TSID"), self.transponderTsid))
 		self["config"].list = self.list
-		self["config"].l.setList(self.list)
 
 	def keyGo(self):
 		onid = int(self.transponderOnid.value)
@@ -1603,7 +1602,6 @@ class TunerScreen(ConfigListScreen, Screen):
 			currtp = self.transponderToString([None, self.scan_sat.frequency.value, self.scan_sat.symbolrate.value, self.scan_sat.polarization.value])
 			self.tuning.transponder.setValue(currtp)
 		self["config"].list = self.list
-		self["config"].l.setList(self.list)
 
 	def tuningSatChanged(self, *parm):
 		self.updateTransponders()

--- a/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
@@ -292,7 +292,6 @@ class Satfinder(ScanSetup, ServiceScan):
 				self.preDefTransponderAtscEntry = getConfigListEntry(_('Transponder'), self.ATSCTransponders)
 				self.list.append(self.preDefTransponderAtscEntry)
 		self["config"].list = self.list
-		self["config"].l.setList(self.list)
 
 	def createConfig(self, foo):
 		self.tuning_type = ConfigSelection(default="predefined_transponder", choices=[("single_transponder", _("User defined transponder")), ("predefined_transponder", _("Predefined transponder"))])

--- a/lib/python/Screens/InputDeviceSetup.py
+++ b/lib/python/Screens/InputDeviceSetup.py
@@ -222,7 +222,6 @@ class InputDeviceSetup(ConfigListScreen, Screen):
 				self["config"].invalidate(self.nameEntry)
 
 		self["config"].list = self.list
-		self["config"].l.setList(self.list)
 		if not self.selectionChanged in self["config"].onSelectionChanged:
 			self["config"].onSelectionChanged.append(self.selectionChanged)
 		self.selectionChanged()

--- a/lib/python/Screens/Satconfig.py
+++ b/lib/python/Screens/Satconfig.py
@@ -318,7 +318,6 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 			self.list.append(getConfigListEntry(_("Force legacy signal stats"), self.nimConfig.force_legacy_signal_stats, _("If set to 'yes' signal values (SNR, etc) will be calculated from API V3. This is an old API version that has now been superseded.")))
 
 		self["config"].list = self.list
-		self["config"].l.setList(self.list)
 		self.setTextKeyYellow()
 
 	def newConfig(self):

--- a/lib/python/Screens/ScanSetup.py
+++ b/lib/python/Screens/ScanSetup.py
@@ -869,7 +869,6 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 		self.list.append(getConfigListEntry(_("Clear before scan"), self.scan_clearallservices, _("Remove the services on scanned transponders before re-adding services?")))
 		self.list.append(getConfigListEntry(_("Only free scan"), self.scan_onlyfree, _("Choose whether to scan for free services only or whether to include paid/encrypted services too.")))
 		self["config"].list = self.list
-		self["config"].l.setList(self.list)
 
 	def Satexists(self, tlist, pos):
 		for x in tlist:

--- a/lib/python/Screens/SetupFallbacktuner.py
+++ b/lib/python/Screens/SetupFallbacktuner.py
@@ -208,7 +208,6 @@ class SetupFallbacktuner(ConfigListScreen, Screen):
 						config.usage.remote_fallback_atsc,
 						_("URL of fallback remote receiver")))
 		self["config"].list = self.list
-		self["config"].l.setList(self.list)
 
 	def selectionChanged(self):
 		if self.force_update_list:

--- a/lib/python/Screens/SleepTimerEdit.py
+++ b/lib/python/Screens/SleepTimerEdit.py
@@ -114,7 +114,6 @@ class SleepTimerEdit(ConfigListScreen, Screen):
 					self.list.append(getConfigListEntry(_("Wakeup time"),
 						config.usage.wakeup_time[i]))
 		self["config"].list = self.list
-		self["config"].l.setList(self.list)
 
 	def ok(self):
 		if self["config"].isChanged():


### PR DESCRIPTION
It is already used in setList so there is no need to duplicate it.