### PR TITLE
[NimManager] fix FBC detection

### DIFF
--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -956,7 +956,7 @@ class NimManager:
 				entry["supports_blind_scan"] = False
 
 			entry["fbc"] = [0, 0, 0] # not fbc
-			if entry["name"] and ("fbc" in entry["name"].lower() or entry["name"] in SystemInfo["HasFBCtuner"]) and entry["frontend_device"] is not None and os.access("/proc/stb/frontend/%d/fbc_id" % entry["frontend_device"], os.F_OK):
+			if entry["name"] and ("fbc" in entry["name"].lower() or (entry["name"] in SystemInfo["HasFBCtuner"] and entry["frontend_device"] is not None and os.access("/proc/stb/frontend/%d/fbc_id" % entry["frontend_device"], os.F_OK))):
 				fbc_number += 1
 				if fbc_number <= (entry["type"] and "DVB-C" in entry["type"] and 1 or 2):
 					entry["fbc"] = [1, fbc_number, fbc_tuner] # fbc root


### PR DESCRIPTION
-e.g. tuner DVB-C NIM(3128 FBC) Gigablue UE 4K not  entry
/proc/stb/frontend/0/fbc_id

root@gbue4k:~# ls -l /proc/stb/frontend/0/
-r--r--r--    1 root     root             0 Feb 26 19:14
static_current_limiting
-r--r--r--    1 root     root             0 Feb 26 19:14
static_current_limiting_choices

-thanks @jbleyel