### PR TITLE
[StartWizard] Text strings do not have a decode() method

### DIFF
--- a/lib/python/Screens/StartWizard.py
+++ b/lib/python/Screens/StartWizard.py
@@ -139,7 +139,6 @@ class AutoInstallWizard(Screen):
 			self.appClosed(True)
 
 	def dataAvail(self, data):
-		data = data.decode()
 		self["AboutScrollLabel"].appendText(data)
 		self.logfile.write(data)
 


### PR DESCRIPTION
The dataAvail() method does not get any binary data from console. It just gets text strings, so decode() does not apply here.

Introduced with https://github.com/OpenPLi/enigma2/commit/3271f2495b4a19b2a8106911c1a2c8725fa1ab1c#diff-53bf8a17de75f91bd1f609dceae2b971ce6c1699fdef13b9862864c51ddb5cbbR142

Fixes crash:

```
Traceback (most recent call last):
  File "/usr/lib/enigma2/python/Screens/StartWizard.py", line 149, in appClosed
  File "/usr/lib/enigma2/python/Screens/StartWizard.py", line 142, in dataAvail
AttributeError: 'str' object has no attribute 'decode'
```