### PR TITLE
[StartWizard] Check for bytes/strings in dataAvail()

### DIFF
--- a/lib/python/Screens/StartWizard.py
+++ b/lib/python/Screens/StartWizard.py
@@ -140,6 +140,8 @@ class AutoInstallWizard(Screen):
 			self.appClosed(True)
 
 	def dataAvail(self, data):
+		if isinstance(data, bytes):
+			data = data.decode()
 		self["AboutScrollLabel"].appendText(data)
 		self.logfile.write(data)
 


### PR DESCRIPTION
eConsoleAppContainer() passes bytes to dataAvail(), but we also use the latter directly in appClosed() with text strings. So, we have to check what kind of data is received.

thanks @athoik