### PR TITLE
Navigation.py: remove pnav.stopService from playService

### DIFF
--- a/lib/python/Navigation.py
+++ b/lib/python/Navigation.py
@@ -37,6 +37,7 @@ class Navigation:
 		self.currentlyPlayingServiceReference = None
 		self.currentlyPlayingServiceOrGroup = None
 		self.currentlyPlayingService = None
+		self.skipServiceReferenceReset = False
 		self.RecordTimer = RecordTimer.RecordTimer()
 		self.__wasTimerWakeup = getFPWasTimerWakeup()
 		self.__isRestartUI = config.misc.RestartUI.value
@@ -74,8 +75,9 @@ class Navigation:
 		for x in self.event:
 			x(i)
 		if i == iPlayableService.evEnd:
-			self.currentlyPlayingServiceReference = None
-			self.currentlyPlayingServiceOrGroup = None
+			if not self.skipServiceReferenceReset:
+				self.currentlyPlayingServiceReference = None
+				self.currentlyPlayingServiceOrGroup = None
 			self.currentlyPlayingService = None
 
 	def dispatchRecordEvent(self, rec_service, event):
@@ -134,11 +136,6 @@ class Navigation:
 			else:
 				playref = ref
 			if self.pnav:
-				if SystemInfo["FCCactive"] and not self.pnav.playService(playref):
-					self.currentlyPlayingServiceReference = playref
-					self.currentlyPlayingServiceOrGroup = ref
-					return 0
-				self.pnav.stopService()
 				self.currentlyPlayingServiceReference = playref
 				self.currentlyPlayingServiceOrGroup = ref
 				if startPlayingServiceOrGroup and startPlayingServiceOrGroup.flags & eServiceReference.isGroup and not ref.flags & eServiceReference.isGroup:
@@ -173,10 +170,12 @@ class Navigation:
 								if config.usage.frontend_priority_dvbs.value != config.usage.frontend_priority.value:
 									setPreferredTuner(int(config.usage.frontend_priority_dvbs.value))
 									setPriorityFrontend = True
+				self.skipServiceReferenceReset = True
 				if self.pnav.playService(playref):
 					print "[Navigation] Failed to start: ", playref.toString()
 					self.currentlyPlayingServiceReference = None
 					self.currentlyPlayingServiceOrGroup = None
+				self.skipServiceReferenceReset = False
 				if setPriorityFrontend:
 					setPreferredTuner(int(config.usage.frontend_priority.value))
 				return 0


### PR DESCRIPTION
Stopping the service is handled pnav.playService().

Also do not set self.currentlyPlayingServiceReference and self.currentlyPlayingServiceOrGroup to None in the dispatchEvent if the service event is a zap.