### PR TITLE
Add support for enabling and disabling CI devices (#2283)

### DIFF
--- a/lib/dvb_ci/dvbci.cpp
+++ b/lib/dvb_ci/dvbci.cpp
@@ -1027,6 +1027,14 @@ PyObject *eDVBCIInterfaces::readCICaIds(int slotid)
 	return 0;
 }
 
+int eDVBCIInterfaces::setCIEnabled(int slotid, bool enabled)
+{
+	eDVBCISlot *slot = getSlot(slotid);
+	if (slot)
+		return slot->setEnabled(enabled);
+	return -1;
+}
+
 int eDVBCIInterfaces::setCIClockRate(int slotid, int rate)
 {
 	singleLock s(m_slot_lock);
@@ -1232,6 +1240,20 @@ DEFINE_REF(eDVBCISlot);
 
 eDVBCISlot::eDVBCISlot(eMainloop *context, int nr)
 {
+	char configStr[255];
+	slotid = nr;
+	m_context = context;
+	state = stateDisabled;
+	snprintf(configStr, 255, "config.ci.%d.enabled", slotid);
+	bool enabled = eConfigManager::getConfigBoolValue(configStr, true);
+	if (enabled)
+		openDevice();
+	else
+		/* emit */ eDVBCI_UI::getInstance()->m_messagepump.send(eDVBCIInterfaces::Message(eDVBCIInterfaces::Message::slotStateChanged, getSlotID(), 3)); // state disabled
+}
+
+void eDVBCISlot::openDevice()
+{
 	char filename[128];
 
 	application_manager = 0;
@@ -1244,9 +1266,7 @@ eDVBCISlot::eDVBCISlot(eMainloop *context, int nr)
 	plugged = true;
 	m_ci_version = versionUnknown;
 
-	slotid = nr;
-
-	sprintf(filename, "/dev/ci%d", nr);
+	sprintf(filename, "/dev/ci%d", slotid);
 
 //	possible_caids.insert(0x1702);
 //	possible_providers.insert(providerPair("PREMIERE", 0xC00000));
@@ -1259,7 +1279,7 @@ eDVBCISlot::eDVBCISlot(eMainloop *context, int nr)
 
 	if (fd >= 0)
 	{
-		notifier = eSocketNotifier::create(context, fd, eSocketNotifier::Read | eSocketNotifier::Priority | eSocketNotifier::Write);
+		notifier = eSocketNotifier::create(m_context, fd, eSocketNotifier::Read | eSocketNotifier::Priority | eSocketNotifier::Write);
 		CONNECT(notifier->activated, eDVBCISlot::data);
 	} else
 	{
@@ -1273,7 +1293,16 @@ eDVBCISlot::~eDVBCISlot()
 	close(fd);
 }
 
-void eDVBCISlot::setAppManager( eDVBCIApplicationManagerSession *session )
+void eDVBCISlot::closeDevice() 
+{
+	close(fd);
+	fd = -1;
+	notifier->stop();
+	data(eSocketNotifier::Priority);
+	state = stateDisabled;
+}
+
+void eDVBCISlot::setAppManager(eDVBCIApplicationManagerSession *session)
 {
 	singleLock s(eDVBCIInterfaces::m_slot_lock);
 	application_manager=session;
@@ -1604,6 +1633,24 @@ int eDVBCISlot::setClockRate(int rate)
 	snprintf(buf, sizeof(buf), "/proc/stb/tsmux/ci%d_tsclk", slotid);
 	if(CFile::write(buf, rate ? "high" : "normal") == -1)
 		return -1;
+	return 0;
+}
+
+int eDVBCISlot::setEnabled(bool enabled)
+{
+	eDebug("[CI] Slot: %d Enabled: %d, state %d", getSlotID(), enabled, state);
+	if (enabled && state != stateDisabled)
+		return 0;
+
+	if (!enabled && state == stateDisabled)
+		return 0;
+
+	if(enabled)
+		openDevice();
+	else {
+		closeDevice();
+		/* emit */ eDVBCI_UI::getInstance()->m_messagepump.send(eDVBCIInterfaces::Message(eDVBCIInterfaces::Message::slotStateChanged, getSlotID(), 3)); // state disabled
+	}
 	return 0;
 }
 

--- a/lib/dvb_ci/dvbci.h
+++ b/lib/dvb_ci/dvbci.h
@@ -66,6 +66,7 @@ class eDVBCISlot: public iObject, public sigc::trackable
 	bool user_mapped;
 	void data(int);
 	bool plugged;
+	eMainloop *m_context;
 
 	eDVBCIApplicationManagerSession *getAppManager() { return application_manager; }
 	eDVBCIMMISession *getMMIManager() { return mmi_session; }
@@ -85,12 +86,15 @@ class eDVBCISlot: public iObject, public sigc::trackable
 	int setSource(const std::string &source);
 	int setClockRate(int);
 	void determineCIVersion();
+	int setEnabled(bool);
 	static std::string getTunerLetter(int tuner_no) { return std::string(1, char(65 + tuner_no)); }
 public:
-	enum {stateRemoved, stateInserted, stateInvalid, stateResetted};
+	enum {stateRemoved, stateInserted, stateInvalid, stateResetted, stateDisabled};
 	enum {versionUnknown = -1, versionCI = 0, versionCIPlus1 = 1, versionCIPlus2 = 2};
 	eDVBCISlot(eMainloop *context, int nr);
 	~eDVBCISlot();
+	void closeDevice();
+	void openDevice();
 
 	int send(const unsigned char *data, size_t len);
 
@@ -183,6 +187,7 @@ public:
 	void ciRemoved(eDVBCISlot *slot);
 	int getSlotState(int slot);
 
+	int setCIEnabled(int slot, bool enabled);
 	int reset(int slot);
 	int initialize(int slot);
 	int startMMI(int slot);

--- a/lib/dvb_ci/dvbci_ui.cpp
+++ b/lib/dvb_ci/dvbci_ui.cpp
@@ -96,5 +96,10 @@ int eDVBCI_UI::setClockRate(int slot, int rate)
 	return eDVBCIInterfaces::getInstance()->setCIClockRate(slot, rate);
 }
 
+int eDVBCI_UI::setEnabled(int slot, bool enabled)
+{
+	return eDVBCIInterfaces::getInstance()->setCIEnabled(slot, enabled);
+}
+
 //FIXME: correct "run/startlevel"
 eAutoInitP0<eDVBCI_UI> init_dvbciui(eAutoInitNumbers::rc, "DVB-CI UI");

--- a/lib/dvb_ci/dvbci_ui.h
+++ b/lib/dvb_ci/dvbci_ui.h
@@ -34,6 +34,7 @@ public:
 	int answerEnq(int slot, char *val);
 	int cancelEnq(int slot);
 	int setClockRate(int slot, int rate);
+	int setEnabled(int slot, bool enabled);
 };
 
 #endif

