### PR TITLE
[ChannelSelection] add sanity check for getCurrentSelectionName

### DIFF
--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -357,7 +357,7 @@ class ChannelContextMenu(Screen):
 	def getCurrentSelectionName(self):
 		cur = self.csel.getCurrentSelection()
 		if cur and cur.valid():
-			name = eServiceCenter.getInstance().info(cur).getName(cur) or ServiceReference(cur).getServiceName() or ""
+			name = eServiceCenter.getInstance().info(cur) and hasattr(eServiceCenter.getInstance().info(cur), "getName") and eServiceCenter.getInstance().info(cur).getName(cur) or ServiceReference(cur).getServiceName() or ""
 			name = name.replace('\xc2\x86', '').replace('\xc2\x87', '')
 			return name
 		return ""
@@ -934,7 +934,7 @@ class ChannelSelectionEdit:
 		self.editMode = True
 		cur = self.getCurrentSelection()
 		if cur and cur.valid():
-			name = eServiceCenter.getInstance().info(cur).getName(cur) or ServiceReference(cur).getServiceName() or ""
+			name = eServiceCenter.getInstance().info(cur) and hasattr(eServiceCenter.getInstance().info(cur), "getName") and eServiceCenter.getInstance().info(cur).getName(cur) or ServiceReference(cur).getServiceName() or ""
 			name = name.replace('\xc2\x86', '').replace('\xc2\x87', '')
 			if name:
 				self.session.openWithCallback(self.renameEntryCallback, VirtualKeyBoard, title=_("Please enter new name:"), text=name)


### PR DESCRIPTION
File "/usr/lib/enigma2/python/Screens/ChannelSelection.py", line 369, in removeEntry
File "/usr/lib/enigma2/python/Screens/ChannelSelection.py", line 360, in getCurrentSelectionName
AttributeError: 'NoneType' object has no attribute 'getName'