### PR TITLE
Rework "PluginDescriptor"

### DIFF
--- a/lib/python/Components/Network.py
+++ b/lib/python/Components/Network.py
@@ -609,7 +609,7 @@ class Network:
 	def msgPlugins(self):
 		if self.config_ready is not None:
 			for p in plugins.getPlugins(PluginDescriptor.WHERE_NETWORKCONFIG_READ):
-				p.__call__(reason=self.config_ready)
+				p(reason=self.config_ready)
 
 	def hotplug(self, event):
 		interface = event['INTERFACE']

--- a/lib/python/Components/PluginComponent.py
+++ b/lib/python/Components/PluginComponent.py
@@ -27,7 +27,7 @@ class PluginComponent:
 			for x in plugin.where:
 				insort(self.plugins.setdefault(x, []), plugin)
 				if x == PluginDescriptor.WHERE_AUTOSTART:
-					plugin.__call__(reason=0)
+					plugin(reason=0)
 		else:
 			self.restartRequired = True
 
@@ -133,7 +133,7 @@ class PluginComponent:
 	def getPluginsForMenu(self, menuid):
 		res = []
 		for p in self.getPlugins(PluginDescriptor.WHERE_MENU):
-			res += p.__call__(menuid)
+			res += p(menuid)
 		return res
 
 	def clearPluginList(self):

--- a/lib/python/Components/Scanner.py
+++ b/lib/python/Components/Scanner.py
@@ -152,7 +152,7 @@ def scanDevice(mountpoint):
 	scanner = []
 
 	for p in plugins.getPlugins(PluginDescriptor.WHERE_FILESCAN):
-		l = p.__call__()
+		l = p()
 		if not isinstance(l, list):
 			l = [l]
 		scanner += l
@@ -209,7 +209,7 @@ def openList(session, files):
 	scanner = []
 
 	for p in plugins.getPlugins(PluginDescriptor.WHERE_FILESCAN):
-		l = p.__call__()
+		l = p()
 		if not isinstance(l, list):
 			scanner.append(l)
 		else:

--- a/lib/python/Plugins/Extensions/GraphMultiEPG/GraphMultiEpg.py
+++ b/lib/python/Plugins/Extensions/GraphMultiEPG/GraphMultiEpg.py
@@ -1173,7 +1173,7 @@ class GraphMultiEPG(Screen, HelpableScreen):
 		event = self["list"].getCurrent()[0]
 		if event:
 			menu = [(p.name, boundFunction(self.runPlugin, p)) for p in plugins.getPlugins(where=PluginDescriptor.WHERE_EVENTINFO)
-				if 'selectedevent' in p.__call__.__code__.co_varnames]
+				if 'selectedevent' in p.fnc.__code__.co_varnames]
 			if menu:
 				text += ": %s" % event.getEventName()
 			keys = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "red", "green", "yellow"][:len(menu)] + (len(menu) - 13) * [""] + keys

--- a/lib/python/Plugins/Extensions/GraphMultiEPG/GraphMultiEpg.py
+++ b/lib/python/Plugins/Extensions/GraphMultiEPG/GraphMultiEpg.py
@@ -1187,7 +1187,7 @@ class GraphMultiEPG(Screen, HelpableScreen):
 
 	def runPlugin(self, plugin):
 		event = self["list"].getCurrent()
-		plugin.__call__(session=self.session, selectedevent=event)
+		plugin(session=self.session, selectedevent=event)
 
 	def openTimerOverview(self):
 		self.session.open(TimerEditList)

--- a/lib/python/Plugins/Plugin.py
+++ b/lib/python/Plugins/Plugin.py
@@ -86,7 +86,11 @@ class PluginDescriptor:
 
 		self.wakeupfnc = wakeupfnc
 
-		self.__call__ = fnc
+		self.fnc = fnc
+
+	def __call__(self, *args, **kwargs):
+		if callable(self.fnc):
+			return self.fnc(*args, **kwargs)
 
 	def updateIcon(self, path):
 		self.path = path