--- a/lib/python/Screens/Ci.py
+++ b/lib/python/Screens/Ci.py
@@ -13,10 +13,11 @@ import Screens.Standby
 
 forceNotShowCiMessages = False
 
-
 def setCIBitrate(configElement):
 	eDVBCI_UI.getInstance().setClockRate(configElement.slotid, eDVBCI_UI.rateNormal if configElement.value == "no" else eDVBCI_UI.rateHigh)
 
+def setCIEnabled(configElement):
+	eDVBCI_UI.getInstance().setEnabled(configElement.slotid, configElement.value)
 
 def setdvbCiDelay(configElement):
 	open(SystemInfo["CommonInterfaceCIDelay"], "w").write(configElement.value)
@@ -33,6 +34,9 @@ def InitCiConfig():
 	if SystemInfo["CommonInterface"]:
 		for slot in range(SystemInfo["CommonInterface"]):
 			config.ci.append(ConfigSubsection())
+			config.ci[slot].enabled = ConfigYesNo(default=True)
+			config.ci[slot].enabled.slotid = slot
+			config.ci[slot].enabled.addNotifier(setCIEnabled)
 			config.ci[slot].canDescrambleMultipleServices = ConfigSelection(choices=[("auto", _("auto")), ("no", _("no")), ("yes", _("yes"))], default="auto")
 			config.ci[slot].use_static_pin = ConfigYesNo(default=True)
 			config.ci[slot].static_pin = ConfigPIN(default=0)
@@ -431,6 +435,7 @@ class CiSelection(Screen):
 		self.state[slot] = state
 		if self.slot > 1:
 			self.list.append(("**************************", ConfigNothing(), 3, slot))
+		self.list.append((_("CI %s enabled" % (slot)), config.ci[slot].enabled, -1, slot))
 		self.list.append((_("Reset"), ConfigNothing(), 0, slot))
 		self.list.append((_("Init"), ConfigNothing(), 1, slot))
 
@@ -441,6 +446,10 @@ class CiSelection(Screen):
 		elif self.state[slot] == 2: #module ready
 			appname = eDVBCI_UI.getInstance().getAppName(slot)
 			self.list.append((appname, ConfigNothing(), 2, slot))
+		elif self.state[slot] == 3:  # module disabled by the user
+			self.list.append((_("module disabled"), ConfigNothing(), 2, slot))
+			return
+
 		self.list.append(getConfigListEntry(_("Set persistent PIN code"), config.ci[slot].use_static_pin, 3, slot))
 		self.list.append((_("Enter persistent PIN code"), ConfigNothing(), 5, slot))
 		self.list.append((_("Reset persistent PIN code"), ConfigNothing(), 6, slot))
@@ -463,6 +472,7 @@ class CiSelection(Screen):
 
 		if slot > 0:
 			slotidx += 1 #do not change separator
+		slotidx += 1 #do not change CI Enabled
 		slotidx += 1 #do not change Reset
 		slotidx += 1 #do not change Init
 
@@ -473,7 +483,11 @@ class CiSelection(Screen):
 		elif state == 2: #module ready
 			appname = eDVBCI_UI.getInstance().getAppName(slot)
 			self.list[slotidx] = (appname, ConfigNothing(), 2, slot)
-
+			if len(self.list) <= slotidx + 1:
+				self.list = []
+				self.appendEntries(slot, state)
+		elif state == 3:
+			self.list = self.list[0:slotidx+1]
 		lst = self["entries"]
 		lst.list = self.list
 		lst.l.setList(self.list)


### PR DESCRIPTION
*By default every device is enabled
*Allows the user to disable the CI device from the menu (to be used by other software)
*At startup a disabled device will not initialize but will appear in the menu as disabled and the user can choose to enable it

*Note: this is not tested and is a cherry-pick of openatv patches that were tested. At this point I am not sure about the Ci.py changes.