### PR TITLE
[StartWizard] Fix language restoration from backup file

### DIFF
--- a/lib/python/Screens/StartWizard.py
+++ b/lib/python/Screens/StartWizard.py
@@ -51,6 +51,7 @@ def setLanguageFromBackup(backupfile):
 		for member in tar.getmembers():
 			if member.name == 'etc/enigma2/settings':
 				for line in tar.extractfile(member):
+					line = line.decode()
 					if line.startswith('config.osd.language'):
 						languageToSelect = line.strip().split('=')[1]
 						if languageToSelect:


### PR DESCRIPTION
Not tested, but "extractfiles() returns bytes, so "line" should be decoded in order to search for text strings inside