### PR TITLE
Avoid conflicts IOCTL for vtuner dvb usb in "ARM" boxes (test)

### DIFF
--- a/lib/dvb/dvb.cpp
+++ b/lib/dvb/dvb.cpp
@@ -409,6 +409,16 @@ eDVBUsbAdapter::eDVBUsbAdapter(int nr)
 		goto error;
 	}
 
+#if _IOC_NONE == 0
+#define VTUNER_GET_MESSAGE  11
+#define VTUNER_SET_RESPONSE 12
+#define VTUNER_SET_NAME     13
+#define VTUNER_SET_TYPE     14
+#define VTUNER_SET_HAS_OUTPUTS 15
+#define VTUNER_SET_FE_INFO  16
+#define VTUNER_SET_NUM_MODES 17
+#define VTUNER_SET_MODES 18
+#else
 #define VTUNER_GET_MESSAGE  1
 #define VTUNER_SET_RESPONSE 2
 #define VTUNER_SET_NAME     3


### PR DESCRIPTION
In this way, like discussed [here](https://forums.openpli.org/topic/90211-problem-with-dvb-t-usb-rtl2832-on-openpli-82/?view=findpost&p=1468487), we can try to solve errors with vtunerc for usb dvb in ARM boxes (in my case uclan ustym 4k pro and also sf8008), decoders where "_IOC_NONE == 0" (instead on MIPS decoders _IOC_NONE is defined, read [here](https://githublab.com/repository/issues/oe-alliance/satip-client/3)), avoiding in this way to define a variable like "VMSG_TYPE2"  in "configure.ac". To test.