@@ -103,10 +107,10 @@ class PluginDescriptor:
 			return self._icon
 
 	def __eq__(self, other):
-		return self.__call__ == other.__call__
+		return self.fnc == other.fnc
 
 	def __ne__(self, other):
-		return self.__call__ != other.__call__
+		return self.fnc != other.fnc
 
 	def __lt__(self, other):
 		if self.weight < other.weight:

--- a/lib/python/Plugins/Plugin.py
+++ b/lib/python/Plugins/Plugin.py
@@ -88,9 +88,6 @@ class PluginDescriptor:
 
 		self.__call__ = fnc
 
-	def __call__(self, *args, **kwargs):
-		return
-
 	def updateIcon(self, path):
 		self.path = path
 

--- a/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
@@ -124,15 +124,15 @@ class UpdatePluginMenu(Screen):
 			self.list.append(("system-restore", _("Restore system settings"), _("Restore your receiver settings.") + self.oktext, None))
 			self.list.append(("opkg-install", _("Install local extension"), _("Scan for local extensions and install them.") + self.oktext, None))
 			for p in plugins.getPlugins(PluginDescriptor.WHERE_SOFTWAREMANAGER):
-				if "SoftwareSupported" in p.__call__:
-					callFnc = p.__call__["SoftwareSupported"](None)
+				if "SoftwareSupported" in p.fnc:
+					callFnc = p.fnc["SoftwareSupported"](None)
 					if callFnc is not None:
-						if "menuEntryName" in p.__call__:
-							menuEntryName = p.__call__["menuEntryName"](None)
+						if "menuEntryName" in p.fnc:
+							menuEntryName = p.fnc["menuEntryName"](None)
 						else:
 							menuEntryName = _('Extended Software')
-						if "menuEntryDescription" in p.__call__:
-							menuEntryDescription = p.__call__["menuEntryDescription"](None)
+						if "menuEntryDescription" in p.fnc:
+							menuEntryDescription = p.fnc["menuEntryDescription"](None)
 						else:
 							menuEntryDescription = _('Extended Software Plugin')
 						self.list.append(('default-plugin', menuEntryName, menuEntryDescription + self.oktext, callFnc))
@@ -146,15 +146,15 @@ class UpdatePluginMenu(Screen):
 				self.list.append(("opkg-manager", _("Packet management"), _("View, install and remove available or installed packages.") + self.oktext, None))
 			self.list.append(("opkg-source", _("Select update source"), _("Edit the update source address.") + self.oktext, None))
 			for p in plugins.getPlugins(PluginDescriptor.WHERE_SOFTWAREMANAGER):
-				if "AdvancedSoftwareSupported" in p.__call__:
-					callFnc = p.__call__["AdvancedSoftwareSupported"](None)
+				if "AdvancedSoftwareSupported" in p.fnc:
+					callFnc = p.fnc["AdvancedSoftwareSupported"](None)
 					if callFnc is not None:
-						if "menuEntryName" in p.__call__:
-							menuEntryName = p.__call__["menuEntryName"](None)
+						if "menuEntryName" in p.fnc:
+							menuEntryName = p.fnc["menuEntryName"](None)
 						else:
 							menuEntryName = _('Advanced software')
-						if "menuEntryDescription" in p.__call__:
-							menuEntryDescription = p.__call__["menuEntryDescription"](None)
+						if "menuEntryDescription" in p.fnc:
+							menuEntryDescription = p.fnc["menuEntryDescription"](None)
 						else:
 							menuEntryDescription = _('Advanced software plugin')
 						self.list.append(('advanced-plugin', menuEntryName, menuEntryDescription + self.oktext, callFnc))

--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -660,7 +660,7 @@ class ChannelContextMenu(Screen):
 			return 0
 
 	def runPlugin(self, plugin):
