### PR TITLE
[Satfinder] ServiceScan is not a parent of satfinder

### DIFF
--- a/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
@@ -15,7 +15,7 @@ from Tools.Transponder import getChannelNumber, channel2frequency
 from Tools.BoundFunction import boundFunction
 
 
-class Satfinder(ScanSetup, ServiceScan):
+class Satfinder(ScanSetup):
 	"""Inherits StaticText [key_red] and [key_green] properties from ScanSetup"""
 
 	def __init__(self, session):


### PR DESCRIPTION
Wrongly introduced here 10 years ago: 
https://github.com/OpenPLi/enigma2/commit/9805b85ac24309592bf795e49e88527f560ab5ce