### PR TITLE
Update HdmiCec.py

### DIFF
--- a/lib/python/Components/HdmiCec.py
+++ b/lib/python/Components/HdmiCec.py
@@ -181,7 +181,7 @@ class HdmiCec:
 		elif message == "osdname":
 			cmd = 0x47
 			data = os.uname()[1]
-			data = data[:14]
+			data = data[:14].encode()
 		elif message == "poweractive":
 			cmd = 0x90
 			data = struct.pack('B', 0x00)


### PR DESCRIPTION
fix crashlog  when exiting standby mode:

Traceback (most recent call last):
  File "/usr/lib/enigma2/python/Components/HdmiCec.py", line 343, in messageReceived
    self.sendMessage(message.getAddress(), 'osdname')
  File "/usr/lib/enigma2/python/Components/HdmiCec.py", line 216, in sendMessage
    data = data.decode()
AttributeError: 'str' object has no attribute 'decode'
[ePyObject] (CallObject(<bound method HdmiCec.messageReceived of <Components.HdmiCec.HdmiCec object at 0xb0ed97f0>>,(<enigma.iCECMessagePtr; proxy of <Swig Object of type 'ePtr< iCECMessage > *' at 0xb208e2a8> >,)) failed)