-		plugin.__call__(session=self.session, service=self.csel.getCurrentSelection())
+		plugin(session=self.session, service=self.csel.getCurrentSelection())
 		self.close()
 
 

--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -733,7 +733,7 @@ class ChannelSelectionEPG(InfoBarHotkey):
 
 	def getEPGPluginList(self, getAll=False):
 		pluginlist = [(p.name, boundFunction(self.runPlugin, p), p.description or p.name) for p in plugins.getPlugins(where=PluginDescriptor.WHERE_EVENTINFO)
-				if 'selectedevent' not in p.__call__.__code__.co_varnames] or []
+				if 'selectedevent' not in p.fnc.__code__.co_varnames] or []
 		from Components.ServiceEventTracker import InfoBarCount
 		if getAll or InfoBarCount == 1:
 			pluginlist.append((_("Show EPG for current channel..."), self.openSingleServiceEPG, _("Display EPG list for current channel")))

--- a/lib/python/Screens/EpgSelection.py
+++ b/lib/python/Screens/EpgSelection.py
@@ -159,7 +159,7 @@ class EPGSelection(Screen):
 
 	def runPlugin(self, plugin):
 		event = self["list"].getCurrent()
-		plugin.__call__(session=self.session, selectedevent=event)
+		plugin(session=self.session, selectedevent=event)
 
 	def openTimerOverview(self):
 		self.session.open(TimerEditList)

--- a/lib/python/Screens/EpgSelection.py
+++ b/lib/python/Screens/EpgSelection.py
@@ -143,7 +143,7 @@ class EPGSelection(Screen):
 		event = self["list"].getCurrent()[0]
 		if event:
 			menu = [(p.name, boundFunction(self.runPlugin, p)) for p in plugins.getPlugins(where=PluginDescriptor.WHERE_EVENTINFO)
-				if 'selectedevent' in p.__call__.__code__.co_varnames]
+				if 'selectedevent' in p.fnc.__code__.co_varnames]
 			if menu:
 				text += ": %s" % event.getEventName()
 		if self.type == EPG_TYPE_MULTI:

--- a/lib/python/Screens/EventView.py
+++ b/lib/python/Screens/EventView.py
@@ -323,7 +323,7 @@ class EventViewBase:
 				self.session.openWithCallback(boxAction, ChoiceBox, title=text, list=menu, windowTitle=_("Event view context menu"))
 
 	def runPlugin(self, plugin):
-		plugin.__call__(session=self.session, service=self.currentService, event=self.event, eventName=self.event.getEventName())
+		plugin(session=self.session, service=self.currentService, event=self.event, eventName=self.event.getEventName())
 
 
 class EventViewSimple(Screen, EventViewBase):

--- a/lib/python/Screens/EventView.py
+++ b/lib/python/Screens/EventView.py
@@ -311,8 +311,8 @@ class EventViewBase:
 		if self.event:
 			text = _("Select action")
 			menu = [(p.name, boundFunction(self.runPlugin, p)) for p in plugins.getPlugins(where=PluginDescriptor.WHERE_EVENTINFO)
-				if 'servicelist' not in p.__call__.__code__.co_varnames
-					if 'selectedevent' not in p.__call__.__code__.co_varnames]
+				if 'servicelist' not in p.fnc.__code__.co_varnames
+					if 'selectedevent' not in p.fnc.__code__.co_varnames]
 			if len(menu) == 1:
 				menu and menu[0][1]()
 			elif len(menu) > 1:

--- a/lib/python/Screens/Hotkey.py
+++ b/lib/python/Screens/Hotkey.py
@@ -124,7 +124,7 @@ def getHotkeyFunctions():
 	pluginlist = plugins.getPlugins(PluginDescriptor.WHERE_EVENTINFO)
 	pluginlist.sort(key=lambda p: p.name)
 	for plugin in pluginlist:
