### PR TITLE
[MovieSelection] fix delete record.stream

### DIFF
--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -155,7 +155,8 @@ def canCopy(item):
 
 def createMoveList(serviceref, dest):
 	#normpath is to remove the trailing '/' from directories
-	src = isinstance(serviceref, str) and serviceref + ".ts" or os.path.normpath(serviceref.getPath())
+	ext_ts = "%s.ts" % serviceref
+	src = isinstance(serviceref, str) and "%s.ts" % serviceref or os.path.normpath(serviceref.getPath()) if os.path.exists(ext_ts) else isinstance(serviceref, str) and "%s.stream" % serviceref or os.path.normpath(serviceref.getPath())
 	srcPath, srcName = os.path.split(src)
 	if os.path.normpath(srcPath) == dest:
 		# move file to itself is allowed, so we have to check it


### PR DESCRIPTION
File "/usr/lib/enigma2/python/Screens/InfoBarGenerics.py", line 2509, in confirm
  File "/usr/lib/enigma2/python/Screens/InfoBarGenerics.py",
line 2502, in moveToTrash
  File
"/usr/lib/enigma2/python/Screens/MovieSelection.py", line 187, in moveServiceFiles
FileNotFoundError: [Errno 2] No such file or directory: '/media/hdd/movie/20221119 1634 - instant record.ts' -> '/media/hdd/movie/.Trash/20221119 1634 - instant record.ts'

-thanks OpenVisionE2  team