### PR TITLE
[ScanSetup] fix cable scan type map value

### DIFF
--- a/lib/python/Screens/ScanSetup.py
+++ b/lib/python/Screens/ScanSetup.py
@@ -694,7 +694,7 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 			self.list.append(self.typeOfScanEntry)
 		elif self.DVB_type.value == "DVB-C":
 			if config.Nims[index_to_scan].cable.scan_type.value != "provider": # only show predefined transponder if in provider mode
-				if self.scan_typecable.value == "predefined_transponder":
+				if self.scan_typecable.value == "predefined_transponder" and self.last_scan_typecable in ("single_transponder", "complete"):
 					self.scan_typecable.value = self.cable_toggle[self.last_scan_typecable]
 			self.last_scan_typecable = self.scan_typecable.value
 			self.typeOfScanEntry = getConfigListEntry(_("Type of scan"), self.scan_typecable)


### PR DESCRIPTION
File "/usr/lib/enigma2/python/Screens/ScanSetup.py", line 698, in
createSetup
    self.scan_typecable.value =
self.cable_toggle[self.last_scan_typecable]
KeyError:
'predefined_transponder'