-		if plugin.name not in twinPlugins and plugin.path and 'selectedevent' not in plugin.__call__.__code__.co_varnames:
+		if plugin.name not in twinPlugins and plugin.path and 'selectedevent' not in plugin.fnc.__code__.co_varnames:
 			if plugin.path[24:] in twinPaths:
 				twinPaths[plugin.path[24:]] += 1
 			else:
@@ -623,7 +623,7 @@ class InfoBarHotkey():
 				pluginlist = plugins.getPlugins(PluginDescriptor.WHERE_EVENTINFO)
 				pluginlist.sort(key=lambda p: p.name)
 				for plugin in pluginlist:
-					if plugin.name not in twinPlugins and plugin.path and 'selectedevent' not in plugin.__call__.__code__.co_varnames:
+					if plugin.name not in twinPlugins and plugin.path and 'selectedevent' not in plugin.fnc.__code__.co_varnames:
 						if plugin.path[24:] in twinPaths:
 							twinPaths[plugin.path[24:]] += 1
 						else:

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -1204,7 +1204,7 @@ class InfoBarEPG:
 				self.session.open(EPGSelection, ref)
 
 	def runPlugin(self, plugin):
-		plugin.__call__(session=self.session, servicelist=self.servicelist)
+		plugin(session=self.session, servicelist=self.servicelist)
 
 	def showEventInfoPlugins(self):
 		pluginlist = self.getEPGPluginList()
@@ -2282,9 +2282,9 @@ class InfoBarPlugins:
 
 	def runPlugin(self, plugin):
 		if isinstance(self, InfoBarChannelSelection):
-			plugin.__call__(session=self.session, servicelist=self.servicelist)
+			plugin(session=self.session, servicelist=self.servicelist)
 		else:
-			plugin.__call__(session=self.session)
+			plugin(session=self.session)
 
 
 from Components.Task import job_manager
@@ -3356,7 +3356,7 @@ class InfoBarTeletextPlugin:
 		self.teletext_plugin = None
 
 		for p in plugins.getPlugins(PluginDescriptor.WHERE_TELETEXT):
-			self.teletext_plugin = p.__call__
+			self.teletext_plugin = p
 
 		if self.teletext_plugin is not None:
 			self["TeletextActions"] = HelpableActionMap(self, ["InfobarTeletextActions"],

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -1052,7 +1052,7 @@ class InfoBarEPG:
 
 	def getEPGPluginList(self, getAll=False):
 		pluginlist = [(p.name, boundFunction(self.runPlugin, p), p.description or p.name) for p in plugins.getPlugins(where=PluginDescriptor.WHERE_EVENTINFO)
-				if 'selectedevent' not in p.__call__.__code__.co_varnames] or []
+				if 'selectedevent' not in p.fnc.__code__.co_varnames] or []
 		from Components.ServiceEventTracker import InfoBarCount
 		if getAll or InfoBarCount == 1:
 			pluginlist.append((_("Show EPG for current channel..."), self.openSingleServiceEPG, _("Display EPG list for current channel")))
@@ -2274,7 +2274,7 @@ class InfoBarPlugins:
 	def getPluginList(self):
 		l = []
 		for p in plugins.getPlugins(where=PluginDescriptor.WHERE_EXTENSIONSMENU):
-			args = inspect.getargspec(p.__call__)[0]
+			args = inspect.getfullargspec(p.fnc)[0]
 			if len(args) == 1 or len(args) == 2 and isinstance(self, InfoBarChannelSelection):
 				l.append(((boundFunction(self.getPluginName, p.name), boundFunction(self.runPlugin, p), lambda: True), None, p.name))
 		l.sort(key=lambda e: e[2]) # sort by name

--- a/lib/python/Screens/Menu.py
+++ b/lib/python/Screens/Menu.py
@@ -268,7 +268,7 @@ class Menu(Screen, ProtectedScreen):
 				l.id = (l.name.lower()).replace(' ', '_')
 				if l.id not in id_list:
 					id_list.append(l.id)
