### PR TITLE
[config] Delete broken "getKeys" method in ConfigDictionarySet()

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -1404,9 +1404,6 @@ class ConfigDictionarySet(ConfigElement):
 		self.dirs = {}
 		self.value = self.default
 
-	def getKeys(self):
-		return self.dir_pathes
-
 	def setValue(self, value):
 		if isinstance(value, dict):
 			self.dirs = value


### PR DESCRIPTION
This is broken (self.dir_pathes is not defined) since its introduction with commit https://github.com/OpenPLi/enigma2/commit/a4bdd82f42a82afc12cb14cd4f9e69d76710a79e#diff-457ecce5cf2c6ddf9bb498f7c9fd7e3ad9b37d3a30188b40b206ea69ec175d44R1302 back in 2016. This method is not used anywhere in enigma2 though, so nobody noticed it. Not sure what was the intension of the author, so better remove the broken method completely instead of trying to fix it.