### PR TITLE
ScanSetup: exe_path should not contain command line arguments

### DIFF
--- a/lib/python/Screens/ScanSetup.py
+++ b/lib/python/Screens/ScanSetup.py
@@ -310,7 +310,7 @@ class CableTransponderSearchSupport:
 			cmd = "%s --blindscan %d" % (exe_path, nim_idx)
 		else:
 			bin_name = GetCommand(nim_idx)
-			exe_path = "/usr/bin/%s" % bin_name
+			exe_path = "/usr/bin/%s" % bin_name.split()[0]
 			cmd = "%s --init --scan --verbose --wakeup --inv 2 --bus %d" % (bin_name, bus)
 
 		if not fileExists(exe_path):


### PR DESCRIPTION
Bug introduced here: https://github.com/OpenViX/enigma2/commit/94810b81e1cf59966164b0586a157f2c11f4d725