-					plugin_list.append((l.name, boundFunction(l.__call__, self.session), l.id, 200))
+					plugin_list.append((l.name, boundFunction(l.fnc, self.session), l.id, 200))
 
 		if self.menuID is not None and "user" in config.usage.menu_sort_mode.value:
 			self.sub_menu_sort = NoSave(ConfigDictionarySet())

--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -428,7 +428,7 @@ class MovieContextMenu(Screen, ProtectedScreen):
 				# Plugins expect a valid selection, so only include them if we selected a non-dir
 				if not(service.flags & eServiceReference.mustDescent):
 					for p in plugins.getPlugins(PluginDescriptor.WHERE_MOVIELIST):
-						append_to_menu(menu, (p.description, boundFunction(p.__call__, session, service)), key="bullet")
+						append_to_menu(menu, (p.description, boundFunction(p, session, service)), key="bullet")
 		if csel.exist_bookmark():
 			append_to_menu(menu, (_("Remove bookmark"), csel.do_addbookmark))
 		else:
@@ -784,7 +784,7 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 				name = name[1:]
 				for p in plugins.getPlugins(PluginDescriptor.WHERE_MOVIELIST):
 					if name == p.name:
-						p.__call__(self.session, item[0])
+						p(self.session, item[0])
 		elif name.startswith('/'):
 			self.gotFilename(name)
 		else:

--- a/lib/python/Screens/NetworkSetup.py
+++ b/lib/python/Screens/NetworkSetup.py
@@ -449,12 +449,12 @@ class AdapterSetup(Screen, ConfigListScreen, HelpableScreen):
 			self.extended = None
 			self.configStrings = None
 			for p in plugins.getPlugins(PluginDescriptor.WHERE_NETWORKSETUP):
-				callFnc = p.__call__["ifaceSupported"](self.iface)
+				callFnc = p.fnc["ifaceSupported"](self.iface)
 				if callFnc is not None:
-					if "WlanPluginEntry" in p.__call__: # internally used only for WLAN Plugin
+					if "WlanPluginEntry" in p.fnc: # internally used only for WLAN Plugin
 						self.extended = callFnc
-						if "configStrings" in p.__call__:
-							self.configStrings = p.__call__["configStrings"]
+						if "configStrings" in p.fnc:
+							self.configStrings = p.fnc["configStrings"]
 						isExistBcmWifi = os.path.exists("/tmp/bcm/" + self.iface)
 						if not isExistBcmWifi:
 							self.hiddenSSID = getConfigListEntry(_("Hidden network"), config.plugins.wlan.hiddenessid)
@@ -832,20 +832,20 @@ class AdapterSetupConfiguration(Screen, HelpableScreen):
 		self.extended = None
 		self.extendedSetup = None
 		for p in plugins.getPlugins(PluginDescriptor.WHERE_NETWORKSETUP):
-			callFnc = p.__call__["ifaceSupported"](self.iface)
+			callFnc = p.fnc["ifaceSupported"](self.iface)
 			if callFnc is not None:
 				self.extended = callFnc
-				if "WlanPluginEntry" in p.__call__: # internally used only for WLAN Plugin
+				if "WlanPluginEntry" in p.fnc: # internally used only for WLAN Plugin
 					menu.append((_("Scan wireless networks"), "scanwlan"))
 					if iNetwork.getAdapterAttribute(self.iface, "up"):
 						menu.append((_("Show WLAN status"), "wlanstatus"))
 				else:
-					if "menuEntryName" in p.__call__:
-						menuEntryName = p.__call__["menuEntryName"](self.iface)
+					if "menuEntryName" in p.fnc:
+						menuEntryName = p.fnc["menuEntryName"](self.iface)
 					else:
 						menuEntryName = _('Extended setup...')
