### PR TITLE
Set power led on on record in standby

### DIFF
--- a/lib/python/Components/Renderer/FrontpanelLed.py
+++ b/lib/python/Components/Renderer/FrontpanelLed.py
@@ -16,7 +16,7 @@ PATTERN_BLINK = (20, 0x55555555, 0xa7fccf7a)
 class LedPatterns():
 	def __init__(self):
 		self.__led0_patterns = [PATTERN_OFF, PATTERN_BLINK, PATTERN_ON, PATTERN_BLINK]
-		self.__led1_patterns = [PATTERN_ON, PATTERN_ON, PATTERN_OFF, PATTERN_OFF]
+		self.__led1_patterns = [PATTERN_ON, PATTERN_ON, PATTERN_OFF, PATTERN_ON]
 
 	def setLedPatterns(self, which, patterns):
 		if which == 0:

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -342,7 +342,7 @@ def InitUsageConfig():
 		def powerLEDChanged(configElement):
 			if "fp" in SystemInfo["PowerLED"]:
 				open(SystemInfo["PowerLED"], "w").write(configElement.value and "1" or "0")
-				patterns = [PATTERN_ON, PATTERN_ON, PATTERN_OFF, PATTERN_OFF] if configElement.value else [PATTERN_OFF, PATTERN_OFF, PATTERN_OFF, PATTERN_OFF]
+				patterns = [PATTERN_ON, PATTERN_ON, PATTERN_OFF, PATTERN_ON] if configElement.value else [PATTERN_OFF, PATTERN_OFF, PATTERN_OFF, PATTERN_OFF]
 				ledPatterns.setLedPatterns(1, patterns)
 			else:
 				open(SystemInfo["PowerLED"], "w").write(configElement.value and "on" or "off")


### PR DESCRIPTION
GB does not support led blink, so the red led is on during standby recording and does not indicate that recording is in progress.
Therefore, during recording, the power led is also turned on to indicate that recording is in progress just like in normal mode.
On request by Dima73.