-					if "menuEntryDescription" in p.__call__:
-						menuEntryDescription = p.__call__["menuEntryDescription"](self.iface)
+					if "menuEntryDescription" in p.fnc:
+						menuEntryDescription = p.fnc["menuEntryDescription"](self.iface)
 					else:
 						menuEntryDescription = _('Extended network setup plugin...')
 					self.extendedSetup = ('extendedSetup', menuEntryDescription, self.extended)

--- a/lib/python/Screens/PluginBrowser.py
+++ b/lib/python/Screens/PluginBrowser.py
@@ -146,7 +146,7 @@ class PluginBrowser(Screen, ProtectedScreen):
 
 	def run(self):
 		plugin = self["list"].l.getCurrentSelection()[0]
-		plugin.__call__(session=self.session)
+		plugin(session=self.session)
 		self.help = False
 
 	def setDefaultList(self, answer):

--- a/lib/python/StartEnigma.py
+++ b/lib/python/StartEnigma.py
@@ -200,7 +200,7 @@ class Session:
 
 		for p in plugins.getPlugins(PluginDescriptor.WHERE_SESSIONSTART):
 			try:
-				p.__call__(reason=0, session=self)
+				p(reason=0, session=self)
 			except:
 				print("[StartEnigma] Plugin raised exception at WHERE_SESSIONSTART")
 				import traceback

--- a/lib/python/StartEnigma.py
+++ b/lib/python/StartEnigma.py
@@ -459,7 +459,7 @@ def runScreenTest():
 
 	CiHandler.setSession(session)
 
-	screensToRun = [p.__call__ for p in plugins.getPlugins(PluginDescriptor.WHERE_WIZARD)]
+	screensToRun = [p.fnc for p in plugins.getPlugins(PluginDescriptor.WHERE_WIZARD)]
 
 	profile("wizards")
 	screensToRun += wizardManager.getWizards()


### PR DESCRIPTION
This PR initially reverts commits 8cc034a7be1a9b94dbb18eb50ca8cd0a30474e0c and e22ba45f17298388d23e9bc71343364a70ff63d3 in the python3 branch which do NOT make any sense... at all! The problem trying to fix with the 2 reverted commits was:
```
File "/usr/lib/enigma2/python/Components/PluginComponent.py", line 106, in readPluginList
    self.addPlugin(p)
  File "/usr/lib/enigma2/python/Components/PluginComponent.py", line 31, in addPlugin
    plugin(reason=0)
TypeError: 'PluginDescriptor' object is not callable
```

In python3, in order to run our plugins like this:
```
for p in self.getPlugins(PluginDescriptor.WHERE_MENU):
	res += p(menuid)
```

they must be callable, that is implement the special `__call__` method. The PluginDescriptor class, which is what `p` is in the above example, did not have a `__call__` method. Instead, it defined a `__call__` attribute that was set equal to the `fnc` argument, which is essentially what we want to run. This worked in python2, but not in python3.

So, this PR, fixes the mess and clears the confusion created by having a `__call__` attribute in the PluginDescriptor class (that crap exists in the code for decades!) by properly defining the `__call__` method, so plugins can be called.

Do you see any room from improvement in this PR?

In openatv for example they have put some basic "safety" measures in their [respective class](https://github.com/openatv/enigma2/blob/7.0/lib/python/Plugins/Plugin.py). They return an empty [ ] in case a plugin defines a `fnc` that is not callable. Also they define a `__getattribute__` method for old code still using the `__call__` attribute expecting to get the plugin's `fnc`. Is there any point to this? I have updated all such code in enigma2.


What about putting some checks in the PluginDescriptor class for the different "WHERE..." cases? Depending on what is the "where" argument, the "fnc" argument differs significantly! It can be a function to a list or a dictionary! I believe it would be nice having some basic checks of what a plugins throws us as a "fnc". 

Opinions? 