### PR TITLE
Get rid of getConfigListEntry()

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -1915,7 +1915,7 @@ configfile = ConfigFile()
 configfile.load()
 
 
--def getConfigListEntry(*args):
+def getConfigListEntry(*args):
 	assert len(args) > 0, "getConfigListEntry needs a minimum of one argument (descr, configElement)"
 	return args
 

--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -1915,6 +1915,11 @@ configfile = ConfigFile()
 configfile.load()
 
 
+-def getConfigListEntry(*args):
+	assert len(args) > 0, "getConfigListEntry needs a minimum of one argument (descr, configElement)"
+	return args
+
+
 def updateConfigElement(element, newelement):
 	newelement.value = element.value
 	return newelement

--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -1915,11 +1915,6 @@ configfile = ConfigFile()
 configfile.load()
 
 
-def getConfigListEntry(*args):
-	assert len(args) > 0, "getConfigListEntry needs a minimum of one argument (descr, configElement)"
-	return args
-
-
 def updateConfigElement(element, newelement):
 	newelement.value = element.value
 	return newelement

--- a/lib/python/Plugins/Extensions/DVDBurn/ProjectSettings.py
+++ b/lib/python/Plugins/Extensions/DVDBurn/ProjectSettings.py
@@ -6,7 +6,7 @@ from Components.Sources.List import List
 from Components.Sources.StaticText import StaticText
 from Components.FileList import FileList
 from Tools.Directories import fileExists, resolveFilename, SCOPE_PLUGINS, SCOPE_FONTS, SCOPE_HDD
-from Components.config import config, getConfigListEntry
+from Components.config import config
 from Components.ConfigList import ConfigListScreen
 
 
@@ -140,32 +140,32 @@ class ProjectSettings(ConfigListScreen, Screen):
 		authormode = self.settings.authormode.getValue()
 		output = self.settings.output.getValue()
 		self.list = []
-		self.list.append(getConfigListEntry(_("Collection name"), self.settings.name))
-		self.list.append(getConfigListEntry(_("Authoring mode"), self.settings.authormode))
-		self.list.append(getConfigListEntry(_("Output"), self.settings.output))
+		self.list.append((_("Collection name"), self.settings.name))
+		self.list.append((_("Authoring mode"), self.settings.authormode))
+		self.list.append((_("Output"), self.settings.output))
 		if output == "iso":
-			self.list.append(getConfigListEntry(_("ISO path"), self.settings.isopath))
+			self.list.append((_("ISO path"), self.settings.isopath))
 		if authormode.startswith("menu"):
-			self.list.append(getConfigListEntry(_("Menu") + ' ' + _("template file"), self.settings.menutemplate))
+			self.list.append((_("Menu") + ' ' + _("template file"), self.settings.menutemplate))
 			if config.usage.setup_level.index >= 2: # expert+
-				self.list.append(getConfigListEntry(_("Menu") + ' ' + _("Title"), self.project.menutemplate.settings.titleformat))
-				self.list.append(getConfigListEntry(_("Menu") + ' ' + _("Subtitles"), self.project.menutemplate.settings.subtitleformat))
-				self.list.append(getConfigListEntry(_("Menu") + ' ' + _("background image"), self.project.menutemplate.settings.menubg))
-				self.list.append(getConfigListEntry(_("Menu") + ' ' + _("Language selection"), self.project.menutemplate.settings.menulang))
-			#self.list.append(getConfigListEntry(_("Menu")+' '+_("headline")+' '+_("color"), self.settings.color_headline))
-			#self.list.append(getConfigListEntry(_("Menu")+' '+_("text")+' '+_("color"), self.settings.color_button))
-			#self.list.append(getConfigListEntry(_("Menu")+' '+_("highlighted button")+' '+_("color"), self.settings.color_highlight))
-			#self.list.append(getConfigListEntry(_("Menu")+' '+_("font face"), self.settings.font_face))
-			#self.list.append(getConfigListEntry(_("Font size")+' ('+_("headline")+', '+_("Title")+', '+_("Subtitles")+')', self.settings.font_size))
-			#self.list.append(getConfigListEntry(_("Menu")+' '+_("spaces (top, between rows, left)"), self.settings.space))
-			#self.list.append(getConfigListEntry(_("Menu")+' '+_("Audio"), self.settings.menuaudio))
+				self.list.append((_("Menu") + ' ' + _("Title"), self.project.menutemplate.settings.titleformat))
+				self.list.append((_("Menu") + ' ' + _("Subtitles"), self.project.menutemplate.settings.subtitleformat))
+				self.list.append((_("Menu") + ' ' + _("background image"), self.project.menutemplate.settings.menubg))
+				self.list.append((_("Menu") + ' ' + _("Language selection"), self.project.menutemplate.settings.menulang))
+			#self.list.append((_("Menu")+' '+_("headline")+' '+_("color"), self.settings.color_headline))
+			#self.list.append((_("Menu")+' '+_("text")+' '+_("color"), self.settings.color_button))
+			#self.list.append((_("Menu")+' '+_("highlighted button")+' '+_("color"), self.settings.color_highlight))
+			#self.list.append((_("Menu")+' '+_("font face"), self.settings.font_face))
+			#self.list.append((_("Font size")+' ('+_("headline")+', '+_("Title")+', '+_("Subtitles")+')', self.settings.font_size))
+			#self.list.append((_("Menu")+' '+_("spaces (top, between rows, left)"), self.settings.space))
+			#self.list.append((_("Menu")+' '+_("Audio"), self.settings.menuaudio))
 		if config.usage.setup_level.index >= 2: # expert+
 			if authormode != "data_ts":
-				self.list.append(getConfigListEntry(_("Titleset mode"), self.settings.titlesetmode))
+				self.list.append((_("Titleset mode"), self.settings.titlesetmode))
 				if self.settings.titlesetmode.getValue() == "single" or authormode == "just_linked":
-					self.list.append(getConfigListEntry(_("VMGM (intro trailer)"), self.settings.vmgm))
+					self.list.append((_("VMGM (intro trailer)"), self.settings.vmgm))
 			else:
-				self.list.append(getConfigListEntry(_("DVD data format"), self.settings.dataformat))
+				self.list.append((_("DVD data format"), self.settings.dataformat))
 
 		self["config"].setList(self.list)
 		self.keydict = {}

--- a/lib/python/Plugins/Extensions/DVDBurn/TitleProperties.py
+++ b/lib/python/Plugins/Extensions/DVDBurn/TitleProperties.py
@@ -4,7 +4,7 @@ from Components.Sources.List import List
 from Components.Sources.StaticText import StaticText
 from Components.Pixmap import Pixmap
 from enigma import ePicLoad
-from Components.config import config, getConfigListEntry, ConfigInteger
+from Components.config import config, ConfigInteger
 from Components.ConfigList import ConfigListScreen
 from Components.AVSwitch import AVSwitch
 from . import DVDTitle
@@ -67,24 +67,24 @@ class TitleProperties(Screen, ConfigListScreen):
 			self.properties.position = ConfigInteger(default=self.title_idx + 1, limits=(1, len(self.project.titles)))
 			title = self.project.titles[self.title_idx]
 			self.list = []
-			self.list.append(getConfigListEntry("DVD " + _("Track"), self.properties.position))
-			self.list.append(getConfigListEntry("DVD " + _("Title"), self.properties.menutitle))
-			self.list.append(getConfigListEntry("DVD " + _("Description"), self.properties.menusubtitle))
+			self.list.append(("DVD " + _("Track"), self.properties.position))
+			self.list.append(("DVD " + _("Title"), self.properties.menutitle))
+			self.list.append(("DVD " + _("Description"), self.properties.menusubtitle))
 			if config.usage.setup_level.index >= 2: # expert+
 				for audiotrack in self.properties.audiotracks:
 					DVB_aud = audiotrack.DVB_lang.getValue() or audiotrack.pid.getValue()
-					self.list.append(getConfigListEntry(_("Burn audio track (%s)") % DVB_aud, audiotrack.active))
+					self.list.append((_("Burn audio track (%s)") % DVB_aud, audiotrack.active))
 					if audiotrack.active.getValue():
-						self.list.append(getConfigListEntry(_("Audio track (%s) format") % DVB_aud, audiotrack.format))
-						self.list.append(getConfigListEntry(_("Audio track (%s) language") % DVB_aud, audiotrack.language))
+						self.list.append((_("Audio track (%s) format") % DVB_aud, audiotrack.format))
+						self.list.append((_("Audio track (%s) language") % DVB_aud, audiotrack.language))
 
-				self.list.append(getConfigListEntry("DVD " + _("Aspect ratio"), self.properties.aspect))
+				self.list.append(("DVD " + _("Aspect ratio"), self.properties.aspect))
 				if self.properties.aspect.getValue() == "16:9":
-					self.list.append(getConfigListEntry("DVD " + "widescreen", self.properties.widescreen))
+					self.list.append(("DVD " + "widescreen", self.properties.widescreen))
 				else:
-					self.list.append(getConfigListEntry("DVD " + "widescreen", self.properties.crop))
+					self.list.append(("DVD " + "widescreen", self.properties.crop))
 			if len(title.chaptermarks) == 0:
-				self.list.append(getConfigListEntry(_("Auto chapter split every ? minutes (0=never)"), self.properties.autochapter))
+				self.list.append((_("Auto chapter split every ? minutes (0=never)"), self.properties.autochapter))
 			infotext = "DVB " + _("Title") + ': ' + title.DVBname + "\n" + _("Description") + ': ' + title.DVBdescr + "\n" + _("Channel") + ': ' + title.DVBchannel + '\n' + _("Start time") + title.formatDVDmenuText(": $D.$M.$Y, $T\n", self.title_idx + 1)
 			chaptermarks = title.getChapterMarks(template="$h:$m:$s")
 			chapters_count = len(chaptermarks)

--- a/lib/python/Plugins/Extensions/GraphMultiEPG/GraphMultiEpgSetup.py
+++ b/lib/python/Plugins/Extensions/GraphMultiEPG/GraphMultiEpgSetup.py
@@ -3,7 +3,7 @@ from Components.ActionMap import ActionMap
 from Components.Pixmap import Pixmap
 from Components.Label import Label
 from Components.PluginComponent import plugins
-from Components.config import config, getConfigListEntry
+from Components.config import config
 from Components.ConfigList import ConfigListScreen
 
 addnotifier = None
@@ -39,23 +39,23 @@ class GraphMultiEpgSetup(ConfigListScreen, Screen):
 
 		global addnotifier
 		self.list = []
-		self.list.append(getConfigListEntry(_("Event font size (relative to skin size)"), config.misc.graph_mepg.ev_fontsize))
-		self.list.append(getConfigListEntry(_("Time scale"), config.misc.graph_mepg.prev_time_period))
-		self.list.append(getConfigListEntry(_("Prime time"), config.misc.graph_mepg.prime_time))
-		self.list.append(getConfigListEntry(_("Items per page "), config.misc.graph_mepg.items_per_page))
-		self.list.append(getConfigListEntry(_("Items per page for list screen"), config.misc.graph_mepg.items_per_page_listscreen))
-		self.list.append(getConfigListEntry(_("Start with list screen"), config.misc.graph_mepg.default_mode))
-		self.list.append(getConfigListEntry(_("Skip empty services"), config.misc.graph_mepg.overjump))
-		self.list.append(getConfigListEntry(_("Service title mode"), config.misc.graph_mepg.servicetitle_mode))
-		self.list.append(getConfigListEntry(_("Round start time on"), config.misc.graph_mepg.roundTo))
-		self.list.append(getConfigListEntry(_("Function of OK button"), config.misc.graph_mepg.OKButton))
-		self.list.append(getConfigListEntry(_("Alignment of service names"), config.misc.graph_mepg.servicename_alignment))
-		self.list.append(getConfigListEntry(_("Alignment of events"), config.misc.graph_mepg.event_alignment))
-		self.list.append(getConfigListEntry(_("Show vertical timelines"), config.misc.graph_mepg.show_timelines))
-		self.list.append(getConfigListEntry(_("Center time-labels and remove date"), config.misc.graph_mepg.center_timeline))
-		self.list.append(getConfigListEntry(_("Show in extensions menu"), config.misc.graph_mepg.extension_menu))
-		self.list.append(getConfigListEntry(_("Show record clock icons"), config.misc.graph_mepg.show_record_clocks))
-		self.list.append(getConfigListEntry(_("Zap bouquets blindly on zap buttons"), config.misc.graph_mepg.zap_blind_bouquets))
+		self.list.append((_("Event font size (relative to skin size)"), config.misc.graph_mepg.ev_fontsize))
+		self.list.append((_("Time scale"), config.misc.graph_mepg.prev_time_period))
+		self.list.append((_("Prime time"), config.misc.graph_mepg.prime_time))
+		self.list.append((_("Items per page "), config.misc.graph_mepg.items_per_page))
+		self.list.append((_("Items per page for list screen"), config.misc.graph_mepg.items_per_page_listscreen))
+		self.list.append((_("Start with list screen"), config.misc.graph_mepg.default_mode))
+		self.list.append((_("Skip empty services"), config.misc.graph_mepg.overjump))
+		self.list.append((_("Service title mode"), config.misc.graph_mepg.servicetitle_mode))
+		self.list.append((_("Round start time on"), config.misc.graph_mepg.roundTo))
+		self.list.append((_("Function of OK button"), config.misc.graph_mepg.OKButton))
+		self.list.append((_("Alignment of service names"), config.misc.graph_mepg.servicename_alignment))
+		self.list.append((_("Alignment of events"), config.misc.graph_mepg.event_alignment))
+		self.list.append((_("Show vertical timelines"), config.misc.graph_mepg.show_timelines))
+		self.list.append((_("Center time-labels and remove date"), config.misc.graph_mepg.center_timeline))
+		self.list.append((_("Show in extensions menu"), config.misc.graph_mepg.extension_menu))
+		self.list.append((_("Show record clock icons"), config.misc.graph_mepg.show_record_clocks))
+		self.list.append((_("Zap bouquets blindly on zap buttons"), config.misc.graph_mepg.zap_blind_bouquets))
 		if addnotifier is None:
 			addnotifier = config.misc.graph_mepg.extension_menu.addNotifier(plugins.reloadPlugins, initial_call=False)
 

--- a/lib/python/Plugins/Extensions/MediaPlayer/settings.py
+++ b/lib/python/Plugins/Extensions/MediaPlayer/settings.py
@@ -3,7 +3,7 @@ from Screens.HelpMenu import HelpableScreen
 from Components.FileList import FileList
 from Components.Sources.StaticText import StaticText
 from Components.MediaPlayer import PlayList
-from Components.config import config, getConfigListEntry, ConfigYesNo, ConfigDirectory
+from Components.config import config, ConfigYesNo, ConfigDirectory
 from Components.ConfigList import ConfigListScreen
 from Components.ActionMap import ActionMap
 
@@ -84,14 +84,14 @@ class MediaPlayerSettings(ConfigListScreen, Screen):
 		print("[initConfigList]", element)
 		try:
 			self.list = []
-			self.list.append(getConfigListEntry(_("Repeat playlist"), config.mediaplayer.repeat))
-			self.list.append(getConfigListEntry(_("Save playlist on exit"), config.mediaplayer.savePlaylistOnExit))
-			self.list.append(getConfigListEntry(_("Save last directory on exit"), config.mediaplayer.saveDirOnExit))
+			self.list.append((_("Repeat playlist"), config.mediaplayer.repeat))
+			self.list.append((_("Save playlist on exit"), config.mediaplayer.savePlaylistOnExit))
+			self.list.append((_("Save last directory on exit"), config.mediaplayer.saveDirOnExit))
 			if not config.mediaplayer.saveDirOnExit.getValue():
-				self.list.append(getConfigListEntry(_("Start directory"), config.mediaplayer.defaultDir))
-			self.list.append(getConfigListEntry(_("Sorting of playlists"), config.mediaplayer.sortPlaylists))
-			self.list.append(getConfigListEntry(_("Always hide infobar"), config.mediaplayer.alwaysHideInfoBar))
-			self.list.append(getConfigListEntry(_("Show media player on main menu"), config.mediaplayer.onMainMenu))
+				self.list.append((_("Start directory"), config.mediaplayer.defaultDir))
+			self.list.append((_("Sorting of playlists"), config.mediaplayer.sortPlaylists))
+			self.list.append((_("Always hide infobar"), config.mediaplayer.alwaysHideInfoBar))
+			self.list.append((_("Show media player on main menu"), config.mediaplayer.onMainMenu))
 			self["config"].setList(self.list)
 		except KeyError:
 			print("keyError")

--- a/lib/python/Plugins/Extensions/PicturePlayer/ui.py
+++ b/lib/python/Plugins/Extensions/PicturePlayer/ui.py
@@ -11,7 +11,7 @@ from Components.AVSwitch import AVSwitch
 from Components.Sources.List import List
 from Components.ConfigList import ConfigList, ConfigListScreen
 
-from Components.config import config, ConfigSubsection, ConfigInteger, ConfigSelection, ConfigText, ConfigYesNo, KEY_LEFT, KEY_RIGHT, getConfigListEntry
+from Components.config import config, ConfigSubsection, ConfigInteger, ConfigSelection, ConfigText, ConfigYesNo, KEY_LEFT, KEY_RIGHT
 from skin import applySkinFactor, parameters
 
 
@@ -163,17 +163,17 @@ class Pic_Setup(ConfigListScreen, Screen):
 		self["key_green"] = StaticText(_("Save"))
 
 		setup_list = [
-			getConfigListEntry(_("Slide show interval (sec.)"), config.pic.slidetime),
-			getConfigListEntry(_("Scaling mode"), config.pic.resize),
-			getConfigListEntry(_("Cache thumbnails"), config.pic.cache),
-			getConfigListEntry(_("Show info line"), config.pic.infoline),
-			getConfigListEntry(_("Frame size in full view"), config.pic.framesize),
-			getConfigListEntry(_("Slide picture in loop"), config.pic.loop),
-			getConfigListEntry(_("Background color"), config.pic.bgcolor),
-			getConfigListEntry(_("Text color"), config.pic.textcolor),
-			getConfigListEntry(_("Full view resolution"), config.usage.pic_resolution),
-			getConfigListEntry(_("Auto EXIF Orientation rotation/flipping"), config.pic.autoOrientation),
-			getConfigListEntry(_("Stop play TV"), config.pic.stopPlayTv),
+			(_("Slide show interval (sec.)"), config.pic.slidetime),
+			(_("Scaling mode"), config.pic.resize),
+			(_("Cache thumbnails"), config.pic.cache),
+			(_("Show info line"), config.pic.infoline),
+			(_("Frame size in full view"), config.pic.framesize),
+			(_("Slide picture in loop"), config.pic.loop),
+			(_("Background color"), config.pic.bgcolor),
+			(_("Text color"), config.pic.textcolor),
+			(_("Full view resolution"), config.usage.pic_resolution),
+			(_("Auto EXIF Orientation rotation/flipping"), config.pic.autoOrientation),
+			(_("Stop play TV"), config.pic.stopPlayTv),
 		]
 		ConfigListScreen.__init__(self, setup_list, session)
 

--- a/lib/python/Plugins/SystemPlugins/CableScan/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/CableScan/plugin.py
@@ -5,7 +5,7 @@ from Plugins.Plugin import PluginDescriptor
 from Components.Label import Label
 from Components.ActionMap import ActionMap
 from Components.NimManager import nimmanager
-from Components.config import config, ConfigSubsection, ConfigSelection, ConfigYesNo, ConfigInteger, getConfigListEntry, ConfigFloat
+from Components.config import config, ConfigSubsection, ConfigSelection, ConfigYesNo, ConfigInteger, ConfigFloat
 from Components.ConfigList import ConfigListScreen
 from Components.Sources.StaticText import StaticText
 from Components.ProgressBar import ProgressBar
@@ -146,13 +146,13 @@ class CableScanScreen(ConfigListScreen, Screen):
 		self.prevservice = None
 
 		self.list = []
-		self.list.append(getConfigListEntry(_('Frequency'), config.plugins.CableScan.frequency))
-		self.list.append(getConfigListEntry(_('Symbol rate'), config.plugins.CableScan.symbolrate))
-		self.list.append(getConfigListEntry(_('Modulation'), config.plugins.CableScan.modulation))
-		self.list.append(getConfigListEntry(_('Network ID') + _(' (0 - all networks)'), config.plugins.CableScan.networkid))
-		self.list.append(getConfigListEntry(_("Use official channel numbering"), config.plugins.CableScan.keepnumbering))
-		self.list.append(getConfigListEntry(_("HD list"), config.plugins.CableScan.hdlist))
-		self.list.append(getConfigListEntry(_("Enable auto cable scan"), config.plugins.CableScan.auto))
+		self.list.append((_('Frequency'), config.plugins.CableScan.frequency))
+		self.list.append((_('Symbol rate'), config.plugins.CableScan.symbolrate))
+		self.list.append((_('Modulation'), config.plugins.CableScan.modulation))
+		self.list.append((_('Network ID') + _(' (0 - all networks)'), config.plugins.CableScan.networkid))
+		self.list.append((_("Use official channel numbering"), config.plugins.CableScan.keepnumbering))
+		self.list.append((_("HD list"), config.plugins.CableScan.hdlist))
+		self.list.append((_("Enable auto cable scan"), config.plugins.CableScan.auto))
 
 		ConfigListScreen.__init__(self, self.list, session)
 		self["introduction"] = Label(_("Configure your network settings and press OK to scan"))

--- a/lib/python/Plugins/SystemPlugins/DiseqcTester/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/DiseqcTester/plugin.py
@@ -11,7 +11,7 @@ from Components.Sources.List import List
 from Components.Sources.Progress import Progress
 from Components.Sources.StaticText import StaticText
 from Components.ConfigList import ConfigListScreen
-from Components.config import getConfigListEntry, ConfigSelection, ConfigYesNo
+from Components.config import ConfigSelection, ConfigYesNo
 import random
 
 
@@ -523,19 +523,19 @@ class DiseqcTesterTestTypeSelection(ConfigListScreen, Screen):
 		self.list = []
 
 		self.testtype = ConfigSelection(choices={"quick": _("Quick"), "random": _("Random"), "complete": _("Complete")}, default="quick")
-		self.testtypeEntry = getConfigListEntry(_("Test type"), self.testtype)
+		self.testtypeEntry = (_("Test type"), self.testtype)
 		self.list.append(self.testtypeEntry)
 
 		self.loopsfailed = ConfigSelection(choices={"-1": _("Every known"), "1": "1", "2": "2", "3": "3", "4": "4", "5": "5", "6": "6", "7": "7", "8": "8"}, default="3")
-		self.loopsfailedEntry = getConfigListEntry(_("Stop testing plane after # failed transponders"), self.loopsfailed)
+		self.loopsfailedEntry = (_("Stop testing plane after # failed transponders"), self.loopsfailed)
 		self.list.append(self.loopsfailedEntry)
 
 		self.loopssuccessful = ConfigSelection(choices={"-1": _("Every known"), "1": "1", "2": "2", "3": "3", "4": "4", "5": "5", "6": "6", "7": "7", "8": "8"}, default="1")
-		self.loopssuccessfulEntry = getConfigListEntry(_("Stop testing plane after # successful transponders"), self.loopssuccessful)
+		self.loopssuccessfulEntry = (_("Stop testing plane after # successful transponders"), self.loopssuccessful)
 		self.list.append(self.loopssuccessfulEntry)
 
 		self.log = ConfigYesNo(False)
-		self.logEntry = getConfigListEntry(_("Log results to /tmp"), self.log)
+		self.logEntry = (_("Log results to /tmp"), self.log)
 		self.list.append(self.logEntry)
 
 		ConfigListScreen.__init__(self, self.list, session)

--- a/lib/python/Plugins/SystemPlugins/FastChannelChange/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/FastChannelChange/plugin.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from Plugins.Plugin import PluginDescriptor
 from Screens.Screen import Screen
 from Screens.InfoBar import InfoBar
-from Components.config import config, getConfigListEntry, ConfigSubsection, ConfigYesNo, ConfigSelection
+from Components.config import config, ConfigSubsection, ConfigYesNo, ConfigSelection
 from Components.ConfigList import ConfigListScreen
 from Components.ActionMap import ActionMap
 from Components.Sources.StaticText import StaticText
@@ -479,13 +479,13 @@ class FCCSetup(Screen, ConfigListScreen):
 			self["description"] = StaticText(_("Receiver or driver does not support FCC"))
 
 	def createConfig(self):
-		self.enableEntry = getConfigListEntry(_("FCC enabled"), config.plugins.fccsetup.activate)
-		self.fccmaxEntry = getConfigListEntry(_("Max channels"), config.plugins.fccsetup.maxfcc)
-		self.zapupdownEntry = getConfigListEntry(_("Zap Up/Down"), config.plugins.fccsetup.zapupdown)
-		self.historyEntry = getConfigListEntry(_("History Prev/Next"), config.plugins.fccsetup.history)
-		self.priorityEntry = getConfigListEntry(_("priority"), config.plugins.fccsetup.priority)
-		self.recEntry = getConfigListEntry(_("Disable FCC during recordings"), config.plugins.fccsetup.disableforrec)
-		self.extEntry = getConfigListEntry(_("Show in extensions menu"), config.plugins.fccsetup.extensions)
+		self.enableEntry = (_("FCC enabled"), config.plugins.fccsetup.activate)
+		self.fccmaxEntry = (_("Max channels"), config.plugins.fccsetup.maxfcc)
+		self.zapupdownEntry = (_("Zap Up/Down"), config.plugins.fccsetup.zapupdown)
+		self.historyEntry = (_("History Prev/Next"), config.plugins.fccsetup.history)
+		self.priorityEntry = (_("priority"), config.plugins.fccsetup.priority)
+		self.recEntry = (_("Disable FCC during recordings"), config.plugins.fccsetup.disableforrec)
+		self.extEntry = (_("Show in extensions menu"), config.plugins.fccsetup.extensions)
 
 	def createSetup(self):
 		self.list = []

--- a/lib/python/Plugins/SystemPlugins/FastScan/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/FastScan/plugin.py
@@ -3,7 +3,7 @@ from Plugins.Plugin import PluginDescriptor
 
 from Screens.Screen import Screen
 from Screens.MessageBox import MessageBox
-from Components.config import config, ConfigSelection, ConfigYesNo, getConfigListEntry, ConfigSubsection, ConfigText
+from Components.config import config, ConfigSelection, ConfigYesNo, ConfigSubsection, ConfigText
 from Components.ConfigList import ConfigListScreen
 from Components.NimManager import nimmanager
 from Components.Label import Label
@@ -173,7 +173,7 @@ class FastScanScreen(ConfigListScreen, Screen):
 			if configEntry.value:
 				nimList = [(str(x), nimmanager.nim_slots[x].friendly_full_description) for x in nimmanager.getNimListForSat(transponders[[x[1][0] for x in providers if x[0] == configEntry.value][0]][3])]
 				self.scan_nims = ConfigSelection(default=lastConfiguration[0] if lastConfiguration and lastConfiguration[0] in [x[0] for x in nimList] else nimList[0][0], choices=nimList)
-				self.tunerEntry = getConfigListEntry(_("Tuner"), self.scan_nims)
+				self.tunerEntry = (_("Tuner"), self.scan_nims)
 
 		providerList = getProviderList()
 		if lastConfiguration and lastConfiguration[1] in providerList:
@@ -190,8 +190,8 @@ class FastScanScreen(ConfigListScreen, Screen):
 			self.scan_keepnumbering = ConfigYesNo(default=True)
 			self.scan_keepsettings = ConfigYesNo(default=False)
 			self.scan_create_radio_bouquet = ConfigYesNo(default=False)
-		self.scanProvider = getConfigListEntry(_("Provider"), self.scan_provider)
-		self.scanHD = getConfigListEntry(_("HD list"), self.scan_hd)
+		self.scanProvider = (_("Provider"), self.scan_provider)
+		self.scanHD = (_("HD list"), self.scan_hd)
 		self.config_autoproviders = {}
 		auto_providers = config.misc.fastscan.autoproviders.value.split(",")
 		for provider in providers:
@@ -213,15 +213,15 @@ class FastScanScreen(ConfigListScreen, Screen):
 				if index[0] == self.scan_provider.value and index[1][2]:
 					self.list.append(self.scanHD)
 					break
-			self.list.append(getConfigListEntry(_("Use fastscan channel numbering"), self.scan_keepnumbering))
-			self.list.append(getConfigListEntry(_("Use fastscan channel names"), self.scan_keepsettings))
-			self.list.append(getConfigListEntry(_("Create separate radio userbouquet"), self.scan_create_radio_bouquet))
-			self.list.append(getConfigListEntry(_("Drop unconfigured satellites"), config.misc.fastscan.drop))
-			self.list.append(getConfigListEntry(_("Enable auto fastscan"), config.misc.fastscan.auto))
+			self.list.append((_("Use fastscan channel numbering"), self.scan_keepnumbering))
+			self.list.append((_("Use fastscan channel names"), self.scan_keepsettings))
+			self.list.append((_("Create separate radio userbouquet"), self.scan_create_radio_bouquet))
+			self.list.append((_("Drop unconfigured satellites"), config.misc.fastscan.drop))
+			self.list.append((_("Enable auto fastscan"), config.misc.fastscan.auto))
 			if config.misc.fastscan.auto.value == "multi":
 				for provider in providers:
 					if nimmanager.getNimListForSat(transponders[provider[1][0]][3]):
-						self.list.append(getConfigListEntry(_("Enable auto fastscan for %s") % provider[0], self.config_autoproviders[provider[0]]))
+						self.list.append((_("Enable auto fastscan for %s") % provider[0], self.config_autoproviders[provider[0]]))
 		self["config"].list = self.list
 
 	def saveConfiguration(self):

--- a/lib/python/Plugins/SystemPlugins/HdmiCEC/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/HdmiCEC/plugin.py
@@ -1,6 +1,6 @@
 from Screens.Screen import Screen
 from Components.ConfigList import ConfigListScreen
-from Components.config import config, getConfigListEntry
+from Components.config import config
 from Components.Label import Label
 from Components.Sources.StaticText import StaticText
 
@@ -40,33 +40,33 @@ class HdmiCECSetupScreen(ConfigListScreen, Screen):
 
 	def createSetup(self):
 		self.list = []
-		self.list.append(getConfigListEntry(_("Enabled"), config.hdmicec.enabled, _("Enable or disable using HDMI-CEC.")))
+		self.list.append((_("Enabled"), config.hdmicec.enabled, _("Enable or disable using HDMI-CEC.")))
 		if config.hdmicec.enabled.value:
-			self.list.append(getConfigListEntry(_("Put TV in standby"), config.hdmicec.control_tv_standby, _("Automatically put the TV in standby whenever the receiver goes into standby or deep standby.")))
-			self.list.append(getConfigListEntry(_("Wakeup TV from standby"), config.hdmicec.control_tv_wakeup, _("When the receiver wakes from standby or deep standby, it will send a command to the TV to bring it out of standby too.")))
+			self.list.append((_("Put TV in standby"), config.hdmicec.control_tv_standby, _("Automatically put the TV in standby whenever the receiver goes into standby or deep standby.")))
+			self.list.append((_("Wakeup TV from standby"), config.hdmicec.control_tv_wakeup, _("When the receiver wakes from standby or deep standby, it will send a command to the TV to bring it out of standby too.")))
 			if config.hdmicec.control_tv_wakeup.value:
-				self.list.append(getConfigListEntry(_("Wakeup command for TV"), config.hdmicec.tv_wakeup_command, _("Some TVs do not wake from standby when they receive the 'Image View On' command. If this is the case try the 'Text View On' command instead.")))
-			self.list.append(getConfigListEntry(_("Regard deep standby as standby"), config.hdmicec.handle_deepstandby_events, _("If set to 'yes' the same commands will be sent to the TV for deep standby events, as are sent during regular standby events.")))
-			self.list.append(getConfigListEntry(_("Switch TV to correct input"), config.hdmicec.report_active_source, _("When receiver wakes from standby, it will command the TV to switch to the HDMI input the receiver is connected to.")))
-			self.list.append(getConfigListEntry(_("Use TV remote control"), config.hdmicec.report_active_menu, _("Allows the TV remote to be used to control the receiver.")))
-			self.list.append(getConfigListEntry(_("Handle standby from TV"), config.hdmicec.handle_tv_standby, _("When enabled the receiver will automatically return to standby when the TV is turned off.")))
-			self.list.append(getConfigListEntry(_("Handle wakeup from TV"), config.hdmicec.handle_tv_wakeup, _("When enabled the receiver will automatically wake from standby when the TV is turned on.")))
+				self.list.append((_("Wakeup command for TV"), config.hdmicec.tv_wakeup_command, _("Some TVs do not wake from standby when they receive the 'Image View On' command. If this is the case try the 'Text View On' command instead.")))
+			self.list.append((_("Regard deep standby as standby"), config.hdmicec.handle_deepstandby_events, _("If set to 'yes' the same commands will be sent to the TV for deep standby events, as are sent during regular standby events.")))
+			self.list.append((_("Switch TV to correct input"), config.hdmicec.report_active_source, _("When receiver wakes from standby, it will command the TV to switch to the HDMI input the receiver is connected to.")))
+			self.list.append((_("Use TV remote control"), config.hdmicec.report_active_menu, _("Allows the TV remote to be used to control the receiver.")))
+			self.list.append((_("Handle standby from TV"), config.hdmicec.handle_tv_standby, _("When enabled the receiver will automatically return to standby when the TV is turned off.")))
+			self.list.append((_("Handle wakeup from TV"), config.hdmicec.handle_tv_wakeup, _("When enabled the receiver will automatically wake from standby when the TV is turned on.")))
 			if config.hdmicec.handle_tv_wakeup.value:
-				self.list.append(getConfigListEntry(_("Wakeup signal from TV"), config.hdmicec.tv_wakeup_detection, _("Wake the receiver from standby when selected wake command is sent from the TV.")))
-			self.list.append(getConfigListEntry(_("Forward volume keys"), config.hdmicec.volume_forwarding, _("Volume keys on the receiver remote will control the TV volume.")))
+				self.list.append((_("Wakeup signal from TV"), config.hdmicec.tv_wakeup_detection, _("Wake the receiver from standby when selected wake command is sent from the TV.")))
+			self.list.append((_("Forward volume keys"), config.hdmicec.volume_forwarding, _("Volume keys on the receiver remote will control the TV volume.")))
 			if config.hdmicec.volume_forwarding.value:
 				if config.hdmicec.minimum_send_interval.value != "0":
-					self.list.append(getConfigListEntry(_("Forwarded volume step size"), config.hdmicec.volume_forwarding_repeat, _("The number of steps to change the volume on the device the keys are forwarded to.")))
+					self.list.append((_("Forwarded volume step size"), config.hdmicec.volume_forwarding_repeat, _("The number of steps to change the volume on the device the keys are forwarded to.")))
 				else:
-					self.list.append(getConfigListEntry(_("Forwarded volume step size") + _(" - information"), config.hdmicec.volume_forwarding_repeat_empty, _("'Minimum send interval' needs to be enabled to use this option.")))
-			self.list.append(getConfigListEntry(_("Put receiver in standby"), config.hdmicec.control_receiver_standby, _("Put A/V receiver to standby too.")))
-			self.list.append(getConfigListEntry(_("Wakeup receiver from standby"), config.hdmicec.control_receiver_wakeup, _("Wakeup A/V receiver from standby too.")))
-			self.list.append(getConfigListEntry(_("Minimum send interval"), config.hdmicec.minimum_send_interval, _("Delay between CEC commands when sending a series of commands. Some devices require this delay for correct functioning, usually between 50-150ms.")))
-			self.list.append(getConfigListEntry(_("Repeat leave standby messages"), config.hdmicec.repeat_wakeup_timer, _("The command to wake from standby will be sent multiple times.")))
-			self.list.append(getConfigListEntry(_("Send 'sourceactive' before zap timers"), config.hdmicec.sourceactive_zaptimers, _("Command the TV to switch to the correct HDMI input when zap timers activate.")))
-			self.list.append(getConfigListEntry(_("Detect next boxes before standby"), config.hdmicec.next_boxes_detect, _("Before sending the command to switch the TV to standby, the receiver tests if all the other devices plugged to TV are in standby. If they are not, the 'sourceinactive' command will be sent to the TV instead of the 'standby' command.")))
-			self.list.append(getConfigListEntry(_("Debug to file"), config.hdmicec.debug, _("If enabled, a log will be kept of CEC protocol traffic ('hdmicec.log')")))
-			self.logpath_entry = getConfigListEntry(_("Select path for logfile"), config.hdmicec.log_path, _("Press OK to select the save location of the log file."))
+					self.list.append((_("Forwarded volume step size") + _(" - information"), config.hdmicec.volume_forwarding_repeat_empty, _("'Minimum send interval' needs to be enabled to use this option.")))
+			self.list.append((_("Put receiver in standby"), config.hdmicec.control_receiver_standby, _("Put A/V receiver to standby too.")))
+			self.list.append((_("Wakeup receiver from standby"), config.hdmicec.control_receiver_wakeup, _("Wakeup A/V receiver from standby too.")))
+			self.list.append((_("Minimum send interval"), config.hdmicec.minimum_send_interval, _("Delay between CEC commands when sending a series of commands. Some devices require this delay for correct functioning, usually between 50-150ms.")))
+			self.list.append((_("Repeat leave standby messages"), config.hdmicec.repeat_wakeup_timer, _("The command to wake from standby will be sent multiple times.")))
+			self.list.append((_("Send 'sourceactive' before zap timers"), config.hdmicec.sourceactive_zaptimers, _("Command the TV to switch to the correct HDMI input when zap timers activate.")))
+			self.list.append((_("Detect next boxes before standby"), config.hdmicec.next_boxes_detect, _("Before sending the command to switch the TV to standby, the receiver tests if all the other devices plugged to TV are in standby. If they are not, the 'sourceinactive' command will be sent to the TV instead of the 'standby' command.")))
+			self.list.append((_("Debug to file"), config.hdmicec.debug, _("If enabled, a log will be kept of CEC protocol traffic ('hdmicec.log')")))
+			self.logpath_entry = (_("Select path for logfile"), config.hdmicec.log_path, _("Press OK to select the save location of the log file."))
 			if config.hdmicec.debug.value != "0":
 				self.list.append(self.logpath_entry)
 		self["config"].list = self.list

--- a/lib/python/Plugins/SystemPlugins/OSD3DSetup/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/OSD3DSetup/plugin.py
@@ -4,7 +4,7 @@ from Components.Label import Label
 from Components.ConfigList import ConfigListScreen
 from Components.ServiceEventTracker import ServiceEventTracker
 from Components.SystemInfo import SystemInfo
-from Components.config import config, ConfigSubsection, ConfigInteger, ConfigSelection, ConfigSlider, getConfigListEntry
+from Components.config import config, ConfigSubsection, ConfigInteger, ConfigSelection, ConfigSlider
 from enigma import iPlayableService, iServiceInformation, eServiceCenter, eServiceReference, eDVBDB
 
 modelist = {"off": _("Off"), "auto": _("Auto"), "sidebyside": _("Side by side"), "topandbottom": _("Top and bottom")}
@@ -44,8 +44,8 @@ class OSD3DSetupScreen(ConfigListScreen, Screen):
 
 		self.mode = ConfigSelection(choices=modelist, default=mode)
 		self.znorm = ConfigSlider(default=znorm + 50, increment=1, limits=(0, 100))
-		self.list.append(getConfigListEntry(_("3d mode"), self.mode))
-		self.list.append(getConfigListEntry(_("Depth"), self.znorm))
+		self.list.append((_("3d mode"), self.mode))
+		self.list.append((_("Depth"), self.znorm))
 		self["config"].list = self.list
 
 	def keyLeft(self):

--- a/lib/python/Plugins/SystemPlugins/OSDPositionSetup/overscanwizard.py
+++ b/lib/python/Plugins/SystemPlugins/OSDPositionSetup/overscanwizard.py
@@ -1,7 +1,7 @@
 from Screens.Screen import Screen
 from Components.ActionMap import ActionMap
 from Components.ConfigList import ConfigListScreen
-from Components.config import config, ConfigSlider, , ConfigYesNo
+from Components.config import config, ConfigSlider, ConfigYesNo
 from Components.Label import Label
 from Plugins.SystemPlugins.OSDPositionSetup.plugin import setPosition, setConfiguredPosition
 from enigma import quitMainloop, eTimer, getDesktop

--- a/lib/python/Plugins/SystemPlugins/OSDPositionSetup/overscanwizard.py
+++ b/lib/python/Plugins/SystemPlugins/OSDPositionSetup/overscanwizard.py
@@ -1,7 +1,7 @@
 from Screens.Screen import Screen
 from Components.ActionMap import ActionMap
 from Components.ConfigList import ConfigListScreen
-from Components.config import config, ConfigSlider, getConfigListEntry, ConfigYesNo
+from Components.config import config, ConfigSlider, , ConfigYesNo
 from Components.Label import Label
 from Plugins.SystemPlugins.OSDPositionSetup.plugin import setPosition, setConfiguredPosition
 from enigma import quitMainloop, eTimer, getDesktop
@@ -77,7 +77,7 @@ class OverscanWizard(Screen, ConfigListScreen):
 				"If you see the tips of all eight arrowheads, then your TV has overscan disabled.\n\n"
 				"Test Pattern by TigerDave - www.tigerdave.com/ht_menu.htm"))
 			self.yes_no = ConfigYesNo(default=True, graphic=False)
-			self.list.append(getConfigListEntry(_("Did you see all eight arrow heads?"), self.yes_no))
+			self.list.append((_("Did you see all eight arrow heads?"), self.yes_no))
 			self.save_new_position = False
 			setPosition(0, 720, 0, 576)
 		elif self.step == 2:
@@ -87,7 +87,7 @@ class OverscanWizard(Screen, ConfigListScreen):
 				"has overscan enabled, and is not configured properly.\n\n"
 				"Please refer to your TV's manual to find how you can disable overscan on your TV. Look for terms like 'Just fit', 'Full width', etc. "
 				"If you can't find it, ask other users at http://forums.openpli.org.\n\n"))
-			self.list.append(getConfigListEntry(_("Did you see all eight arrow heads?"), self.yes_no))
+			self.list.append((_("Did you see all eight arrow heads?"), self.yes_no))
 			self.yes_no.value = True
 			self.save_new_position = False
 			setPosition(0, 720, 0, 576)
@@ -101,10 +101,10 @@ class OverscanWizard(Screen, ConfigListScreen):
 			self.dst_right = ConfigSlider(default=config.plugins.OSDPositionSetup.dst_left.value + config.plugins.OSDPositionSetup.dst_width.value, increment=1, limits=(0, 720))
 			self.dst_top = ConfigSlider(default=config.plugins.OSDPositionSetup.dst_top.value, increment=1, limits=(0, 576))
 			self.dst_bottom = ConfigSlider(default=config.plugins.OSDPositionSetup.dst_top.value + config.plugins.OSDPositionSetup.dst_height.value, increment=1, limits=(0, 576))
-			self.list.append(getConfigListEntry(_("left"), self.dst_left))
-			self.list.append(getConfigListEntry(_("right"), self.dst_right))
-			self.list.append(getConfigListEntry(_("top"), self.dst_top))
-			self.list.append(getConfigListEntry(_("bottom"), self.dst_bottom))
+			self.list.append((_("left"), self.dst_left))
+			self.list.append((_("right"), self.dst_right))
+			self.list.append((_("top"), self.dst_top))
+			self.list.append((_("bottom"), self.dst_bottom))
 			setConfiguredPosition()
 		elif self.step == 4:
 			self["introduction"].setText(_("You did not see all eight arrow heads. This means your TV has overscan enabled "
@@ -115,14 +115,14 @@ class OverscanWizard(Screen, ConfigListScreen):
 				"When you select a different skin, the user interface of your receiver will restart.\n\n"
 				"Note: you can always start the Overscan wizard later, via\n\nmenu->installation->system->Overscan wizard"))
 			self.yes_no.value = False
-			self.list.append(getConfigListEntry(_("Do you want to select a different skin?"), self.yes_no))
+			self.list.append((_("Do you want to select a different skin?"), self.yes_no))
 		elif self.step == 5:
 			self.Timer.stop()
 			self.setTitle(_("Overscan wizard"))
 			self["introduction"].setText(_("The overscan wizard has been completed.\n\n"
 				"Note: you can always start the Overscan wizard later, via\n\nMenu->Installation->System->Audio/Video->Overscan wizard"))
 			self.yes_no.value = True
-			self.list.append(getConfigListEntry(_("Do you want to quit the overscan wizard?"), self.yes_no))
+			self.list.append((_("Do you want to quit the overscan wizard?"), self.yes_no))
 		elif self.step == 6:
 			config.skin.primary_skin.value = "PLi-HD/skin.xml"
 			config.save()

--- a/lib/python/Plugins/SystemPlugins/PositionerSetup/ui.py
+++ b/lib/python/Plugins/SystemPlugins/PositionerSetup/ui.py
@@ -14,7 +14,7 @@ from Components.ActionMap import NumberActionMap, ActionMap
 from Components.NimManager import nimmanager
 from Components.MenuList import MenuList
 from Components.ScrollLabel import ScrollLabel
-from Components.config import config, ConfigSatlist, ConfigNothing, ConfigSelection, ConfigSubsection, ConfigInteger, ConfigFloat, KEY_LEFT, KEY_RIGHT, KEY_0, getConfigListEntry, NoSave
+from Components.config import config, ConfigSatlist, ConfigNothing, ConfigSelection, ConfigSubsection, ConfigInteger, ConfigFloat, KEY_LEFT, KEY_RIGHT, KEY_0, NoSave
 from Components.TuneTest import Tuner
 from Components.Pixmap import Pixmap
 from Tools.Transponder import ConvertToHumanReadable
@@ -1400,8 +1400,8 @@ class ONIDTSIDScreen(ConfigListScreen, Screen):
 
 	def createSetup(self):
 		self.list = []
-		self.list.append(getConfigListEntry(_("ONID"), self.transponderOnid))
-		self.list.append(getConfigListEntry(_("TSID"), self.transponderTsid))
+		self.list.append((_("ONID"), self.transponderOnid))
+		self.list.append((_("TSID"), self.transponderTsid))
 		self["config"].list = self.list
 
 	def keyGo(self):
@@ -1567,38 +1567,38 @@ class TunerScreen(ConfigListScreen, Screen):
 
 	def createSetup(self):
 		self.list = []
-		self.list.append(getConfigListEntry(_('Tune'), self.tuning.type))
-		self.list.append(getConfigListEntry(_('Satellite'), self.tuning.sat))
+		self.list.append((_('Tune'), self.tuning.type))
+		self.list.append((_('Satellite'), self.tuning.sat))
 		nim = nimmanager.nim_slots[self.feid]
 
 		if self.tuning.type.value == "manual_transponder":
 			if nim.isCompatible("DVB-S2"):
-				self.list.append(getConfigListEntry(_('System'), self.scan_sat.system))
+				self.list.append((_('System'), self.scan_sat.system))
 			else:
 				# downgrade to dvb-s, in case a -s2 config was active
 				self.scan_sat.system.value = eDVBFrontendParametersSatellite.System_DVB_S
-			self.list.append(getConfigListEntry(_('Frequency'), self.scan_sat.frequency))
-			self.list.append(getConfigListEntry(_("Polarisation"), self.scan_sat.polarization))
-			self.list.append(getConfigListEntry(_('Symbol rate'), self.scan_sat.symbolrate))
+			self.list.append((_('Frequency'), self.scan_sat.frequency))
+			self.list.append((_("Polarisation"), self.scan_sat.polarization))
+			self.list.append((_('Symbol rate'), self.scan_sat.symbolrate))
 			if self.scan_sat.system.value == eDVBFrontendParametersSatellite.System_DVB_S:
-				self.list.append(getConfigListEntry(_("FEC"), self.scan_sat.fec))
-				self.list.append(getConfigListEntry(_('Inversion'), self.scan_sat.inversion))
+				self.list.append((_("FEC"), self.scan_sat.fec))
+				self.list.append((_('Inversion'), self.scan_sat.inversion))
 			elif self.scan_sat.system.value == eDVBFrontendParametersSatellite.System_DVB_S2:
-				self.list.append(getConfigListEntry(_("FEC"), self.scan_sat.fec_s2))
-				self.list.append(getConfigListEntry(_('Inversion'), self.scan_sat.inversion))
-				self.modulationEntry = getConfigListEntry(_('Modulation'), self.scan_sat.modulation)
+				self.list.append((_("FEC"), self.scan_sat.fec_s2))
+				self.list.append((_('Inversion'), self.scan_sat.inversion))
+				self.modulationEntry = (_('Modulation'), self.scan_sat.modulation)
 				self.list.append(self.modulationEntry)
-				self.list.append(getConfigListEntry(_('Roll-off'), self.scan_sat.rolloff))
-				self.list.append(getConfigListEntry(_('Pilot'), self.scan_sat.pilot))
+				self.list.append((_('Roll-off'), self.scan_sat.rolloff))
+				self.list.append((_('Pilot'), self.scan_sat.pilot))
 				if nim.isMultistream():
-					self.list.append(getConfigListEntry(_('Input Stream ID'), self.scan_sat.is_id))
-					self.list.append(getConfigListEntry(_('PLS Mode'), self.scan_sat.pls_mode))
-					self.list.append(getConfigListEntry(_('PLS Code'), self.scan_sat.pls_code))
+					self.list.append((_('Input Stream ID'), self.scan_sat.is_id))
+					self.list.append((_('PLS Mode'), self.scan_sat.pls_mode))
+					self.list.append((_('PLS Code'), self.scan_sat.pls_code))
 				if nim.isT2MI():
-					self.list.append(getConfigListEntry(_('T2MI PLP ID'), self.scan_sat.t2mi_plp_id))
-					self.list.append(getConfigListEntry(_('T2MI PID'), self.scan_sat.t2mi_pid))
+					self.list.append((_('T2MI PLP ID'), self.scan_sat.t2mi_plp_id))
+					self.list.append((_('T2MI PID'), self.scan_sat.t2mi_pid))
 		else: # "predefined_transponder"
-			self.list.append(getConfigListEntry(_("Transponder"), self.tuning.transponder))
+			self.list.append((_("Transponder"), self.tuning.transponder))
 			currtp = self.transponderToString([None, self.scan_sat.frequency.value, self.scan_sat.symbolrate.value, self.scan_sat.polarization.value])
 			self.tuning.transponder.setValue(currtp)
 		self["config"].list = self.list

--- a/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
@@ -8,7 +8,7 @@ from Plugins.Plugin import PluginDescriptor
 from Components.Sources.FrontendStatus import FrontendStatus
 from Components.ActionMap import ActionMap
 from Components.NimManager import nimmanager, getConfigSatlist
-from Components.config import config, ConfigSelection, getConfigListEntry
+from Components.config import config, ConfigSelection
 from Components.SystemInfo import SystemInfo
 from Components.TuneTest import Tuner
 from Tools.Transponder import getChannelNumber, channel2frequency
@@ -150,17 +150,17 @@ class Satfinder(ScanSetup):
 	def createSetup(self):
 		self.list = []
 		indent = "  "
-		self.satfinderTunerEntry = getConfigListEntry(_("Tuner"), self.satfinder_scan_nims)
+		self.satfinderTunerEntry = (_("Tuner"), self.satfinder_scan_nims)
 		self.list.append(self.satfinderTunerEntry)
 		self.DVB_type = self.nim_type_dict[int(self.satfinder_scan_nims.value)]["selection"]
-		self.DVB_TypeEntry = getConfigListEntry(_("DVB type"), self.DVB_type) # multitype?
+		self.DVB_TypeEntry = (_("DVB type"), self.DVB_type) # multitype?
 		if len(self.nim_type_dict[int(self.satfinder_scan_nims.value)]["modes"]) > 1:
 			self.list.append(self.DVB_TypeEntry)
 		if self.DVB_type.value == "DVB-S":
 			self.tuning_sat = self.scan_satselection[self.getSelectedSatIndex(self.feid)]
-			self.satEntry = getConfigListEntry(_('Satellite'), self.tuning_sat)
+			self.satEntry = (_('Satellite'), self.tuning_sat)
 			self.list.append(self.satEntry)
-			self.typeOfTuningEntry = getConfigListEntry(_('Tune'), self.tuning_type)
+			self.typeOfTuningEntry = (_('Tune'), self.tuning_type)
 			if len(nimmanager.getTransponders(int(self.tuning_sat.value), self.feid)) < 1: # Only offer 'predefined transponder' if some transponders exist
 				self.tuning_type.value = "single_transponder"
 			else:
@@ -170,67 +170,67 @@ class Satfinder(ScanSetup):
 
 			if self.tuning_type.value == "single_transponder":
 				if nim.canBeCompatible("DVB-S2"):
-					self.systemEntry = getConfigListEntry(_('System'), self.scan_sat.system)
+					self.systemEntry = (_('System'), self.scan_sat.system)
 					self.list.append(self.systemEntry)
 				else:
 					# downgrade to dvb-s, in case a -s2 config was active
 					self.scan_sat.system.value = eDVBFrontendParametersSatellite.System_DVB_S
-				self.list.append(getConfigListEntry(_('Frequency'), self.scan_sat.frequency))
-				self.list.append(getConfigListEntry(_('Polarization'), self.scan_sat.polarization))
-				self.list.append(getConfigListEntry(_('Symbol rate'), self.scan_sat.symbolrate))
-				self.list.append(getConfigListEntry(_('Inversion'), self.scan_sat.inversion))
+				self.list.append((_('Frequency'), self.scan_sat.frequency))
+				self.list.append((_('Polarization'), self.scan_sat.polarization))
+				self.list.append((_('Symbol rate'), self.scan_sat.symbolrate))
+				self.list.append((_('Inversion'), self.scan_sat.inversion))
 				if self.scan_sat.system.value == eDVBFrontendParametersSatellite.System_DVB_S:
-					self.list.append(getConfigListEntry(_("FEC"), self.scan_sat.fec))
+					self.list.append((_("FEC"), self.scan_sat.fec))
 				elif self.scan_sat.system.value == eDVBFrontendParametersSatellite.System_DVB_S2:
-					self.list.append(getConfigListEntry(_("FEC"), self.scan_sat.fec_s2))
-					self.modulationEntry = getConfigListEntry(_('Modulation'), self.scan_sat.modulation)
+					self.list.append((_("FEC"), self.scan_sat.fec_s2))
+					self.modulationEntry = (_('Modulation'), self.scan_sat.modulation)
 					self.list.append(self.modulationEntry)
-					self.list.append(getConfigListEntry(_('Roll-off'), self.scan_sat.rolloff))
-					self.list.append(getConfigListEntry(_('Pilot'), self.scan_sat.pilot))
+					self.list.append((_('Roll-off'), self.scan_sat.rolloff))
+					self.list.append((_('Pilot'), self.scan_sat.pilot))
 					if nim.isMultistream():
-						self.is_id_boolEntry = getConfigListEntry(_('Transport Stream Type'), self.scan_sat.is_id_bool)
+						self.is_id_boolEntry = (_('Transport Stream Type'), self.scan_sat.is_id_bool)
 						self.list.append(self.is_id_boolEntry)
 						if self.scan_sat.is_id_bool.value:
-							self.list.append(getConfigListEntry("%s%s" % (indent, _('Input Stream ID')), self.scan_sat.is_id))
-							self.list.append(getConfigListEntry("%s%s" % (indent, _('PLS Mode')), self.scan_sat.pls_mode))
-							self.list.append(getConfigListEntry("%s%s" % (indent, _('PLS Code')), self.scan_sat.pls_code))
+							self.list.append(("%s%s" % (indent, _('Input Stream ID')), self.scan_sat.is_id))
+							self.list.append(("%s%s" % (indent, _('PLS Mode')), self.scan_sat.pls_mode))
+							self.list.append(("%s%s" % (indent, _('PLS Code')), self.scan_sat.pls_code))
 					else:
 						self.scan_sat.is_id.value = eDVBFrontendParametersSatellite.No_Stream_Id_Filter
 						self.scan_sat.pls_mode.value = eDVBFrontendParametersSatellite.PLS_Gold
 						self.scan_sat.pls_code.value = eDVBFrontendParametersSatellite.PLS_Default_Gold_Code
 					if nim.isT2MI():
-						self.t2mi_plp_id_boolEntry = getConfigListEntry(_('T2MI PLP'), self.scan_sat.t2mi_plp_id_bool)
+						self.t2mi_plp_id_boolEntry = (_('T2MI PLP'), self.scan_sat.t2mi_plp_id_bool)
 						self.list.append(self.t2mi_plp_id_boolEntry)
 						if self.scan_sat.t2mi_plp_id_bool.value:
-							self.list.append(getConfigListEntry("%s%s" % (indent, _('T2MI PLP ID')), self.scan_sat.t2mi_plp_id))
-							self.list.append(getConfigListEntry("%s%s" % (indent, _('T2MI PID')), self.scan_sat.t2mi_pid))
+							self.list.append(("%s%s" % (indent, _('T2MI PLP ID')), self.scan_sat.t2mi_plp_id))
+							self.list.append(("%s%s" % (indent, _('T2MI PID')), self.scan_sat.t2mi_pid))
 					else:
 						self.scan_sat.t2mi_plp_id.value = eDVBFrontendParametersSatellite.No_T2MI_PLP_Id
 						self.scan_sat.t2mi_pid.value = eDVBFrontendParametersSatellite.T2MI_Default_Pid
 			elif self.tuning_type.value == "predefined_transponder":
 				self.scan_nims.value = self.satfinder_scan_nims.value
 				self.updatePreDefTransponders()
-				self.preDefTransponderEntry = getConfigListEntry(_("Transponder"), self.preDefTransponders)
+				self.preDefTransponderEntry = (_("Transponder"), self.preDefTransponders)
 				self.list.append(self.preDefTransponderEntry)
 		elif self.DVB_type.value == "DVB-C":
-			self.typeOfTuningEntry = getConfigListEntry(_('Tune'), self.tuning_type)
+			self.typeOfTuningEntry = (_('Tune'), self.tuning_type)
 			if config.Nims[self.feid].cable.scan_type.value != "provider" or len(nimmanager.getTranspondersCable(int(self.satfinder_scan_nims.value))) < 1: # only show 'predefined transponder' if in provider mode and transponders exist
 				self.tuning_type.value = "single_transponder"
 			else:
 				self.list.append(self.typeOfTuningEntry)
 			if self.tuning_type.value == "single_transponder":
-				self.list.append(getConfigListEntry(_("Frequency"), self.scan_cab.frequency))
-				self.list.append(getConfigListEntry(_("Inversion"), self.scan_cab.inversion))
-				self.list.append(getConfigListEntry(_("Symbol rate"), self.scan_cab.symbolrate))
-				self.list.append(getConfigListEntry(_("Modulation"), self.scan_cab.modulation))
-				self.list.append(getConfigListEntry(_("FEC"), self.scan_cab.fec))
+				self.list.append((_("Frequency"), self.scan_cab.frequency))
+				self.list.append((_("Inversion"), self.scan_cab.inversion))
+				self.list.append((_("Symbol rate"), self.scan_cab.symbolrate))
+				self.list.append((_("Modulation"), self.scan_cab.modulation))
+				self.list.append((_("FEC"), self.scan_cab.fec))
 			elif self.tuning_type.value == "predefined_transponder":
 				self.scan_nims.value = self.satfinder_scan_nims.value
 				self.predefinedCabTranspondersList()
-				self.preDefTransponderCableEntry = getConfigListEntry(_("Transponder"), self.CableTransponders)
+				self.preDefTransponderCableEntry = (_("Transponder"), self.CableTransponders)
 				self.list.append(self.preDefTransponderCableEntry)
 		elif self.DVB_type.value == "DVB-T":
-			self.typeOfTuningEntry = getConfigListEntry(_('Tune'), self.tuning_type)
+			self.typeOfTuningEntry = (_('Tune'), self.tuning_type)
 			region = nimmanager.getTerrestrialDescription(int(self.satfinder_scan_nims.value))
 			if len(nimmanager.getTranspondersTerrestrial(region)) < 1: # Only offer 'predefined transponder' if some transponders exist
 				self.tuning_type.value = "single_transponder"
@@ -238,11 +238,11 @@ class Satfinder(ScanSetup):
 				self.list.append(self.typeOfTuningEntry)
 			if self.tuning_type.value == "single_transponder":
 				if nimmanager.nim_slots[int(self.satfinder_scan_nims.value)].canBeCompatible("DVB-T2"):
-					self.systemEntryTerr = getConfigListEntry(_('System'), self.scan_ter.system)
+					self.systemEntryTerr = (_('System'), self.scan_ter.system)
 					self.list.append(self.systemEntryTerr)
 				else:
 					self.scan_ter.system.value = eDVBFrontendParametersTerrestrial.System_DVB_T
-				self.typeOfInputEntry = getConfigListEntry(_("Use frequency or channel"), self.scan_input_as)
+				self.typeOfInputEntry = (_("Use frequency or channel"), self.scan_input_as)
 				if self.ter_channel_input:
 					self.list.append(self.typeOfInputEntry)
 				else:
@@ -251,45 +251,45 @@ class Satfinder(ScanSetup):
 					channel = getChannelNumber(self.scan_ter.frequency.floatint * 1000, self.ter_tnumber)
 					if channel:
 						self.scan_ter.channel.value = int(channel.replace("+", "").replace("-", ""))
-					self.list.append(getConfigListEntry(_("Channel"), self.scan_ter.channel))
+					self.list.append((_("Channel"), self.scan_ter.channel))
 				else:
 					prev_val = self.scan_ter.frequency.floatint
 					self.scan_ter.frequency.floatint = channel2frequency(self.scan_ter.channel.value, self.ter_tnumber) / 1000
 					if self.scan_ter.frequency.floatint == 474000:
 						self.scan_ter.frequency.floatint = prev_val
-					self.list.append(getConfigListEntry(_("Frequency"), self.scan_ter.frequency))
-				self.list.append(getConfigListEntry(_("Inversion"), self.scan_ter.inversion))
-				self.list.append(getConfigListEntry(_("Bandwidth"), self.scan_ter.bandwidth))
-				self.list.append(getConfigListEntry(_("Code rate HP"), self.scan_ter.fechigh))
-				self.list.append(getConfigListEntry(_("Code rate LP"), self.scan_ter.feclow))
-				self.list.append(getConfigListEntry(_("Modulation"), self.scan_ter.modulation))
-				self.list.append(getConfigListEntry(_("Transmission mode"), self.scan_ter.transmission))
-				self.list.append(getConfigListEntry(_("Guard interval"), self.scan_ter.guard))
-				self.list.append(getConfigListEntry(_("Hierarchy info"), self.scan_ter.hierarchy))
+					self.list.append((_("Frequency"), self.scan_ter.frequency))
+				self.list.append((_("Inversion"), self.scan_ter.inversion))
+				self.list.append((_("Bandwidth"), self.scan_ter.bandwidth))
+				self.list.append((_("Code rate HP"), self.scan_ter.fechigh))
+				self.list.append((_("Code rate LP"), self.scan_ter.feclow))
+				self.list.append((_("Modulation"), self.scan_ter.modulation))
+				self.list.append((_("Transmission mode"), self.scan_ter.transmission))
+				self.list.append((_("Guard interval"), self.scan_ter.guard))
+				self.list.append((_("Hierarchy info"), self.scan_ter.hierarchy))
 				if self.scan_ter.system.value == eDVBFrontendParametersTerrestrial.System_DVB_T2:
-					self.list.append(getConfigListEntry(_('PLP ID'), self.scan_ter.plp_id))
+					self.list.append((_('PLP ID'), self.scan_ter.plp_id))
 			elif self.tuning_type.value == "predefined_transponder":
 				self.scan_nims.value = self.satfinder_scan_nims.value
 				self.predefinedTerrTranspondersList()
-				self.preDefTransponderTerrEntry = getConfigListEntry(_('Transponder'), self.TerrestrialTransponders)
+				self.preDefTransponderTerrEntry = (_('Transponder'), self.TerrestrialTransponders)
 				self.list.append(self.preDefTransponderTerrEntry)
 		elif self.DVB_type.value == "ATSC":
-			self.typeOfTuningEntry = getConfigListEntry(_('Tune'), self.tuning_type)
+			self.typeOfTuningEntry = (_('Tune'), self.tuning_type)
 			if len(nimmanager.getTranspondersATSC(int(self.satfinder_scan_nims.value))) < 1: # only show 'predefined transponder' if transponders exist
 				self.tuning_type.value = "single_transponder"
 			else:
 				self.list.append(self.typeOfTuningEntry)
 			if self.tuning_type.value == "single_transponder":
-				self.systemEntryATSC = getConfigListEntry(_("System"), self.scan_ats.system)
+				self.systemEntryATSC = (_("System"), self.scan_ats.system)
 				self.list.append(self.systemEntryATSC)
-				self.list.append(getConfigListEntry(_("Frequency"), self.scan_ats.frequency))
-				self.list.append(getConfigListEntry(_("Inversion"), self.scan_ats.inversion))
-				self.list.append(getConfigListEntry(_("Modulation"), self.scan_ats.modulation))
+				self.list.append((_("Frequency"), self.scan_ats.frequency))
+				self.list.append((_("Inversion"), self.scan_ats.inversion))
+				self.list.append((_("Modulation"), self.scan_ats.modulation))
 			elif self.tuning_type.value == "predefined_transponder":
 				#FIXME add region
 				self.scan_nims.value = self.satfinder_scan_nims.value
 				self.predefinedATSCTranspondersList()
-				self.preDefTransponderAtscEntry = getConfigListEntry(_('Transponder'), self.ATSCTransponders)
+				self.preDefTransponderAtscEntry = (_('Transponder'), self.ATSCTransponders)
 				self.list.append(self.preDefTransponderAtscEntry)
 		self["config"].list = self.list
 

--- a/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
@@ -17,7 +17,7 @@ from Components.Pixmap import Pixmap
 from Components.MenuList import MenuList
 from Components.Sources.List import List
 from Components.Harddisk import harddiskmanager
-from Components.config import config, getConfigListEntry, ConfigSubsection, ConfigText, ConfigLocations, ConfigYesNo, ConfigSelection
+from Components.config import config, ConfigSubsection, ConfigText, ConfigLocations, ConfigYesNo, ConfigSelection
 from Components.ConfigList import ConfigListScreen
 from Components.Console import Console
 from Components.SelectionList import SelectionList
@@ -365,11 +365,11 @@ class SoftwareManagerSetup(ConfigListScreen, Screen):
 
 	def createSetup(self):
 		self.list = []
-		self.overwriteConfigfilesEntry = getConfigListEntry(_("Overwrite configuration files?"), config.plugins.softwaremanager.overwriteConfigFiles)
+		self.overwriteConfigfilesEntry = (_("Overwrite configuration files?"), config.plugins.softwaremanager.overwriteConfigFiles)
 		self.list.append(self.overwriteConfigfilesEntry)
-		self.list.append(getConfigListEntry(_("show softwaremanager in setup menu"), config.plugins.softwaremanager.onSetupMenu))
-		self.list.append(getConfigListEntry(_("show softwaremanager on blue button"), config.plugins.softwaremanager.onBlueButton))
-		self.list.append(getConfigListEntry(_("backup EPG cache"), config.plugins.softwaremanager.epgcache))
+		self.list.append((_("show softwaremanager in setup menu"), config.plugins.softwaremanager.onSetupMenu))
+		self.list.append((_("show softwaremanager on blue button"), config.plugins.softwaremanager.onBlueButton))
+		self.list.append((_("backup EPG cache"), config.plugins.softwaremanager.epgcache))
 
 		self["config"].list = self.list
 		self["config"].l.setSeperation(400)

--- a/lib/python/Plugins/SystemPlugins/TempFanControl/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/TempFanControl/plugin.py
@@ -3,7 +3,6 @@ from Components.Sensors import sensors
 from Components.Sources.Sensor import SensorSource
 from Components.Sources.StaticText import StaticText
 from Components.ConfigList import ConfigListScreen
-from Components.config import getConfigListEntry
 
 from Screens.Screen import Screen
 
@@ -127,10 +126,10 @@ class TempFanControl(ConfigListScreen, Screen):
 
 		self.list = []
 		for count in range(fancontrol.getFanCount()):
-			self.list.append(getConfigListEntry(_("Fan %d voltage") % (count + 1), fancontrol.getConfig(count).vlt))
-			self.list.append(getConfigListEntry(_("Fan %d PWM") % (count + 1), fancontrol.getConfig(count).pwm))
-			self.list.append(getConfigListEntry(_("Standby fan %d voltage") % (count + 1), fancontrol.getConfig(count).vlt_standby))
-			self.list.append(getConfigListEntry(_("Standby fan %d PWM") % (count + 1), fancontrol.getConfig(count).pwm_standby))
+			self.list.append((_("Fan %d voltage") % (count + 1), fancontrol.getConfig(count).vlt))
+			self.list.append((_("Fan %d PWM") % (count + 1), fancontrol.getConfig(count).pwm))
+			self.list.append((_("Standby fan %d voltage") % (count + 1), fancontrol.getConfig(count).vlt_standby))
+			self.list.append((_("Standby fan %d PWM") % (count + 1), fancontrol.getConfig(count).pwm_standby))
 
 		ConfigListScreen.__init__(self, self.list, session=self.session)
 		#self["config"].list = self.list

--- a/lib/python/Plugins/SystemPlugins/VideoClippingSetup/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/VideoClippingSetup/plugin.py
@@ -1,6 +1,6 @@
 from Screens.Screen import Screen
 from Components.ConfigList import ConfigListScreen
-from Components.config import config, ConfigSubsection, ConfigInteger, ConfigSlider, getConfigListEntry
+from Components.config import config, ConfigSubsection, ConfigInteger, ConfigSlider
 
 config.plugins.VideoClippingSetup = ConfigSubsection()
 config.plugins.VideoClippingSetup.clip_left = ConfigInteger(default=0)
@@ -54,11 +54,11 @@ class VideoClippingCoordinates(ConfigListScreen, Screen):
 		self.clip_width = ConfigSlider(default=width, increment=self.clip_step.value, limits=(0, 720))
 		self.clip_top = ConfigSlider(default=top, increment=self.clip_step.value, limits=(0, 576))
 		self.clip_height = ConfigSlider(default=height, increment=self.clip_step.value, limits=(0, 576))
-		self.list.append(getConfigListEntry(_("stepsize"), self.clip_step))
-		self.list.append(getConfigListEntry(_("left"), self.clip_left))
-		self.list.append(getConfigListEntry(_("width"), self.clip_width))
-		self.list.append(getConfigListEntry(_("top"), self.clip_top))
-		self.list.append(getConfigListEntry(_("height"), self.clip_height))
+		self.list.append((_("stepsize"), self.clip_step))
+		self.list.append((_("left"), self.clip_left))
+		self.list.append((_("width"), self.clip_width))
+		self.list.append((_("top"), self.clip_top))
+		self.list.append((_("height"), self.clip_height))
 		self["config"].list = self.list
 
 	def adjustStep(self):

--- a/lib/python/Plugins/SystemPlugins/VideoEnhancement/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/VideoEnhancement/plugin.py
@@ -1,6 +1,6 @@
 from Plugins.Plugin import PluginDescriptor
 from Components.ConfigList import ConfigListScreen
-from Components.config import , config, ConfigNothing
+from Components.config import config, ConfigNothing
 from Components.ActionMap import ActionMap
 from Components.Sources.StaticText import StaticText
 from Screens.Screen import Screen

--- a/lib/python/Plugins/SystemPlugins/VideoEnhancement/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/VideoEnhancement/plugin.py
@@ -1,6 +1,6 @@
 from Plugins.Plugin import PluginDescriptor
 from Components.ConfigList import ConfigListScreen
-from Components.config import getConfigListEntry, config, ConfigNothing
+from Components.config import , config, ConfigNothing
 from Components.ActionMap import ActionMap
 from Components.Sources.StaticText import StaticText
 from Screens.Screen import Screen
@@ -80,7 +80,7 @@ class VideoEnhancementSetup(ConfigListScreen, Screen):
 	def addToConfigList(self, description, configEntry, hinttext, add_to_xtdlist=False):
 		if isinstance(configEntry, ConfigNothing):
 			return None
-		entry = getConfigListEntry(description, configEntry, hinttext)
+		entry = (description, configEntry, hinttext)
 		self.list.append(entry)
 		if add_to_xtdlist:
 			self.xtdlist.append(entry)
@@ -288,7 +288,7 @@ class VideoEnhancementPreview(ConfigListScreen, Screen):
 	def createSetup(self):
 		self.list = []
 		if self.maxValue == 255:
-			self.configStepsEntry = getConfigListEntry(_("Change step size"), config.pep.configsteps)
+			self.configStepsEntry = (_("Change step size"), config.pep.configsteps)
 
 		if self.configEntry is not None:
 			self.list = self.configEntry

--- a/lib/python/Plugins/SystemPlugins/Videomode/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Videomode/plugin.py
@@ -2,7 +2,7 @@ from Screens.Screen import Screen
 from Plugins.Plugin import PluginDescriptor
 from Components.SystemInfo import SystemInfo
 from Components.ConfigList import ConfigListScreen
-from Components.config import getConfigListEntry, config, ConfigBoolean, ConfigNothing
+from Components.config import config, ConfigBoolean, ConfigNothing
 from Components.Label import Label
 from Components.Sources.StaticText import StaticText
 
@@ -53,17 +53,17 @@ class VideoSetup(ConfigListScreen, Screen):
 		level = config.usage.setup_level.index
 
 		self.list = [
-			getConfigListEntry(_("Video output"), config.av.videoport, _("Configures which video output connector will be used."))
+			(_("Video output"), config.av.videoport, _("Configures which video output connector will be used."))
 		]
 
 		# if we have modes for this port:
 		if config.av.videoport.value in config.av.videomode:
 			# add mode- and rate-selection:
-			self.list.append(getConfigListEntry(pgettext("Video output mode", "Mode"), config.av.videomode[config.av.videoport.value], _("Configure the video output mode (or resolution).")))
+			self.list.append((pgettext("Video output mode", "Mode"), config.av.videomode[config.av.videoport.value], _("Configure the video output mode (or resolution).")))
 			if config.av.videomode[config.av.videoport.value].value == 'PC':
-				self.list.append(getConfigListEntry(_("Resolution"), config.av.videorate[config.av.videomode[config.av.videoport.value].value], _("Configure the screen resolution in PC output mode.")))
+				self.list.append((_("Resolution"), config.av.videorate[config.av.videomode[config.av.videoport.value].value], _("Configure the screen resolution in PC output mode.")))
 			else:
-				self.list.append(getConfigListEntry(_("Refresh rate"), config.av.videorate[config.av.videomode[config.av.videoport.value].value], _("Configure the refresh rate of the screen.")))
+				self.list.append((_("Refresh rate"), config.av.videorate[config.av.videomode[config.av.videoport.value].value], _("Configure the refresh rate of the screen.")))
 
 		port = config.av.videoport.value
 		if port not in config.av.videomode:
@@ -75,88 +75,88 @@ class VideoSetup(ConfigListScreen, Screen):
 		force_wide = self.hw.isWidescreenMode(port, mode)
 
 		if not force_wide:
-			self.list.append(getConfigListEntry(_("Aspect ratio"), config.av.aspect, _("Configure the aspect ratio of the screen.")))
+			self.list.append((_("Aspect ratio"), config.av.aspect, _("Configure the aspect ratio of the screen.")))
 
 		if force_wide or config.av.aspect.value in ("16_9", "16_10"):
 			self.list.extend((
-				getConfigListEntry(_("Display 4:3 content as"), config.av.policy_43, _("When the content has an aspect ratio of 4:3, choose whether to scale/stretch the picture.")),
-				getConfigListEntry(_("Display >16:9 content as"), config.av.policy_169, _("When the content has an aspect ratio of 16:9, choose whether to scale/stretch the picture."))
+				(_("Display 4:3 content as"), config.av.policy_43, _("When the content has an aspect ratio of 4:3, choose whether to scale/stretch the picture.")),
+				(_("Display >16:9 content as"), config.av.policy_169, _("When the content has an aspect ratio of 16:9, choose whether to scale/stretch the picture."))
 			))
 		elif config.av.aspect.value == "4_3":
-			self.list.append(getConfigListEntry(_("Display 16:9 content as"), config.av.policy_169, _("When the content has an aspect ratio of 16:9, choose whether to scale/stretch the picture.")))
+			self.list.append((_("Display 16:9 content as"), config.av.policy_169, _("When the content has an aspect ratio of 16:9, choose whether to scale/stretch the picture.")))
 
 		if config.av.videoport.value == "DVI":
 			if level >= 1:
-				self.list.append(getConfigListEntry(_("Allow unsupported modes"), config.av.edid_override, _("When selected this allows video modes to be selected even if they are not reported as supported.")))
+				self.list.append((_("Allow unsupported modes"), config.av.edid_override, _("When selected this allows video modes to be selected even if they are not reported as supported.")))
 				if SystemInfo["HasBypassEdidChecking"]:
-					self.list.append(getConfigListEntry(_("Bypass HDMI EDID checking"), config.av.bypassEdidChecking, _("Configure if the HDMI EDID checking should be bypassed as this might solve issue with some TVs.")))
+					self.list.append((_("Bypass HDMI EDID checking"), config.av.bypassEdidChecking, _("Configure if the HDMI EDID checking should be bypassed as this might solve issue with some TVs.")))
 				if SystemInfo["HasColorspace"]:
-					self.list.append(getConfigListEntry(_("HDMI Colorspace"), config.av.hdmicolorspace, _("This option allows you to configure the Colorspace from Auto to RGB")))
+					self.list.append((_("HDMI Colorspace"), config.av.hdmicolorspace, _("This option allows you to configure the Colorspace from Auto to RGB")))
 				if SystemInfo["HasColordepth"]:
-					self.list.append(getConfigListEntry(_("HDMI Colordepth"), config.av.hdmicolordepth, _("This option allows you to configure the Colordepth for UHD")))
+					self.list.append((_("HDMI Colordepth"), config.av.hdmicolordepth, _("This option allows you to configure the Colordepth for UHD")))
 				if SystemInfo["HasColorimetry"]:
-					self.list.append(getConfigListEntry(_("HDMI Colorimetry"), config.av.hdmicolorimetry, _("This option allows you to configure the Colorimetry for HDR.")))
+					self.list.append((_("HDMI Colorimetry"), config.av.hdmicolorimetry, _("This option allows you to configure the Colorimetry for HDR.")))
 				if SystemInfo["HasHdrType"]:
-					self.list.append(getConfigListEntry(_("HDMI HDR Type"), config.av.hdmihdrtype, _("This option allows you to configure the HDR type.")))
+					self.list.append((_("HDMI HDR Type"), config.av.hdmihdrtype, _("This option allows you to configure the HDR type.")))
 				if SystemInfo["HasHDMIpreemphasis"]:
-					self.list.append(getConfigListEntry(_("Use HDMI pre-emphasis"), config.av.hdmipreemphasis, _("This option can be useful for long HDMI cables.")))
+					self.list.append((_("Use HDMI pre-emphasis"), config.av.hdmipreemphasis, _("This option can be useful for long HDMI cables.")))
 				if SystemInfo["HDRSupport"]:
-					self.list.append(getConfigListEntry(_("HLG support"), config.av.hlg_support, _("This option allows you to force the HLG modes for UHD")))
-					self.list.append(getConfigListEntry(_("HDR10 support"), config.av.hdr10_support, _("This option allows you to force the HDR10 modes for UHD")))
-					self.list.append(getConfigListEntry(_("Allow 12bit"), config.av.allow_12bit, _("This option allows you to enable or disable the 12 bit color mode")))
-					self.list.append(getConfigListEntry(_("Allow 10bit"), config.av.allow_10bit, _("This option allows you to enable or disable the 10 bit color mode")))
+					self.list.append((_("HLG support"), config.av.hlg_support, _("This option allows you to force the HLG modes for UHD")))
+					self.list.append((_("HDR10 support"), config.av.hdr10_support, _("This option allows you to force the HDR10 modes for UHD")))
+					self.list.append((_("Allow 12bit"), config.av.allow_12bit, _("This option allows you to enable or disable the 12 bit color mode")))
+					self.list.append((_("Allow 10bit"), config.av.allow_10bit, _("This option allows you to enable or disable the 10 bit color mode")))
 
 		if config.av.videoport.value == "Scart":
-			self.list.append(getConfigListEntry(_("Color format"), config.av.colorformat, _("Configure which color format should be used on the SCART output.")))
+			self.list.append((_("Color format"), config.av.colorformat, _("Configure which color format should be used on the SCART output.")))
 			if level >= 1:
-				self.list.append(getConfigListEntry(_("WSS on 4:3"), config.av.wss, _("When enabled, content with an aspect ratio of 4:3 will be stretched to fit the screen.")))
+				self.list.append((_("WSS on 4:3"), config.av.wss, _("When enabled, content with an aspect ratio of 4:3 will be stretched to fit the screen.")))
 				if SystemInfo["ScartSwitch"]:
-					self.list.append(getConfigListEntry(_("Auto scart switching"), config.av.vcrswitch, _("When enabled, your receiver will detect activity on the VCR SCART input.")))
+					self.list.append((_("Auto scart switching"), config.av.vcrswitch, _("When enabled, your receiver will detect activity on the VCR SCART input.")))
 
 		if level >= 1:
-			self.list.append(getConfigListEntry(_("Audio volume step size"), config.av.volume_stepsize, _("Configure the general audio volume step size (limit 1-10).")))
+			self.list.append((_("Audio volume step size"), config.av.volume_stepsize, _("Configure the general audio volume step size (limit 1-10).")))
 			if SystemInfo["CanDownmixAC3"]:
-				self.list.append(getConfigListEntry(_("AC3 downmix"), config.av.downmix_ac3, _("Configure whether multi channel sound tracks should be downmixed to stereo.")))
+				self.list.append((_("AC3 downmix"), config.av.downmix_ac3, _("Configure whether multi channel sound tracks should be downmixed to stereo.")))
 			if SystemInfo["CanDownmixDTS"]:
-				self.list.append(getConfigListEntry(_("DTS downmix"), config.av.downmix_dts, _("Configure whether multi channel sound tracks should be downmixed to stereo.")))
+				self.list.append((_("DTS downmix"), config.av.downmix_dts, _("Configure whether multi channel sound tracks should be downmixed to stereo.")))
 			if SystemInfo["CanDownmixAAC"]:
-				self.list.append(getConfigListEntry(_("AAC downmix"), config.av.downmix_aac, _("Configure whether multi channel sound tracks should be downmixed to stereo.")))
+				self.list.append((_("AAC downmix"), config.av.downmix_aac, _("Configure whether multi channel sound tracks should be downmixed to stereo.")))
 			if SystemInfo["CanDownmixAACPlus"]:
-				self.list.append(getConfigListEntry(_("AAC+ downmix"), config.av.downmix_aacplus, _("Choose whether multi channel aac+ sound tracks should be downmixed to stereo.")))
+				self.list.append((_("AAC+ downmix"), config.av.downmix_aacplus, _("Choose whether multi channel aac+ sound tracks should be downmixed to stereo.")))
 			if SystemInfo["CanAC3Transcode"]:
-				self.list.append(getConfigListEntry(_("AC3 transcoding"), config.av.transcodeac3plus, _("Choose whether AC3 sound tracks should be transcoded.")))
+				self.list.append((_("AC3 transcoding"), config.av.transcodeac3plus, _("Choose whether AC3 sound tracks should be transcoded.")))
 			if SystemInfo["CanAACTranscode"]:
-				self.list.append(getConfigListEntry(_("AAC transcoding"), config.av.transcodeaac, _("Choose whether AAC sound tracks should be transcoded.")))
+				self.list.append((_("AAC transcoding"), config.av.transcodeaac, _("Choose whether AAC sound tracks should be transcoded.")))
 			if SystemInfo["CanDTSHD"]:
-				self.list.append(getConfigListEntry(_("DTS-HD(HR/MA) downmix"), config.av.dtshd, _("Choose whether multi channel DTS-HD(HR/MA) sound tracks should be downmixed or transcoded.")))
+				self.list.append((_("DTS-HD(HR/MA) downmix"), config.av.dtshd, _("Choose whether multi channel DTS-HD(HR/MA) sound tracks should be downmixed or transcoded.")))
 			if SystemInfo["CanWMAPRO"]:
-				self.list.append(getConfigListEntry(_("WMA Pro downmix"), config.av.wmapro, _("Choose whether WMA Pro sound tracks should be downmixed.")))
+				self.list.append((_("WMA Pro downmix"), config.av.wmapro, _("Choose whether WMA Pro sound tracks should be downmixed.")))
 			if SystemInfo["HasMultichannelPCM"]:
-				self.list.append(getConfigListEntry(_("Multichannel PCM"), config.av.multichannel_pcm, _("Configure whether multi channel PCM sound should be enabled.")))
+				self.list.append((_("Multichannel PCM"), config.av.multichannel_pcm, _("Configure whether multi channel PCM sound should be enabled.")))
 			self.list.extend((
-				getConfigListEntry(_("General AC3 delay"), config.av.generalAC3delay, _("Configure the general audio delay of Dolby Digital sound tracks.")),
-				getConfigListEntry(_("General PCM delay"), config.av.generalPCMdelay, _("Configure the general audio delay of stereo sound tracks."))
+				(_("General AC3 delay"), config.av.generalAC3delay, _("Configure the general audio delay of Dolby Digital sound tracks.")),
+				(_("General PCM delay"), config.av.generalPCMdelay, _("Configure the general audio delay of stereo sound tracks."))
 			))
 			if SystemInfo["CanBTAudio"]:
-				self.list.append(getConfigListEntry(_("Enable bluetooth audio"), config.av.btaudio, _("This option allows you to switch audio to bluetooth speakers.")))
+				self.list.append((_("Enable bluetooth audio"), config.av.btaudio, _("This option allows you to switch audio to bluetooth speakers.")))
 			if SystemInfo["CanBTAudioDelay"]:
-				self.list.append(getConfigListEntry(_("General bluetooth audio delay"), config.av.btaudiodelay, _("This option configures the general audio delay for bluetooth speakers.")))
+				self.list.append((_("General bluetooth audio delay"), config.av.btaudiodelay, _("This option configures the general audio delay for bluetooth speakers.")))
 			if SystemInfo["HasAutoVolume"] or SystemInfo["HasAutoVolumeLevel"]:
-				self.list.append(getConfigListEntry(_("Audio auto volume level"), SystemInfo["HasAutoVolume"] and config.av.autovolume or config.av.autovolumelevel, _("This option allows you can to set the auto volume level.")))
+				self.list.append((_("Audio auto volume level"), SystemInfo["HasAutoVolume"] and config.av.autovolume or config.av.autovolumelevel, _("This option allows you can to set the auto volume level.")))
 			if SystemInfo["Has3DSurround"]:
-				self.list.append(getConfigListEntry(_("3D surround"), config.av.surround_3d, _("This option allows you to enable 3D surround sound.")))
+				self.list.append((_("3D surround"), config.av.surround_3d, _("This option allows you to enable 3D surround sound.")))
 				if SystemInfo["Has3DSpeaker"] and config.av.surround_3d.value != "none":
-					self.list.append(getConfigListEntry(_("3D surround speaker position"), config.av.speaker_3d, _("This option allows you to change the virtuell loadspeaker position.")))
+					self.list.append((_("3D surround speaker position"), config.av.speaker_3d, _("This option allows you to change the virtuell loadspeaker position.")))
 			if SystemInfo["Has3DSurroundSpeaker"]:
-				self.list.append(getConfigListEntry(_("3D surround speaker position"), config.av.surround_3d_speaker, _("This option allows you to disable or change the virtuell loadspeaker position.")))
+				self.list.append((_("3D surround speaker position"), config.av.surround_3d_speaker, _("This option allows you to disable or change the virtuell loadspeaker position.")))
 				if SystemInfo["Has3DSurroundSoftLimiter"] and config.av.surround_3d_speaker.value != "disabled":
-					self.list.append(getConfigListEntry(_("3D surround softlimiter"), config.av.surround_softlimiter_3d, _("This option allows you to enable 3D surround softlimiter.")))
+					self.list.append((_("3D surround softlimiter"), config.av.surround_softlimiter_3d, _("This option allows you to enable 3D surround softlimiter.")))
 
 		if SystemInfo["CanChangeOsdAlpha"]:
-			self.list.append(getConfigListEntry(_("OSD transparency"), config.av.osd_alpha, _("Configure the transparency of the OSD.")))
+			self.list.append((_("OSD transparency"), config.av.osd_alpha, _("Configure the transparency of the OSD.")))
 
 		if not isinstance(config.av.scaler_sharpness, ConfigNothing):
-			self.list.append(getConfigListEntry(_("Scaler sharpness"), config.av.scaler_sharpness, _("Configure the sharpness of the video scaling.")))
+			self.list.append((_("Scaler sharpness"), config.av.scaler_sharpness, _("Configure the sharpness of the video scaling.")))
 
 		self["config"].list = self.list
 

--- a/lib/python/Screens/AudioSelection.py
+++ b/lib/python/Screens/AudioSelection.py
@@ -6,7 +6,7 @@ from Screens.ChoiceBox import ChoiceBox
 from Components.ServiceEventTracker import ServiceEventTracker
 from Components.ActionMap import NumberActionMap
 from Components.ConfigList import ConfigListScreen
-from Components.config import config, ConfigSubsection, getConfigListEntry, ConfigNothing, ConfigSelection, ConfigOnOff, ConfigYesNo
+from Components.config import config, ConfigSubsection, ConfigNothing, ConfigSelection, ConfigOnOff, ConfigYesNo
 from Components.Label import Label
 from Components.Sources.List import List
 from Components.Sources.Boolean import Boolean
@@ -102,7 +102,7 @@ class AudioSelection(ConfigListScreen, Screen):
 						extra_text += ",DTS"
 					if SystemInfo["CanDownmixAAC"]:
 						extra_text += ",AAC"
-					conflist.append(getConfigListEntry(_("Multi channel downmix") + extra_text, self.settings.downmix))
+					conflist.append((_("Multi channel downmix") + extra_text, self.settings.downmix))
 					self["key_red"].setBoolean(True)
 
 			if n > 0:
@@ -111,7 +111,7 @@ class AudioSelection(ConfigListScreen, Screen):
 					choicelist = [("0", _("left")), ("1", _("stereo")), ("2", _("right"))]
 					self.settings.channelmode = ConfigSelection(choices=choicelist, default=str(self.audioChannel.getCurrentChannel()))
 					self.settings.channelmode.addNotifier(self.changeMode, initial_call=False)
-					conflist.append(getConfigListEntry(_("Channel"), self.settings.channelmode))
+					conflist.append((_("Channel"), self.settings.channelmode))
 					self["key_green"].setBoolean(True)
 				else:
 					conflist.append(('',))
@@ -154,7 +154,7 @@ class AudioSelection(ConfigListScreen, Screen):
 
 			if subtitlelist:
 				self["key_yellow"].setBoolean(True)
-				conflist.append(getConfigListEntry(_("To subtitle selection"), self.settings.menupage))
+				conflist.append((_("To subtitle selection"), self.settings.menupage))
 			else:
 				self["key_yellow"].setBoolean(False)
 				conflist.append(('',))
@@ -176,10 +176,10 @@ class AudioSelection(ConfigListScreen, Screen):
 				if self.Plugins:
 					self["key_blue"].setBoolean(True)
 					if len(self.Plugins) > 1:
-						conflist.append(getConfigListEntry(_("Audio plugins"), ConfigNothing()))
+						conflist.append((_("Audio plugins"), ConfigNothing()))
 						self.plugincallfunc = [(x[0], x[1]) for x in self.Plugins]
 					else:
-						conflist.append(getConfigListEntry(self.Plugins[0][0], ConfigNothing()))
+						conflist.append((self.Plugins[0][0], ConfigNothing()))
 						self.plugincallfunc = self.Plugins[0][1]
 
 		elif self.settings.menupage.getValue() == PAGE_SUBTITLES:
@@ -231,11 +231,11 @@ class AudioSelection(ConfigListScreen, Screen):
 				streams.append((x, "", number, description, language, selected))
 				idx += 1
 
-			conflist.append(getConfigListEntry(_("To audio selection"), self.settings.menupage))
+			conflist.append((_("To audio selection"), self.settings.menupage))
 
 			if self.infobar.selected_subtitle and self.infobar.selected_subtitle != (0, 0, 0, 0) and not ".DVDPlayer'>" in repr(self.infobar):
 				self["key_blue"].setBoolean(True)
-				conflist.append(getConfigListEntry(_("Subtitle Quickmenu"), ConfigNothing()))
+				conflist.append((_("Subtitle Quickmenu"), ConfigNothing()))
 
 		self["config"].list = conflist
 

--- a/lib/python/Screens/AutoDiseqc.py
+++ b/lib/python/Screens/AutoDiseqc.py
@@ -2,7 +2,7 @@ from Screens.Screen import Screen
 from Components.ConfigList import ConfigListScreen
 from Components.ActionMap import ActionMap
 from Components.Sources.StaticText import StaticText
-from Components.config import config, configfile, getConfigListEntry
+from Components.config import config, configfile
 from Components.NimManager import nimmanager, InitNimManager
 from Components.TuneTest import Tuner
 from enigma import eDVBFrontendParametersSatellite, eDVBResourceManager, eTimer
@@ -511,7 +511,7 @@ class AutoDiseqc(ConfigListScreen, Screen):
 		if len(self.found_sats) > 0:
 			self.list = []
 			for x in self.found_sats:
-				self.list.append(getConfigListEntry((_("DiSEqC port %s: %s") % (x[0], x[2]))))
+				self.list.append(_("DiSEqC port %s: %s") % (x[0], x[2]))
 			self["config"].l.setList(self.list)
 
 		if self.nr_of_ports == self.port_index:

--- a/lib/python/Screens/Ci.py
+++ b/lib/python/Screens/Ci.py
@@ -5,7 +5,7 @@ from Components.Sources.StaticText import StaticText
 from Components.ActionMap import ActionMap
 from Components.ActionMap import NumberActionMap
 from Components.Label import Label
-from Components.config import config, ConfigSubsection, ConfigSelection, ConfigSubList, getConfigListEntry, KEY_LEFT, KEY_RIGHT, KEY_0, ConfigNothing, ConfigPIN, ConfigYesNo, NoSave
+from Components.config import config, ConfigSubsection, ConfigSelection, ConfigSubList, KEY_LEFT, KEY_RIGHT, KEY_0, ConfigNothing, ConfigPIN, ConfigYesNo, NoSave
 from Components.ConfigList import ConfigList, ConfigListScreen
 from Components.SystemInfo import SystemInfo
 from enigma import eTimer, eDVBCI_UI, eDVBCIInterfaces
@@ -122,7 +122,7 @@ class MMIDialog(Screen):
 				x = ConfigPIN(0, len=pinlength)
 			x.addEndNotifier(self.pinEntered)
 			self["subtitle"].setText(entry[2])
-			list.append(getConfigListEntry("", x))
+			list.append(("", x))
 			self["bottom"].setText(_("please press OK when ready"))
 
 	def pinEntered(self, value):
@@ -448,17 +448,17 @@ class CiSelection(Screen):
 			appname = eDVBCI_UI.getInstance().getAppName(slot)
 			self.list.append((appname, ConfigNothing(), 2, slot))
 
-		self.list.append(getConfigListEntry(_("Set persistent PIN code"), config.ci[slot].use_static_pin, 3, slot))
+		self.list.append((_("Set persistent PIN code"), config.ci[slot].use_static_pin, 3, slot))
 		self.list.append((_("Enter persistent PIN code"), ConfigNothing(), 5, slot))
 		self.list.append((_("Reset persistent PIN code"), ConfigNothing(), 6, slot))
-		self.list.append(getConfigListEntry(_("Show CI messages"), config.ci[slot].show_ci_messages, 3, slot))
-		self.list.append(getConfigListEntry(_("Multiple service support"), config.ci[slot].canDescrambleMultipleServices, 3, slot))
+		self.list.append((_("Show CI messages"), config.ci[slot].show_ci_messages, 3, slot))
+		self.list.append((_("Multiple service support"), config.ci[slot].canDescrambleMultipleServices, 3, slot))
 		if SystemInfo["CI%dSupportsHighBitrates" % slot]:
-			self.list.append(getConfigListEntry(_("High bitrate support"), config.ci[slot].canHandleHighBitrates, 3, slot))
+			self.list.append((_("High bitrate support"), config.ci[slot].canHandleHighBitrates, 3, slot))
 		if SystemInfo["CI%dRelevantPidsRoutingSupport" % slot]:
-			self.list.append(getConfigListEntry(_("PID Filtering"), config.ci[slot].relevantPidsRouting, 3, slot))
+			self.list.append((_("PID Filtering"), config.ci[slot].relevantPidsRouting, 3, slot))
 		if SystemInfo["CommonInterfaceCIDelay"]:
-			self.list.append(getConfigListEntry(_("DVB CI Delay"), config.cimisc.dvbCiDelay, 3, slot))
+			self.list.append((_("DVB CI Delay"), config.cimisc.dvbCiDelay, 3, slot))
 
 	def updateState(self, slot):
 		self.list = []
@@ -529,8 +529,8 @@ class PermanentPinEntry(ConfigListScreen, Screen):
 		self.pin2 = ConfigPIN(default=0, censor="*")
 		self.pin1.addEndNotifier(boundFunction(self.valueChanged, 1))
 		self.pin2.addEndNotifier(boundFunction(self.valueChanged, 2))
-		self.list.append(getConfigListEntry(_("Enter PIN"), NoSave(self.pin1)))
-		self.list.append(getConfigListEntry(_("Reenter PIN"), NoSave(self.pin2)))
+		self.list.append((_("Enter PIN"), NoSave(self.pin1)))
+		self.list.append((_("Reenter PIN"), NoSave(self.pin2)))
 		ConfigListScreen.__init__(self, self.list)
 
 		self["actions"] = NumberActionMap(["DirectionActions", "ColorActions", "OkCancelActions"],

--- a/lib/python/Screens/InputDeviceSetup.py
+++ b/lib/python/Screens/InputDeviceSetup.py
@@ -4,7 +4,7 @@ from Screens.MessageBox import MessageBox
 from Components.InputDevice import iInputDevices, iRcTypeControl
 from Components.Sources.StaticText import StaticText
 from Components.Sources.List import List
-from Components.config import config, ConfigYesNo, getConfigListEntry, ConfigSelection
+from Components.config import config, ConfigYesNo, ConfigSelection
 from Components.ConfigList import ConfigListScreen
 from Components.ActionMap import ActionMap, HelpableActionMap
 from Tools.Directories import resolveFilename, SCOPE_CURRENT_SKIN
@@ -193,16 +193,16 @@ class InputDeviceSetup(ConfigListScreen, Screen):
 	def createSetup(self):
 		self.list = []
 		label = _("Change repeat and delay settings?")
-		cmd = "self.enableEntry = getConfigListEntry(label, config.inputDevices." + self.inputDevice + ".enabled)"
+		cmd = "self.enableEntry = (label, config.inputDevices." + self.inputDevice + ".enabled)"
 		exec(cmd)
 		label = _("Interval between keys when repeating:")
-		cmd = "self.repeatEntry = getConfigListEntry(label, config.inputDevices." + self.inputDevice + ".repeat)"
+		cmd = "self.repeatEntry = (label, config.inputDevices." + self.inputDevice + ".repeat)"
 		exec(cmd)
 		label = _("Delay before key repeat starts:")
-		cmd = "self.delayEntry = getConfigListEntry(label, config.inputDevices." + self.inputDevice + ".delay)"
+		cmd = "self.delayEntry = (label, config.inputDevices." + self.inputDevice + ".delay)"
 		exec(cmd)
 		label = _("Device name:")
-		cmd = "self.nameEntry = getConfigListEntry(label, config.inputDevices." + self.inputDevice + ".name)"
+		cmd = "self.nameEntry = (label, config.inputDevices." + self.inputDevice + ".name)"
 		exec(cmd)
 		if self.enableEntry:
 			if isinstance(self.enableEntry[1], ConfigYesNo):
@@ -374,7 +374,7 @@ class RemoteControlType(ConfigListScreen, Screen):
 
 		rctype = config.plugins.remotecontroltype.rctype.value
 		self.rctype = ConfigSelection(choices=self.rcList, default=str(rctype))
-		self.list.append(getConfigListEntry(_("Remote control type"), self.rctype))
+		self.list.append((_("Remote control type"), self.rctype))
 		self["config"].list = self.list
 
 		self.defaultRcType = 0

--- a/lib/python/Screens/InstallWizard.py
+++ b/lib/python/Screens/InstallWizard.py
@@ -2,7 +2,7 @@ from Screens.Screen import Screen
 from Components.ConfigList import ConfigListScreen, ConfigList
 from Components.ActionMap import ActionMap
 from Components.Sources.StaticText import StaticText
-from Components.config import config, ConfigSubsection, ConfigBoolean, getConfigListEntry, ConfigSelection, ConfigYesNo, ConfigIP, ConfigNothing
+from Components.config import config, ConfigSubsection, ConfigBoolean, ConfigSelection, ConfigYesNo, ConfigIP, ConfigNothing
 from Components.Network import iNetwork
 from Components.Opkg import OpkgComponent
 from enigma import eDVBDB
@@ -84,26 +84,26 @@ class InstallWizard(ConfigListScreen, Screen):
 		if self.index == self.STATE_UPDATE:
 			if config.misc.installwizard.hasnetwork.value:
 				ip = ".".join([str(x) for x in iNetwork.getAdapterAttribute(self.adapter, "ip")])
-				self.list.append(getConfigListEntry(_("Your internet connection is working (IP address: %s)") % ip, self.enabled))
+				self.list.append((_("Your internet connection is working (IP address: %s)") % ip, self.enabled))
 			else:
-				self.list.append(getConfigListEntry(_("Your receiver does not have an internet connection"), self.enabled))
+				self.list.append((_("Your receiver does not have an internet connection"), self.enabled))
 		elif self.index == self.STATE_CHOISE_CHANNELLIST:
-			self.list.append(getConfigListEntry(_("Install channel list"), self.enabled))
+			self.list.append((_("Install channel list"), self.enabled))
 			if self.enabled.value:
-				self.list.append(getConfigListEntry(_("Channel list type"), self.channellist_type))
+				self.list.append((_("Channel list type"), self.channellist_type))
 		elif self.index == self.INSTALL_PLUGINS:
-			self.list.append(getConfigListEntry(_("No, I do not want to install plugins"), self.noplugins))
-			self.list.append(getConfigListEntry(_("Yes, I do want to install plugins"), self.doplugins))
+			self.list.append((_("No, I do not want to install plugins"), self.noplugins))
+			self.list.append((_("Yes, I do want to install plugins"), self.doplugins))
 		elif self.index == self.SCAN:
-			self.list.append(getConfigListEntry(_("I do not want to perform any service scans"), self.noscan))
-			self.list.append(getConfigListEntry(_("Do an automatic service scan now"), self.autoscan))
-			self.list.append(getConfigListEntry(_("Do a manual service scan now"), self.manualscan))
+			self.list.append((_("I do not want to perform any service scans"), self.noscan))
+			self.list.append((_("Do an automatic service scan now"), self.autoscan))
+			self.list.append((_("Do a manual service scan now"), self.manualscan))
 			from Plugins.SystemPlugins.FastScan.plugin import getProviderList
 			if getProviderList():
-				self.list.append(getConfigListEntry(_("Do a fast service scan now"), self.fastscan))
+				self.list.append((_("Do a fast service scan now"), self.fastscan))
 			from Components.NimManager import nimmanager
 			if nimmanager.getEnabledNimListOfType("DVB-C"):
-				self.list.append(getConfigListEntry(_("Do a cable service scan now"), self.cablescan))
+				self.list.append((_("Do a cable service scan now"), self.cablescan))
 		self["config"].list = self.list
 
 	def keyLeft(self):

--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -7,7 +7,7 @@ from Components.DiskInfo import DiskInfo
 from Components.Pixmap import Pixmap, MultiPixmap
 from Components.Label import Label
 from Components.PluginComponent import plugins
-from Components.config import config, ConfigSubsection, ConfigText, ConfigInteger, ConfigLocations, ConfigSet, ConfigYesNo, ConfigSelection, getConfigListEntry
+from Components.config import config, ConfigSubsection, ConfigText, ConfigInteger, ConfigLocations, ConfigSet, ConfigYesNo, ConfigSelection
 from Components.ConfigList import ConfigListScreen
 from Components.ServiceEventTracker import ServiceEventTracker, InfoBarBase
 from Components.Sources.Boolean import Boolean
@@ -271,24 +271,24 @@ class MovieBrowserConfiguration(ConfigListScreen, Screen):
 		cfg.listtype = ConfigSelection(default=str(config.movielist.listtype.value), choices=l_listtype)
 		cfg.description = ConfigYesNo(default=(config.movielist.description.value != MovieList.HIDE_DESCRIPTION))
 		configList = [
-			getConfigListEntry(_("Sort"), cfg.moviesort, _("You can set sorting type for items in movielist.")),
-			getConfigListEntry(_("Show extended description"), cfg.description, _("You can enable if will be displayed extended EPG description for item.")),
-			getConfigListEntry(_("Type"), cfg.listtype, _("Set movielist type.")),
-			getConfigListEntry(_("Use individual settings for each directory"), config.movielist.settings_per_directory, _("Settings can be different for each directory separately (for non removeable devices only).")),
-			getConfigListEntry(_("Allow quitting movie player with exit"), config.usage.leave_movieplayer_onExit, _("When enabled, it is possible to leave the movie player with exit.")),
-			getConfigListEntry(_("Behavior when a movie reaches the end"), config.usage.on_movie_eof, _("Set action when movie playback is finished.")),
-			getConfigListEntry(_("Stop service on return to movie list"), config.movielist.stop_service, _("If is enabled and movie playback is finished, then after return to movielist will not be automaticaly start service playback.")),
-			getConfigListEntry(_("Load length of movies in movie list"), config.usage.load_length_of_movies_in_moviellist, _("Display movie length in movielist (except single line style).")),
-			getConfigListEntry(_("Show status icons in movie list"), config.usage.show_icons_in_movielist, _("Set if You want see status icons, progress bars or nothing.")),
-			getConfigListEntry(_("Show icon for new/unseen items"), config.usage.movielist_unseen, _("If enabled, then there will be displayed icons for new/unseen items too.")),
-			getConfigListEntry(_("Play audiofiles in list mode"), config.movielist.play_audio_internal, _("If set as 'Yes', then audiofiles are played in 'list mode' only, instead in full screen player.")),
-			getConfigListEntry(_("Root directory"), config.movielist.root, _("You can set selected directory as 'root' directory for movie player.")),
-			getConfigListEntry(_("Hide known extensions"), config.movielist.hide_extensions, _("Do not show file extensions for registered multimedia files.")),
-			getConfigListEntry(_("Automatic bookmarks"), config.movielist.add_bookmark, _("If enabled, bookmarks will be updated with the new location when you move or copy a recording.")),
-			getConfigListEntry(_("Show underline characters in filenames"), config.movielist.show_underlines, _("If disabled, underline characters in file and directory names are not shown and are replaced with spaces.")),
+			(_("Sort"), cfg.moviesort, _("You can set sorting type for items in movielist.")),
+			(_("Show extended description"), cfg.description, _("You can enable if will be displayed extended EPG description for item.")),
+			(_("Type"), cfg.listtype, _("Set movielist type.")),
+			(_("Use individual settings for each directory"), config.movielist.settings_per_directory, _("Settings can be different for each directory separately (for non removeable devices only).")),
+			(_("Allow quitting movie player with exit"), config.usage.leave_movieplayer_onExit, _("When enabled, it is possible to leave the movie player with exit.")),
+			(_("Behavior when a movie reaches the end"), config.usage.on_movie_eof, _("Set action when movie playback is finished.")),
+			(_("Stop service on return to movie list"), config.movielist.stop_service, _("If is enabled and movie playback is finished, then after return to movielist will not be automaticaly start service playback.")),
+			(_("Load length of movies in movie list"), config.usage.load_length_of_movies_in_moviellist, _("Display movie length in movielist (except single line style).")),
+			(_("Show status icons in movie list"), config.usage.show_icons_in_movielist, _("Set if You want see status icons, progress bars or nothing.")),
+			(_("Show icon for new/unseen items"), config.usage.movielist_unseen, _("If enabled, then there will be displayed icons for new/unseen items too.")),
+			(_("Play audiofiles in list mode"), config.movielist.play_audio_internal, _("If set as 'Yes', then audiofiles are played in 'list mode' only, instead in full screen player.")),
+			(_("Root directory"), config.movielist.root, _("You can set selected directory as 'root' directory for movie player.")),
+			(_("Hide known extensions"), config.movielist.hide_extensions, _("Do not show file extensions for registered multimedia files.")),
+			(_("Automatic bookmarks"), config.movielist.add_bookmark, _("If enabled, bookmarks will be updated with the new location when you move or copy a recording.")),
+			(_("Show underline characters in filenames"), config.movielist.show_underlines, _("If disabled, underline characters in file and directory names are not shown and are replaced with spaces.")),
 			]
 		for btn in ('red', 'green', 'yellow', 'blue', 'TV', 'Radio', 'Text', 'F1', 'F2', 'F3'):
-			configList.append(getConfigListEntry(_(btn), userDefinedButtons[btn]))
+			configList.append((_(btn), userDefinedButtons[btn]))
 		ConfigListScreen.__init__(self, configList, session=session, on_change=self.changedEntry)
 		self["key_red"] = StaticText(_("Cancel"))
 		self["key_green"] = StaticText(_("OK"))

--- a/lib/python/Screens/NetworkSetup.py
+++ b/lib/python/Screens/NetworkSetup.py
@@ -9,7 +9,7 @@ from Components.Sources.List import List
 from Components.Label import Label, MultiColorLabel
 from Components.Pixmap import Pixmap, MultiPixmap
 from Components.MenuList import MenuList
-from Components.config import config, ConfigYesNo, ConfigIP, NoSave, ConfigText, ConfigPassword, ConfigSelection, getConfigListEntry
+from Components.config import config, ConfigYesNo, ConfigIP, NoSave, ConfigText, ConfigPassword, ConfigSelection
 from Components.ConfigList import ConfigListScreen
 from Components.PluginComponent import plugins
 from Components.ActionMap import ActionMap, NumberActionMap, HelpableActionMap
@@ -243,7 +243,7 @@ class NameserverSetup(ConfigListScreen, HelpableScreen, Screen):
 
 		i = 1
 		for x in self.nameserverEntries:
-			self.list.append(getConfigListEntry(_("Nameserver %d") % (i), x))
+			self.list.append((_("Nameserver %d") % (i), x))
 			i += 1
 
 		self["config"].list = self.list
@@ -431,19 +431,19 @@ class AdapterSetup(ConfigListScreen, HelpableScreen, Screen):
 
 	def createSetup(self):
 		self.list = []
-		self.InterfaceEntry = getConfigListEntry(_("Use interface"), self.activateInterfaceEntry)
+		self.InterfaceEntry = (_("Use interface"), self.activateInterfaceEntry)
 
 		self.list.append(self.InterfaceEntry)
 		if self.activateInterfaceEntry.value:
-			self.dhcpEntry = getConfigListEntry(_("Use DHCP"), self.dhcpConfigEntry)
+			self.dhcpEntry = (_("Use DHCP"), self.dhcpConfigEntry)
 			self.list.append(self.dhcpEntry)
 			if not self.dhcpConfigEntry.value:
-				self.list.append(getConfigListEntry(_('IP address'), self.ipConfigEntry))
-				self.list.append(getConfigListEntry(_('Netmask'), self.netmaskConfigEntry))
-				self.gatewayEntry = getConfigListEntry(_('Use a gateway'), self.hasGatewayConfigEntry)
+				self.list.append((_('IP address'), self.ipConfigEntry))
+				self.list.append((_('Netmask'), self.netmaskConfigEntry))
+				self.gatewayEntry = (_('Use a gateway'), self.hasGatewayConfigEntry)
 				self.list.append(self.gatewayEntry)
 				if self.hasGatewayConfigEntry.value:
-					self.list.append(getConfigListEntry(_('Gateway'), self.gatewayConfigEntry))
+					self.list.append((_('Gateway'), self.gatewayConfigEntry))
 
 			self.extended = None
 			self.configStrings = None
@@ -456,15 +456,15 @@ class AdapterSetup(ConfigListScreen, HelpableScreen, Screen):
 							self.configStrings = p.fnc["configStrings"]
 						isExistBcmWifi = os.path.exists("/tmp/bcm/" + self.iface)
 						if not isExistBcmWifi:
-							self.hiddenSSID = getConfigListEntry(_("Hidden network"), config.plugins.wlan.hiddenessid)
+							self.hiddenSSID = (_("Hidden network"), config.plugins.wlan.hiddenessid)
 							self.list.append(self.hiddenSSID)
-						self.wlanSSID = getConfigListEntry(_("Network name (SSID)"), config.plugins.wlan.essid)
+						self.wlanSSID = (_("Network name (SSID)"), config.plugins.wlan.essid)
 						self.list.append(self.wlanSSID)
-						self.encryption = getConfigListEntry(_("Encryption"), config.plugins.wlan.encryption)
+						self.encryption = (_("Encryption"), config.plugins.wlan.encryption)
 						self.list.append(self.encryption)
 						if not isExistBcmWifi:
-							self.encryptionType = getConfigListEntry(_("Encryption key type"), config.plugins.wlan.wepkeytype)
-						self.encryptionKey = getConfigListEntry(_("Encryption key"), config.plugins.wlan.psk)
+							self.encryptionType = (_("Encryption key type"), config.plugins.wlan.wepkeytype)
+						self.encryptionKey = (_("Encryption key"), config.plugins.wlan.psk)
 
 						if config.plugins.wlan.encryption.value != "Unencrypted":
 							if config.plugins.wlan.encryption.value == 'WEP':

--- a/lib/python/Screens/ParentalControlSetup.py
+++ b/lib/python/Screens/ParentalControlSetup.py
@@ -1,7 +1,7 @@
 from Screens.Screen import Screen
 from Components.ConfigList import ConfigListScreen
 from Components.ActionMap import NumberActionMap
-from Components.config import config, getConfigListEntry, ConfigNothing, NoSave, configfile
+from Components.config import config, ConfigNothing, NoSave, configfile
 
 from Components.Sources.StaticText import StaticText
 from Screens.MessageBox import MessageBox
@@ -63,31 +63,31 @@ class ParentalControlSetup(ConfigListScreen, ProtectedScreen, Screen):
 				pin_entry_text = _("Change PIN") + _(": 0000 - default (disabled)")
 			else:
 				pin_entry_text = _("Set PIN")
-			self.changePin = getConfigListEntry(pin_entry_text, NoSave(ConfigNothing()))
+			self.changePin = (pin_entry_text, NoSave(ConfigNothing()))
 			self.list.append(self.changePin)
-			self.list.append(getConfigListEntry(_("Protect services"), config.ParentalControl.servicepinactive))
+			self.list.append((_("Protect services"), config.ParentalControl.servicepinactive))
 			if config.ParentalControl.servicepinactive.value:
-				self.list.append(getConfigListEntry(_("Remember service PIN"), config.ParentalControl.storeservicepin))
+				self.list.append((_("Remember service PIN"), config.ParentalControl.storeservicepin))
 				if config.ParentalControl.storeservicepin.value != "never":
-					self.list.append(getConfigListEntry(_("Hide parentel locked services"), config.ParentalControl.hideBlacklist))
-				self.list.append(getConfigListEntry(_("Protect on EPG age"), config.ParentalControl.age))
-				self.reloadLists = getConfigListEntry(_("Reload blacklists"), NoSave(ConfigNothing()))
+					self.list.append((_("Hide parentel locked services"), config.ParentalControl.hideBlacklist))
+				self.list.append((_("Protect on EPG age"), config.ParentalControl.age))
+				self.reloadLists = (_("Reload blacklists"), NoSave(ConfigNothing()))
 				self.list.append(self.reloadLists)
-			self.list.append(getConfigListEntry(_("Protect Screens"), config.ParentalControl.setuppinactive))
+			self.list.append((_("Protect Screens"), config.ParentalControl.setuppinactive))
 			if config.ParentalControl.setuppinactive.value:
-				self.list.append(getConfigListEntry(_("Protect main menu"), config.ParentalControl.config_sections.main_menu))
-				self.list.append(getConfigListEntry(_("Protect timer menu"), config.ParentalControl.config_sections.timer_menu))
-				self.list.append(getConfigListEntry(_("Protect plugin browser"), config.ParentalControl.config_sections.plugin_browser))
-				self.list.append(getConfigListEntry(_("Protect configuration"), config.ParentalControl.config_sections.configuration))
-				self.list.append(getConfigListEntry(_("Protect standby menu"), config.ParentalControl.config_sections.standby_menu))
-				self.list.append(getConfigListEntry(_("Protect software update screen"), config.ParentalControl.config_sections.software_update))
-				self.list.append(getConfigListEntry(_("Protect manufacturer reset screen"), config.ParentalControl.config_sections.manufacturer_reset))
-				self.list.append(getConfigListEntry(_("Protect movie list"), config.ParentalControl.config_sections.movie_list))
-				self.list.append(getConfigListEntry(_("Protect context menus"), config.ParentalControl.config_sections.context_menus))
+				self.list.append((_("Protect main menu"), config.ParentalControl.config_sections.main_menu))
+				self.list.append((_("Protect timer menu"), config.ParentalControl.config_sections.timer_menu))
+				self.list.append((_("Protect plugin browser"), config.ParentalControl.config_sections.plugin_browser))
+				self.list.append((_("Protect configuration"), config.ParentalControl.config_sections.configuration))
+				self.list.append((_("Protect standby menu"), config.ParentalControl.config_sections.standby_menu))
+				self.list.append((_("Protect software update screen"), config.ParentalControl.config_sections.software_update))
+				self.list.append((_("Protect manufacturer reset screen"), config.ParentalControl.config_sections.manufacturer_reset))
+				self.list.append((_("Protect movie list"), config.ParentalControl.config_sections.movie_list))
+				self.list.append((_("Protect context menus"), config.ParentalControl.config_sections.context_menus))
 				if config.usage.menu_sort_mode.value.startswith("user"):
-					self.list.append(getConfigListEntry(_("Protect menu sort"), config.ParentalControl.config_sections.menu_sort))
+					self.list.append((_("Protect menu sort"), config.ParentalControl.config_sections.menu_sort))
 		else:
-			self.changePin = getConfigListEntry(_("Enable parental protection"), NoSave(ConfigNothing()))
+			self.changePin = (_("Enable parental protection"), NoSave(ConfigNothing()))
 			self.list.append(self.changePin)
 		self["config"].list = self.list
 

--- a/lib/python/Screens/RecordPaths.py
+++ b/lib/python/Screens/RecordPaths.py
@@ -2,7 +2,7 @@ from Screens.Screen import Screen
 from Screens.LocationBox import MovieLocationBox, TimeshiftLocationBox
 from Screens.MessageBox import MessageBox
 from Components.Label import Label
-from Components.config import config, ConfigSelection, getConfigListEntry
+from Components.config import config, ConfigSelection
 from Components.ConfigList import ConfigListScreen
 from Components.ActionMap import ActionMap
 from Tools.Directories import fileExists
@@ -90,16 +90,16 @@ class RecordPathsSettings(ConfigListScreen, Screen):
 
 		self.list = []
 		if config.usage.setup_level.index >= 2:
-			self.default_entry = getConfigListEntry(_("Default movie location"), self.default_dirname)
+			self.default_entry = (_("Default movie location"), self.default_dirname)
 			self.list.append(self.default_entry)
-			self.timer_entry = getConfigListEntry(_("Timer recording location"), self.timer_dirname)
+			self.timer_entry = (_("Timer recording location"), self.timer_dirname)
 			self.list.append(self.timer_entry)
-			self.instantrec_entry = getConfigListEntry(_("Instant recording location"), self.instantrec_dirname)
+			self.instantrec_entry = (_("Instant recording location"), self.instantrec_dirname)
 			self.list.append(self.instantrec_entry)
 		else:
-			self.default_entry = getConfigListEntry(_("Movie location"), self.default_dirname)
+			self.default_entry = (_("Movie location"), self.default_dirname)
 			self.list.append(self.default_entry)
-		self.timeshift_entry = getConfigListEntry(_("Timeshift location"), self.timeshift_dirname)
+		self.timeshift_entry = (_("Timeshift location"), self.timeshift_dirname)
 		self.list.append(self.timeshift_entry)
 		self["config"].setList(self.list)
 

--- a/lib/python/Screens/Satconfig.py
+++ b/lib/python/Screens/Satconfig.py
@@ -8,7 +8,7 @@ from Components.Button import Button
 from Components.Label import Label
 from Components.UsageConfig import showrotorpositionChoicesUpdate, preferredTunerChoicesUpdate
 from Components.SelectionList import SelectionList, SelectionEntryComponent
-from Components.config import getConfigListEntry, config, ConfigNothing, ConfigYesNo, configfile, ConfigBoolean, ConfigSelection
+from Components.config import config, ConfigNothing, ConfigYesNo, configfile, ConfigBoolean, ConfigSelection
 from Components.Sources.List import List
 from Components.Sources.StaticText import StaticText
 from Screens.MessageBox import MessageBox
@@ -27,42 +27,42 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 		nim = self.nimConfig
 
 		if mode == "single":
-			self.singleSatEntry = getConfigListEntry(self.indent % _("Satellite"), nim.diseqcA, _("Select the satellite your dish receives from. If you are unsure select 'automatic' and the receiver will attempt to determine this for you."))
+			self.singleSatEntry = (self.indent % _("Satellite"), nim.diseqcA, _("Select the satellite your dish receives from. If you are unsure select 'automatic' and the receiver will attempt to determine this for you."))
 			list.append(self.singleSatEntry)
 			if nim.diseqcA.value in ("360", "560"):
-				list.append(getConfigListEntry(self.indent % _("Use circular LNB"), nim.simpleDiSEqCSetCircularLNB, _("If you are using a Circular polarised LNB select 'yes', otherwise select 'no'.")))
-			list.append(getConfigListEntry(self.indent % _("Send DiSEqC"), nim.simpleSingleSendDiSEqC, _("Only select 'yes' if you are using a multiswich that requires a DiSEqC Port-A command signal. For all other setups select 'no'.")))
+				list.append((self.indent % _("Use circular LNB"), nim.simpleDiSEqCSetCircularLNB, _("If you are using a Circular polarised LNB select 'yes', otherwise select 'no'.")))
+			list.append((self.indent % _("Send DiSEqC"), nim.simpleSingleSendDiSEqC, _("Only select 'yes' if you are using a multiswich that requires a DiSEqC Port-A command signal. For all other setups select 'no'.")))
 		else:
-			list.append(getConfigListEntry(self.indent % _("Port A"), nim.diseqcA, _("Select the satellite which is connected to Port-A of your switch. If you are unsure select 'automatic' and the receiver will attempt to determine this for you. If nothing is connected to this port, select 'nothing connected'.")))
+			list.append((self.indent % _("Port A"), nim.diseqcA, _("Select the satellite which is connected to Port-A of your switch. If you are unsure select 'automatic' and the receiver will attempt to determine this for you. If nothing is connected to this port, select 'nothing connected'.")))
 
 		if mode in ("toneburst_a_b", "diseqc_a_b", "diseqc_a_b_c_d"):
-			list.append(getConfigListEntry(self.indent % _("Port B"), nim.diseqcB, _("Select the satellite which is connected to Port-B of your switch. If you are unsure select 'automatic' and the receiver will attempt to determine this for you. If nothing is connected to this port, select 'nothing connected'.")))
+			list.append((self.indent % _("Port B"), nim.diseqcB, _("Select the satellite which is connected to Port-B of your switch. If you are unsure select 'automatic' and the receiver will attempt to determine this for you. If nothing is connected to this port, select 'nothing connected'.")))
 			if mode == "diseqc_a_b_c_d":
-				list.append(getConfigListEntry(self.indent % _("Port C"), nim.diseqcC, _("Select the satellite which is connected to Port-C of your switch. If you are unsure select 'automatic' and the receiver will attempt to determine this for you. If nothing is connected to this port, select 'nothing connected'.")))
-				list.append(getConfigListEntry(self.indent % _("Port D"), nim.diseqcD, _("Select the satellite which is connected to Port-D of your switch. If you are unsure select 'automatic' and the receiver will attempt to determine this for you. If nothing is connected to this port, select 'nothing connected'.")))
+				list.append((self.indent % _("Port C"), nim.diseqcC, _("Select the satellite which is connected to Port-C of your switch. If you are unsure select 'automatic' and the receiver will attempt to determine this for you. If nothing is connected to this port, select 'nothing connected'.")))
+				list.append((self.indent % _("Port D"), nim.diseqcD, _("Select the satellite which is connected to Port-D of your switch. If you are unsure select 'automatic' and the receiver will attempt to determine this for you. If nothing is connected to this port, select 'nothing connected'.")))
 			if mode != "toneburst_a_b":
-				list.append(getConfigListEntry(self.indent % _("Set voltage and 22KHz"), nim.simpleDiSEqCSetVoltageTone, _("Leave this set to 'yes' unless you fully understand why you are adjusting it.")))
-				list.append(getConfigListEntry(self.indent % _("Send DiSEqC only on satellite change"), nim.simpleDiSEqCOnlyOnSatChange, _("Select 'yes' to only send the DiSEqC command when changing from one satellite to another, or select 'no' for the DiSEqC command to be resent on every zap.")))
+				list.append((self.indent % _("Set voltage and 22KHz"), nim.simpleDiSEqCSetVoltageTone, _("Leave this set to 'yes' unless you fully understand why you are adjusting it.")))
+				list.append((self.indent % _("Send DiSEqC only on satellite change"), nim.simpleDiSEqCOnlyOnSatChange, _("Select 'yes' to only send the DiSEqC command when changing from one satellite to another, or select 'no' for the DiSEqC command to be resent on every zap.")))
 
 	def createPositionerSetup(self, list):
 		nim = self.nimConfig
 		if nim.diseqcMode.value == "positioner_select":
-			self.selectSatsEntry = getConfigListEntry(self.indent % _("Press OK to select satellites"), self.nimConfig.pressOKtoList, _("Press OK to select a group of satellites to configure in one block."))
+			self.selectSatsEntry = (self.indent % _("Press OK to select satellites"), self.nimConfig.pressOKtoList, _("Press OK to select a group of satellites to configure in one block."))
 			list.append(self.selectSatsEntry)
-		list.append(getConfigListEntry(self.indent % _("Longitude"), nim.longitude, _("Enter your current longitude. This is the number of degrees you are from zero meridian as a decimal.")))
-		list.append(getConfigListEntry(" ", nim.longitudeOrientation, _("Enter if you are in the east or west hemisphere.")))
-		list.append(getConfigListEntry(self.indent % _("Latitude"), nim.latitude, _("Enter your current latitude. This is the number of degrees you are from the equator as a decimal.")))
-		list.append(getConfigListEntry(" ", nim.latitudeOrientation, _("Enter if you are north or south of the equator.")))
+		list.append((self.indent % _("Longitude"), nim.longitude, _("Enter your current longitude. This is the number of degrees you are from zero meridian as a decimal.")))
+		list.append((" ", nim.longitudeOrientation, _("Enter if you are in the east or west hemisphere.")))
+		list.append((self.indent % _("Latitude"), nim.latitude, _("Enter your current latitude. This is the number of degrees you are from the equator as a decimal.")))
+		list.append((" ", nim.latitudeOrientation, _("Enter if you are north or south of the equator.")))
 		if SystemInfo["CanMeasureFrontendInputPower"]:
-			self.advancedPowerMeasurement = getConfigListEntry(self.indent % _("Use power measurement"), nim.powerMeasurement, _("Power management. Consult your receiver's manual for more information."))
+			self.advancedPowerMeasurement = (self.indent % _("Use power measurement"), nim.powerMeasurement, _("Power management. Consult your receiver's manual for more information."))
 			list.append(self.advancedPowerMeasurement)
 			if nim.powerMeasurement.value:
-				list.append(getConfigListEntry(self.indent % _("Power threshold in mA"), nim.powerThreshold, _("Power threshold. Consult your receiver's manual for more information.")))
-				self.turningSpeed = getConfigListEntry(self.indent % _("Rotor turning speed"), nim.turningSpeed, _("Select how quickly the dish should move between satellites."))
+				list.append((self.indent % _("Power threshold in mA"), nim.powerThreshold, _("Power threshold. Consult your receiver's manual for more information.")))
+				self.turningSpeed = (self.indent % _("Rotor turning speed"), nim.turningSpeed, _("Select how quickly the dish should move between satellites."))
 				list.append(self.turningSpeed)
 				if nim.turningSpeed.value == "fast epoch":
-					self.turnFastEpochBegin = getConfigListEntry(self.indent % _("Begin time"), nim.fastTurningBegin, _("Only move the dish quickly after this hour."))
-					self.turnFastEpochEnd = getConfigListEntry(self.indent % _("End time"), nim.fastTurningEnd, _("Only move the dish quickly before this hour."))
+					self.turnFastEpochBegin = (self.indent % _("Begin time"), nim.fastTurningBegin, _("Only move the dish quickly after this hour."))
+					self.turnFastEpochEnd = (self.indent % _("End time"), nim.fastTurningEnd, _("Only move the dish quickly before this hour."))
 					list.append(self.turnFastEpochBegin)
 					list.append(self.turnFastEpochEnd)
 		else:
@@ -71,13 +71,13 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 				nim.powerMeasurement.save()
 		if not hasattr(self, 'additionalMotorOptions'):
 			self.additionalMotorOptions = ConfigBoolean(default=any([x.value != x.default for x in (nim.turningspeedH, nim.turningspeedV, nim.tuningstepsize, nim.rotorPositions)]), descriptions={False: _("Show sub-menu"), True: _("Hide sub-menu")})
-		self.showAdditionalMotorOptions = getConfigListEntry(self.indent % _("Extra motor options"), self.additionalMotorOptions, _("Additional motor options allow you to enter details from your motor's spec sheet so enigma can work out how long it will take to move the dish from one satellite to another satellite."))
+		self.showAdditionalMotorOptions = (self.indent % _("Extra motor options"), self.additionalMotorOptions, _("Additional motor options allow you to enter details from your motor's spec sheet so enigma can work out how long it will take to move the dish from one satellite to another satellite."))
 		self.list.append(self.showAdditionalMotorOptions)
 		if self.additionalMotorOptions.value:
-			self.list.append(getConfigListEntry(self.indent % ("   %s [%s/sec]" % (_("Horizontal turning speed"), chr(176))), nim.turningspeedH, _("Consult your motor's spec sheet for this information, or leave the default setting.")))
-			self.list.append(getConfigListEntry(self.indent % ("   %s [%s/sec]" % (_("Vertical turning speed"), chr(176))), nim.turningspeedV, _("Consult your motor's spec sheet for this information, or leave the default setting.")))
-			self.list.append(getConfigListEntry(self.indent % ("   %s [%s]" % (_("Turning step size"), chr(176))), nim.tuningstepsize, _("Consult your motor's spec sheet for this information, or leave the default setting.")))
-			self.list.append(getConfigListEntry(self.indent % ("   %s" % _("Max memory positions")), nim.rotorPositions, _("Consult your motor's spec sheet for this information, or leave the default setting.")))
+			self.list.append((self.indent % ("   %s [%s/sec]" % (_("Horizontal turning speed"), chr(176))), nim.turningspeedH, _("Consult your motor's spec sheet for this information, or leave the default setting.")))
+			self.list.append((self.indent % ("   %s [%s/sec]" % (_("Vertical turning speed"), chr(176))), nim.turningspeedV, _("Consult your motor's spec sheet for this information, or leave the default setting.")))
+			self.list.append((self.indent % ("   %s [%s]" % (_("Turning step size"), chr(176))), nim.tuningstepsize, _("Consult your motor's spec sheet for this information, or leave the default setting.")))
+			self.list.append((self.indent % ("   %s" % _("Max memory positions")), nim.rotorPositions, _("Consult your motor's spec sheet for this information, or leave the default setting.")))
 
 	def adaptConfigModeChoices(self):
 		if self.nim.isCompatible("DVB-S") and not self.nim.isFBCLink():
@@ -113,7 +113,7 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 			self.cableCountriesEntry = None
 
 		if self.nim.isMultiType():
-			self.multiType = getConfigListEntry(_("Tuner type"), self.nimConfig.multiType, _("This is a multitype tuner. Available options depend on the hardware."))
+			self.multiType = (_("Tuner type"), self.nimConfig.multiType, _("This is a multitype tuner. Available options depend on the hardware."))
 			self.list.append(self.multiType)
 			if self.nimConfig.multiType.value == "nothing":
 				self.nimConfig.configMode.value = "nothing"
@@ -125,14 +125,14 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 
 		if self.nim.isCompatible("DVB-S") or (self.nim.isCombined() and self.nim.canBeCompatible("DVB-S")):
 			if self.nim.isCombined():
-				self.configModeDVBS = getConfigListEntry(_("Configure DVB-S"), self.nimConfig.configModeDVBS, _("Select 'Yes' when you want to configure this tuner for DVB-S"))
+				self.configModeDVBS = (_("Configure DVB-S"), self.nimConfig.configModeDVBS, _("Select 'Yes' when you want to configure this tuner for DVB-S"))
 				self.list.append(self.configModeDVBS)
 			if (not self.nim.isMultiType() or self.nimConfig.configMode.value != "nothing") and (not self.nim.isCombined() or self.nimConfig.configModeDVBS.value):
-				self.configMode = getConfigListEntry(self.indent % _("Configuration mode"), self.nimConfig.configMode, _("Select 'FBC SCR' if this tuner will connect to a SCR (Unicable/JESS) device. For all other setups select 'FBC automatic'.") if self.nim.isFBCLink() else _("Configure this tuner using simple or advanced options, or loop it through to another tuner, or copy a configuration from another tuner, or disable it."))
+				self.configMode = (self.indent % _("Configuration mode"), self.nimConfig.configMode, _("Select 'FBC SCR' if this tuner will connect to a SCR (Unicable/JESS) device. For all other setups select 'FBC automatic'.") if self.nim.isFBCLink() else _("Configure this tuner using simple or advanced options, or loop it through to another tuner, or copy a configuration from another tuner, or disable it."))
 				self.list.append(self.configMode)
 				warning_text = _(" Warning: the selected tuner should not use SCR Unicable type for LNBs because each tuner need a own SCR number.")
 				if self.nimConfig.configMode.value == "simple":			#simple setup
-					self.diseqcModeEntry = getConfigListEntry(self.indent % pgettext("Satellite configuration mode", "Mode"), self.nimConfig.diseqcMode, _("Select how the satellite dish is set up. i.e. fixed dish, single LNB, DiSEqC switch, positioner, etc."))
+					self.diseqcModeEntry = (self.indent % pgettext("Satellite configuration mode", "Mode"), self.nimConfig.diseqcMode, _("Select how the satellite dish is set up. i.e. fixed dish, single LNB, DiSEqC switch, positioner, etc."))
 					self.list.append(self.diseqcModeEntry)
 					if self.nimConfig.diseqcMode.value in ("single", "toneburst_a_b", "diseqc_a_b", "diseqc_a_b_c_d"):
 						self.createSimpleSetup(self.list, self.nimConfig.diseqcMode.value)
@@ -140,13 +140,13 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 						self.createPositionerSetup(self.list)
 				elif self.nimConfig.configMode.value == "equal":
 					self.nimConfig.connectedTo.setChoices([((str(id), nimmanager.getNimDescription(id))) for id in nimmanager.canEqualTo(self.slotid)])
-					self.list.append(getConfigListEntry(self.indent % _("Tuner"), self.nimConfig.connectedTo, _("This setting allows the tuner configuration to be a duplication of how another tuner is already configured.") + warning_text))
+					self.list.append((self.indent % _("Tuner"), self.nimConfig.connectedTo, _("This setting allows the tuner configuration to be a duplication of how another tuner is already configured.") + warning_text))
 				elif self.nimConfig.configMode.value == "satposdepends":
 					self.nimConfig.connectedTo.setChoices([((str(id), nimmanager.getNimDescription(id))) for id in nimmanager.canDependOn(self.slotid)])
-					self.list.append(getConfigListEntry(self.indent % _("Tuner"), self.nimConfig.connectedTo, _("Select the tuner that controls the motorised dish.") + warning_text))
+					self.list.append((self.indent % _("Tuner"), self.nimConfig.connectedTo, _("Select the tuner that controls the motorised dish.") + warning_text))
 				elif self.nimConfig.configMode.value == "loopthrough":
 					self.nimConfig.connectedTo.setChoices([((str(id), nimmanager.getNimDescription(id))) for id in nimmanager.canConnectTo(self.slotid)])
-					self.list.append(getConfigListEntry(self.indent % _("Connected to"), self.nimConfig.connectedTo, _("Select the tuner that this loopthrough depends on.") + warning_text))
+					self.list.append((self.indent % _("Connected to"), self.nimConfig.connectedTo, _("Select the tuner that this loopthrough depends on.") + warning_text))
 				elif self.nimConfig.configMode.value == "nothing":
 					pass
 				elif self.nimConfig.configMode.value == "advanced":
@@ -173,15 +173,15 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 						if saved_value is not None:
 							self.nimConfig.advanced.sats.value = saved_value
 						self.nimConfig.advanced.sats.save_forced = True
-					self.advancedSatsEntry = getConfigListEntry(self.indent % _("Satellite"), self.nimConfig.advanced.sats, _("Select the satellite you want to configure. Once that satellite is configured you can select and configure other satellites that will be accessed using this same tuner."))
+					self.advancedSatsEntry = (self.indent % _("Satellite"), self.nimConfig.advanced.sats, _("Select the satellite you want to configure. Once that satellite is configured you can select and configure other satellites that will be accessed using this same tuner."))
 					self.list.append(self.advancedSatsEntry)
 					current_config_sats = self.nimConfig.advanced.sats.value
 					if current_config_sats == "3607":
 						self.nimConfig.connectedTo.setChoices([((str(id), nimmanager.getNimDescription(id))) for id in candependonable])
-						self.list.append(getConfigListEntry(self.indent % _("Tuner"), self.nimConfig.connectedTo, _("Select the tuner that controls the motorised dish.")))
+						self.list.append((self.indent % _("Tuner"), self.nimConfig.connectedTo, _("Select the tuner that controls the motorised dish.")))
 					if current_config_sats in ("3605", "3606", "3607"):
 						if current_config_sats != "3607":
-							self.advancedSelectSatsEntry = getConfigListEntry(self.indent % _("Press OK to select satellites"), self.nimConfig.pressOKtoList, _("Selecting this option allows you to configure a group of satellites in one block."))
+							self.advancedSelectSatsEntry = (self.indent % _("Press OK to select satellites"), self.nimConfig.pressOKtoList, _("Selecting this option allows you to configure a group of satellites in one block."))
 							self.list.append(self.advancedSelectSatsEntry)
 						self.fillListWithAdvancedSatEntrys(self.nimConfig.advanced.sat[int(current_config_sats)])
 					else:
@@ -193,27 +193,27 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 					self.have_advanced = True
 				if self.nimConfig.configMode.value != "nothing" and config.usage.setup_level.index >= 2:
 					if fileExists("/proc/stb/frontend/%d/tone_amplitude" % self.nim.slot):
-						self.toneamplitude = getConfigListEntry(self.indent % _("Tone amplitude"), self.nimConfig.toneAmplitude, _("Your receiver can use tone amplitude. Consult your receiver's manual for more information."))
+						self.toneamplitude = (self.indent % _("Tone amplitude"), self.nimConfig.toneAmplitude, _("Your receiver can use tone amplitude. Consult your receiver's manual for more information."))
 						self.list.append(self.toneamplitude)
 					if fileExists("/proc/stb/frontend/%d/use_scpc_optimized_search_range" % self.nim.slot):
-						self.scpc = getConfigListEntry(self.indent % _("SCPC optimized search range"), self.nimConfig.scpcSearchRange, _("Your receiver can use SCPC optimized search range. Consult your receiver's manual for more information."))
+						self.scpc = (self.indent % _("SCPC optimized search range"), self.nimConfig.scpcSearchRange, _("Your receiver can use SCPC optimized search range. Consult your receiver's manual for more information."))
 						self.list.append(self.scpc)
 					if fileExists("/proc/stb/frontend/%d/t2mirawmode" % self.nim.slot):
-						self.t2mirawmode = getConfigListEntry(self.indent % _("T2MI RAW Mode"), self.nimConfig.t2miRawMode, _("With T2MI RAW mode disabled (default) we can use single T2MI PLP de-encapsulation. With T2MI RAW mode enabled we can use astra-sm to analyze T2MI"))
+						self.t2mirawmode = (self.indent % _("T2MI RAW Mode"), self.nimConfig.t2miRawMode, _("With T2MI RAW mode disabled (default) we can use single T2MI PLP de-encapsulation. With T2MI RAW mode enabled we can use astra-sm to analyze T2MI"))
 						self.list.append(self.t2mirawmode)
 		if self.nim.isCompatible("DVB-C") or (self.nim.isCombined() and self.nim.canBeCompatible("DVB-C")):
 			if self.nim.isCombined():
-				self.configModeDVBC = getConfigListEntry(_("Configure DVB-C"), self.nimConfig.configModeDVBC, _("Select 'Yes' when you want to configure this tuner for DVB-C"))
+				self.configModeDVBC = (_("Configure DVB-C"), self.nimConfig.configModeDVBC, _("Select 'Yes' when you want to configure this tuner for DVB-C"))
 				self.list.append(self.configModeDVBC)
 			elif not self.nim.isMultiType():
 				warning_text = ""
 				if "Vuplus DVB-C NIM(BCM3148)" in self.nim.description and self.nim.isFBCRoot() and self.nim.is_fbc[2] != 1:
 					warning_text = _("Warning: FBC-C V1 tuner should be connected to the first slot to work correctly. Otherwise, only 2 out of 8 demodulators will be available when connected in the second slot. ")
-				self.configMode = getConfigListEntry(self.indent % _("Configuration mode"), self.nimConfig.configMode, warning_text + _("Select 'enabled' if this tuner has a signal cable connected, otherwise select 'nothing connected'."))
+				self.configMode = (self.indent % _("Configuration mode"), self.nimConfig.configMode, warning_text + _("Select 'enabled' if this tuner has a signal cable connected, otherwise select 'nothing connected'."))
 				self.list.append(self.configMode)
 			if self.nimConfig.configModeDVBC.value if self.nim.isCombined() else self.nimConfig.configMode.value != "nothing":
-				self.list.append(getConfigListEntry(self.indent % _("Network ID"), self.nimConfig.cable.scan_networkid, _("This setting depends on your cable provider and location. If you don't know the correct setting refer to the menu in the official cable receiver, or get it from your cable provider, or seek help via internet forum.")))
-				self.cableScanType = getConfigListEntry(self.indent % _("Used service scan type"), self.nimConfig.cable.scan_type, _("Select 'provider' to scan from the predefined list of cable multiplexes. Select 'bands' to only scan certain parts of the spectrum. Select 'steps' to scan in steps of a particular frequency bandwidth."))
+				self.list.append((self.indent % _("Network ID"), self.nimConfig.cable.scan_networkid, _("This setting depends on your cable provider and location. If you don't know the correct setting refer to the menu in the official cable receiver, or get it from your cable provider, or seek help via internet forum.")))
+				self.cableScanType = (self.indent % _("Used service scan type"), self.nimConfig.cable.scan_type, _("Select 'provider' to scan from the predefined list of cable multiplexes. Select 'bands' to only scan certain parts of the spectrum. Select 'steps' to scan in steps of a particular frequency bandwidth."))
 				self.list.append(self.cableScanType)
 				if self.nimConfig.cable.scan_type.value == "provider":
 					# country/region tier one
@@ -223,7 +223,7 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 						default = cablecountrycode in cablecountrycodelist and cablecountrycode or None
 						choices = [("all", _("All"))] + sorted([(x, self.countrycodeToCountry(x)) for x in cablecountrycodelist], key=lambda listItem: listItem[1])
 						self.cableCountries = ConfigSelection(default=default, choices=choices)
-						self.cableCountriesEntry = getConfigListEntry(self.indent % _("Country"), self.cableCountries, _("Select your country. If not available select 'all'."))
+						self.cableCountriesEntry = (self.indent % _("Country"), self.cableCountries, _("Select your country. If not available select 'all'."))
 						self.originalCableRegion = self.nimConfig.cable.scan_provider.value
 					# country/region tier two
 					if self.cableCountries.value == "all":
@@ -237,45 +237,45 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 						self.nimConfig.cable.scan_provider.value = configEntry.value
 						self.nimConfig.cable.scan_provider.save()
 					self.cableRegions.addNotifier(updateCableProvider)
-					self.cableRegionsEntry = getConfigListEntry(self.indent % _("Region"), self.cableRegions, _("Select your provider and region. If not present in this list you will need to select one of the other 'service scan types'."))
+					self.cableRegionsEntry = (self.indent % _("Region"), self.cableRegions, _("Select your provider and region. If not present in this list you will need to select one of the other 'service scan types'."))
 					self.list.append(self.cableCountriesEntry)
 					self.list.append(self.cableRegionsEntry)
 				else:
-					self.cableConfigScanDetails = getConfigListEntry(self.indent % _("Config Scan Details"), self.nimConfig.cable.config_scan_details, _("Select 'yes' to choose what bands or step sizes will be scanned."))
+					self.cableConfigScanDetails = (self.indent % _("Config Scan Details"), self.nimConfig.cable.config_scan_details, _("Select 'yes' to choose what bands or step sizes will be scanned."))
 					self.list.append(self.cableConfigScanDetails)
 					if self.nimConfig.cable.config_scan_details.value:
 						if self.nimConfig.cable.scan_type.value == "bands":
 							# TRANSLATORS: option name, indicating which type of (DVB-C) band should be scanned. The name of the band is printed in '%s'. E.g.: 'Scan EU MID band'
-							self.list.append(getConfigListEntry(self.indent % (_("Scan %s band") % ("EU VHF I")), self.nimConfig.cable.scan_band_EU_VHF_I, _("Select 'yes' to include the %s band in your search.") % ("EU VHF I")))
-							self.list.append(getConfigListEntry(self.indent % (_("Scan %s band") % ("EU MID")), self.nimConfig.cable.scan_band_EU_MID, _("Select 'yes' to include the %s band in your search.") % ("EU MID")))
-							self.list.append(getConfigListEntry(self.indent % (_("Scan %s band") % ("EU VHF III")), self.nimConfig.cable.scan_band_EU_VHF_III, _("Select 'yes' to include the %s band in your search.") % ("EU VHF III")))
-							self.list.append(getConfigListEntry(self.indent % (_("Scan %s band") % ("EU UHF IV")), self.nimConfig.cable.scan_band_EU_UHF_IV, _("Select 'yes' to include the %s band in your search.") % ("EU VHF IV")))
-							self.list.append(getConfigListEntry(self.indent % (_("Scan %s band") % ("EU UHF V")), self.nimConfig.cable.scan_band_EU_UHF_V, _("Select 'yes' to include the %s band in your search.") % ("EU VHF V")))
-							self.list.append(getConfigListEntry(self.indent % (_("Scan %s band") % ("EU SUPER")), self.nimConfig.cable.scan_band_EU_SUPER, _("Select 'yes' to include the %s band in your search.") % ("EU SUPER")))
-							self.list.append(getConfigListEntry(self.indent % (_("Scan %s band") % ("EU HYPER")), self.nimConfig.cable.scan_band_EU_HYPER, _("Select 'yes' to include the %s band in your search.") % ("EU HYPER")))
-							self.list.append(getConfigListEntry(self.indent % (_("Scan %s band") % ("US LOW")), self.nimConfig.cable.scan_band_US_LOW, _("Select 'yes' to include the %s band in your search.") % ("US LOW")))
-							self.list.append(getConfigListEntry(self.indent % (_("Scan %s band") % ("US MID")), self.nimConfig.cable.scan_band_US_MID, _("Select 'yes' to include the %s band in your search.") % ("US MID")))
-							self.list.append(getConfigListEntry(self.indent % (_("Scan %s band") % ("US HIGH")), self.nimConfig.cable.scan_band_US_HIGH, _("Select 'yes' to include the %s band in your search.") % ("US HIGH")))
-							self.list.append(getConfigListEntry(self.indent % (_("Scan %s band") % ("US SUPER")), self.nimConfig.cable.scan_band_US_SUPER, _("Select 'yes' to include the %s band in your search.") % ("US SUPER")))
-							self.list.append(getConfigListEntry(self.indent % (_("Scan %s band") % ("US HYPER")), self.nimConfig.cable.scan_band_US_HYPER, _("Select 'yes' to include the %s band in your search.") % ("US HYPER")))
+							self.list.append((self.indent % (_("Scan %s band") % ("EU VHF I")), self.nimConfig.cable.scan_band_EU_VHF_I, _("Select 'yes' to include the %s band in your search.") % ("EU VHF I")))
+							self.list.append((self.indent % (_("Scan %s band") % ("EU MID")), self.nimConfig.cable.scan_band_EU_MID, _("Select 'yes' to include the %s band in your search.") % ("EU MID")))
+							self.list.append((self.indent % (_("Scan %s band") % ("EU VHF III")), self.nimConfig.cable.scan_band_EU_VHF_III, _("Select 'yes' to include the %s band in your search.") % ("EU VHF III")))
+							self.list.append((self.indent % (_("Scan %s band") % ("EU UHF IV")), self.nimConfig.cable.scan_band_EU_UHF_IV, _("Select 'yes' to include the %s band in your search.") % ("EU VHF IV")))
+							self.list.append((self.indent % (_("Scan %s band") % ("EU UHF V")), self.nimConfig.cable.scan_band_EU_UHF_V, _("Select 'yes' to include the %s band in your search.") % ("EU VHF V")))
+							self.list.append((self.indent % (_("Scan %s band") % ("EU SUPER")), self.nimConfig.cable.scan_band_EU_SUPER, _("Select 'yes' to include the %s band in your search.") % ("EU SUPER")))
+							self.list.append((self.indent % (_("Scan %s band") % ("EU HYPER")), self.nimConfig.cable.scan_band_EU_HYPER, _("Select 'yes' to include the %s band in your search.") % ("EU HYPER")))
+							self.list.append((self.indent % (_("Scan %s band") % ("US LOW")), self.nimConfig.cable.scan_band_US_LOW, _("Select 'yes' to include the %s band in your search.") % ("US LOW")))
+							self.list.append((self.indent % (_("Scan %s band") % ("US MID")), self.nimConfig.cable.scan_band_US_MID, _("Select 'yes' to include the %s band in your search.") % ("US MID")))
+							self.list.append((self.indent % (_("Scan %s band") % ("US HIGH")), self.nimConfig.cable.scan_band_US_HIGH, _("Select 'yes' to include the %s band in your search.") % ("US HIGH")))
+							self.list.append((self.indent % (_("Scan %s band") % ("US SUPER")), self.nimConfig.cable.scan_band_US_SUPER, _("Select 'yes' to include the %s band in your search.") % ("US SUPER")))
+							self.list.append((self.indent % (_("Scan %s band") % ("US HYPER")), self.nimConfig.cable.scan_band_US_HYPER, _("Select 'yes' to include the %s band in your search.") % ("US HYPER")))
 						else:
-							self.list.append(getConfigListEntry(self.indent % _("Frequency scan step size(khz)"), self.nimConfig.cable.scan_frequency_steps, _("Enter the frequency step size for the tuner to use when searching for cable multiplexes. For more information consult your cable provider's documentation.")))
+							self.list.append((self.indent % _("Frequency scan step size(khz)"), self.nimConfig.cable.scan_frequency_steps, _("Enter the frequency step size for the tuner to use when searching for cable multiplexes. For more information consult your cable provider's documentation.")))
 						# TRANSLATORS: option name, indicating which type of (DVB-C) modulation should be scanned. The modulation type is printed in '%s'. E.g.: 'Scan QAM16'
-						self.list.append(getConfigListEntry(self.indent % (_("Scan %s") % ("QAM16")), self.nimConfig.cable.scan_mod_qam16, _("Select 'yes' to include %s multiplexes in your search.") % ("QAM16")))
-						self.list.append(getConfigListEntry(self.indent % (_("Scan %s") % ("QAM32")), self.nimConfig.cable.scan_mod_qam32, _("Select 'yes' to include %s multiplexes in your search.") % ("QAM32")))
-						self.list.append(getConfigListEntry(self.indent % (_("Scan %s") % ("QAM64")), self.nimConfig.cable.scan_mod_qam64, _("Select 'yes' to include %s multiplexes in your search.") % ("QAM64")))
-						self.list.append(getConfigListEntry(self.indent % (_("Scan %s") % ("QAM128")), self.nimConfig.cable.scan_mod_qam128, _("Select 'yes' to include %s multiplexes in your search.") % ("QAM128")))
-						self.list.append(getConfigListEntry(self.indent % (_("Scan %s") % ("QAM256")), self.nimConfig.cable.scan_mod_qam256, _("Select 'yes' to include %s multiplexes in your search.") % ("QAM256")))
-						self.list.append(getConfigListEntry(self.indent % (_("Scan %s") % ("SR6900")), self.nimConfig.cable.scan_sr_6900, _("Select 'yes' to include symbol rate %s in your search.") % ("6900")))
-						self.list.append(getConfigListEntry(self.indent % (_("Scan %s") % ("SR6875")), self.nimConfig.cable.scan_sr_6875, _("Select 'yes' to include symbol rate %s in your search.") % ("6875")))
-						self.list.append(getConfigListEntry(self.indent % (_("Scan additional SR")), self.nimConfig.cable.scan_sr_ext1, _("This field allows you to search an additional symbol rate up to %s.") % ("7320")))
-						self.list.append(getConfigListEntry(self.indent % (_("Scan additional SR")), self.nimConfig.cable.scan_sr_ext2, _("This field allows you to search an additional symbol rate up to %s.") % ("7320")))
+						self.list.append((self.indent % (_("Scan %s") % ("QAM16")), self.nimConfig.cable.scan_mod_qam16, _("Select 'yes' to include %s multiplexes in your search.") % ("QAM16")))
+						self.list.append((self.indent % (_("Scan %s") % ("QAM32")), self.nimConfig.cable.scan_mod_qam32, _("Select 'yes' to include %s multiplexes in your search.") % ("QAM32")))
+						self.list.append((self.indent % (_("Scan %s") % ("QAM64")), self.nimConfig.cable.scan_mod_qam64, _("Select 'yes' to include %s multiplexes in your search.") % ("QAM64")))
+						self.list.append((self.indent % (_("Scan %s") % ("QAM128")), self.nimConfig.cable.scan_mod_qam128, _("Select 'yes' to include %s multiplexes in your search.") % ("QAM128")))
+						self.list.append((self.indent % (_("Scan %s") % ("QAM256")), self.nimConfig.cable.scan_mod_qam256, _("Select 'yes' to include %s multiplexes in your search.") % ("QAM256")))
+						self.list.append((self.indent % (_("Scan %s") % ("SR6900")), self.nimConfig.cable.scan_sr_6900, _("Select 'yes' to include symbol rate %s in your search.") % ("6900")))
+						self.list.append((self.indent % (_("Scan %s") % ("SR6875")), self.nimConfig.cable.scan_sr_6875, _("Select 'yes' to include symbol rate %s in your search.") % ("6875")))
+						self.list.append((self.indent % (_("Scan additional SR")), self.nimConfig.cable.scan_sr_ext1, _("This field allows you to search an additional symbol rate up to %s.") % ("7320")))
+						self.list.append((self.indent % (_("Scan additional SR")), self.nimConfig.cable.scan_sr_ext2, _("This field allows you to search an additional symbol rate up to %s.") % ("7320")))
 		if self.nim.isCompatible("DVB-T") or (self.nim.isCombined() and self.nim.canBeCompatible("DVB-T")):
 			if self.nim.isCombined():
-				self.configModeDVBT = getConfigListEntry(_("Configure DVB-T"), self.nimConfig.configModeDVBT, _("Select 'Yes' when you want to configure this tuner for DVB-T"))
+				self.configModeDVBT = (_("Configure DVB-T"), self.nimConfig.configModeDVBT, _("Select 'Yes' when you want to configure this tuner for DVB-T"))
 				self.list.append(self.configModeDVBT)
 			elif not self.nim.isMultiType():
-				self.configMode = getConfigListEntry(self.indent % _("Configuration mode"), self.nimConfig.configMode, _("Select 'enabled' if this tuner has a signal cable connected, otherwise select 'nothing connected'."))
+				self.configMode = (self.indent % _("Configuration mode"), self.nimConfig.configMode, _("Select 'enabled' if this tuner has a signal cable connected, otherwise select 'nothing connected'."))
 				self.list.append(self.configMode)
 			if self.nimConfig.configModeDVBT.value if self.nim.isCombined() else self.nimConfig.configMode.value != "nothing":
 				# country/region tier one
@@ -285,7 +285,7 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 					default = terrestrialcountrycode in terrestrialcountrycodelist and terrestrialcountrycode or None
 					choices = [("all", _("All"))] + sorted([(x, self.countrycodeToCountry(x)) for x in terrestrialcountrycodelist], key=lambda listItem: listItem[1])
 					self.terrestrialCountries = ConfigSelection(default=default, choices=choices)
-					self.terrestrialCountriesEntry = getConfigListEntry(self.indent % _("Country"), self.terrestrialCountries, _("Select your country. If not available select 'all'."))
+					self.terrestrialCountriesEntry = (self.indent % _("Country"), self.terrestrialCountries, _("Select your country. If not available select 'all'."))
 					self.originalTerrestrialRegion = self.nimConfig.terrestrial.value
 				# country/region tier two
 				if self.terrestrialCountries.value == "all":
@@ -299,22 +299,22 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 					self.nimConfig.terrestrial.value = configEntry.value
 					self.nimConfig.terrestrial.save()
 				self.terrestrialRegions.addNotifier(updateTerrestrialProvider)
-				self.terrestrialRegionsEntry = getConfigListEntry(self.indent % _("Region"), self.terrestrialRegions, _("Select your region. If not available change 'Country' to 'all' and select one of the default alternatives."))
+				self.terrestrialRegionsEntry = (self.indent % _("Region"), self.terrestrialRegions, _("Select your region. If not available change 'Country' to 'all' and select one of the default alternatives."))
 				self.list.append(self.terrestrialCountriesEntry)
 				self.list.append(self.terrestrialRegionsEntry)
-				self.list.append(getConfigListEntry(self.indent % _("Enable 5V for active antenna"), self.nimConfig.terrestrial_5V, _("Enable this setting if your aerial system needs power")))
+				self.list.append((self.indent % _("Enable 5V for active antenna"), self.nimConfig.terrestrial_5V, _("Enable this setting if your aerial system needs power")))
 		if self.nim.isCompatible("ATSC") or (self.nim.isCombined() and self.nim.canBeCompatible("ATSC")):
 			if self.nim.isCombined():
-				self.configModeATSC = getConfigListEntry(_("Configure ATSC"), self.nimConfig.configModeATSC, _("Select 'Yes' when you want to configure this tuner for ATSC"))
+				self.configModeATSC = (_("Configure ATSC"), self.nimConfig.configModeATSC, _("Select 'Yes' when you want to configure this tuner for ATSC"))
 				self.list.append(self.configModeATSC)
 			elif not self.nim.isMultiType():
-				self.configMode = getConfigListEntry(self.indent % _("Configuration mode"), self.nimConfig.configMode, _("Select 'enabled' if this tuner has a signal cable connected, otherwise select 'nothing connected'."))
+				self.configMode = (self.indent % _("Configuration mode"), self.nimConfig.configMode, _("Select 'enabled' if this tuner has a signal cable connected, otherwise select 'nothing connected'."))
 				self.list.append(self.configMode)
 			if self.nimConfig.configModeATSC.value if self.nim.isCombined() else self.nimConfig.configMode.value != "nothing":
-				self.list.append(getConfigListEntry(self.indent % _("ATSC provider"), self.nimConfig.atsc, _("Select your ATSC provider.")))
+				self.list.append((self.indent % _("ATSC provider"), self.nimConfig.atsc, _("Select your ATSC provider.")))
 
 		if self.nimConfig.configMode.value != "nothing" and config.usage.setup_level.index > 1 and not self.nim.isFBCLink():
-			self.list.append(getConfigListEntry(_("Force legacy signal stats"), self.nimConfig.force_legacy_signal_stats, _("If set to 'yes' signal values (SNR, etc) will be calculated from API V3. This is an old API version that has now been superseded.")))
+			self.list.append((_("Force legacy signal stats"), self.nimConfig.force_legacy_signal_stats, _("If set to 'yes' signal values (SNR, etc) will be calculated from API V3. This is an old API version that has now been superseded.")))
 
 		self["config"].list = self.list
 		self.setTextKeyYellow()
@@ -386,47 +386,47 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 			currLnb = None
 
 		# LNBs
-		self.advancedLnbsEntry = getConfigListEntry(self.indent % _("LNB"), Sat.lnb, _("Allocate a number to the physical LNB you are configuring. You will be able to select this LNB again for other satellites (e.g. motorised dishes) to save setting up the same LNB multiple times."))
+		self.advancedLnbsEntry = (self.indent % _("LNB"), Sat.lnb, _("Allocate a number to the physical LNB you are configuring. You will be able to select this LNB again for other satellites (e.g. motorised dishes) to save setting up the same LNB multiple times."))
 		self.list.append(self.advancedLnbsEntry)
 
 		if currLnb:
 			if self.nim.isFBCLink():
 				currLnb.lof.value = "unicable"
-			self.list.append(getConfigListEntry(self.indent % _("Priority"), currLnb.prio, _("This setting is for special setups only. It gives this LNB higher priority over other LNBs with lower values. The free LNB with the highest priority will be the first LNB selected for tuning services.")))
-			self.advancedLof = getConfigListEntry(self.indent % _("Type of LNB/device"), currLnb.lof, _("Select the type of LNB/device being used (normally 'Universal'). If your LNB type is not available select 'user defined'."))
+			self.list.append((self.indent % _("Priority"), currLnb.prio, _("This setting is for special setups only. It gives this LNB higher priority over other LNBs with lower values. The free LNB with the highest priority will be the first LNB selected for tuning services.")))
+			self.advancedLof = (self.indent % _("Type of LNB/device"), currLnb.lof, _("Select the type of LNB/device being used (normally 'Universal'). If your LNB type is not available select 'user defined'."))
 			self.list.append(self.advancedLof)
 			if currLnb.lof.value == "user_defined":
-				self.list.append(getConfigListEntry(self.indent % "LOF/L", currLnb.lofl, _("Enter your low band local oscillator frequency. For more information consult the spec sheet of your LNB.")))
-				self.list.append(getConfigListEntry(self.indent % "LOF/H", currLnb.lofh, _("Enter your high band local oscillator frequency. For more information consult the spec sheet of your LNB.")))
-				self.list.append(getConfigListEntry(self.indent % _("Threshold"), currLnb.threshold, _("Enter the frequency at which you LNB switches between low band and high band. For more information consult the spec sheet of your LNB.")))
+				self.list.append((self.indent % "LOF/L", currLnb.lofl, _("Enter your low band local oscillator frequency. For more information consult the spec sheet of your LNB.")))
+				self.list.append((self.indent % "LOF/H", currLnb.lofh, _("Enter your high band local oscillator frequency. For more information consult the spec sheet of your LNB.")))
+				self.list.append((self.indent % _("Threshold"), currLnb.threshold, _("Enter the frequency at which you LNB switches between low band and high band. For more information consult the spec sheet of your LNB.")))
 
 			if currLnb.lof.value == "unicable":
 				warning_text = ""
 				if "Vuplus DVB-S NIM(AVL6222)" in self.nim.description and self.nim.internallyConnectableTo() is not None:
 					warning_text = _("Warning: the second input of this dual tuner may not support SCR LNBs. ")
-				self.advancedUnicable = getConfigListEntry(self.indent % ("%s%s" % ("SCR (Unicable/JESS) ", _("type"))), currLnb.unicable, warning_text + _("Select the type of Single Cable Reception device you are using."))
+				self.advancedUnicable = (self.indent % ("%s%s" % ("SCR (Unicable/JESS) ", _("type"))), currLnb.unicable, warning_text + _("Select the type of Single Cable Reception device you are using."))
 				self.list.append(self.advancedUnicable)
-				self.externallyPowered = getConfigListEntry(self.indent % _("Externally powered"), currLnb.powerinserter, _("Select whether your SCR device is externally powered."))
+				self.externallyPowered = (self.indent % _("Externally powered"), currLnb.powerinserter, _("Select whether your SCR device is externally powered."))
 				if currLnb.unicable.value == "unicable_user":
-					self.advancedFormat = getConfigListEntry(self.indent % _("Format"), currLnb.format, _("Select the protocol used by your SCR device. Choices are 'SCR Unicable' (Unicable), or 'SCR JESS' (JESS, also known as Unicable II)."))
-					self.advancedPosition = getConfigListEntry(self.indent % _("Position"), currLnb.positionNumber, _("Only change this setting if you are using a SCR device that has been reprogrammed with a custom programmer. For further information check with the person that reprogrammed the device."))
-					self.advancedSCR = getConfigListEntry(self.indent % _("Channel"), currLnb.scrList, _("Select the User Band channel to be assigned to this tuner. This is an index into the table of frequencies the SCR switch or SCR LNB uses to pass the requested transponder to the tuner."))
+					self.advancedFormat = (self.indent % _("Format"), currLnb.format, _("Select the protocol used by your SCR device. Choices are 'SCR Unicable' (Unicable), or 'SCR JESS' (JESS, also known as Unicable II)."))
+					self.advancedPosition = (self.indent % _("Position"), currLnb.positionNumber, _("Only change this setting if you are using a SCR device that has been reprogrammed with a custom programmer. For further information check with the person that reprogrammed the device."))
+					self.advancedSCR = (self.indent % _("Channel"), currLnb.scrList, _("Select the User Band channel to be assigned to this tuner. This is an index into the table of frequencies the SCR switch or SCR LNB uses to pass the requested transponder to the tuner."))
 					self.list.append(self.advancedFormat)
 					self.list.append(self.advancedPosition)
 					self.list.append(self.advancedSCR)
-					self.list.append(getConfigListEntry(self.indent % _("Frequency"), currLnb.scrfrequency, _("Select the User Band frequency to be assigned to this tuner. This is the frequency the SCR switch or SCR LNB uses to pass the requested transponder to the tuner.")))
-					self.list.append(getConfigListEntry(self.indent % "LOF/L", currLnb.lofl, _("Consult your SCR device spec sheet for this information.")))
-					self.list.append(getConfigListEntry(self.indent % "LOF/H", currLnb.lofh, _("Consult your SCR device spec sheet for this information.")))
-					self.list.append(getConfigListEntry(self.indent % _("Threshold"), currLnb.threshold, _("Consult your SCR device spec sheet for this information.")))
+					self.list.append((self.indent % _("Frequency"), currLnb.scrfrequency, _("Select the User Band frequency to be assigned to this tuner. This is the frequency the SCR switch or SCR LNB uses to pass the requested transponder to the tuner.")))
+					self.list.append((self.indent % "LOF/L", currLnb.lofl, _("Consult your SCR device spec sheet for this information.")))
+					self.list.append((self.indent % "LOF/H", currLnb.lofh, _("Consult your SCR device spec sheet for this information.")))
+					self.list.append((self.indent % _("Threshold"), currLnb.threshold, _("Consult your SCR device spec sheet for this information.")))
 					if not SystemInfo["FbcTunerPowerAlwaysOn"] or not self.nim.isFBCTuner():
 						self.list.append(self.externallyPowered)
 					if not currLnb.powerinserter.value:
-						self.list.append(getConfigListEntry(self.indent % _("Bootup time"), currLnb.bootuptime, _("Consult your SCR device spec sheet for this information.")))
+						self.list.append((self.indent % _("Bootup time"), currLnb.bootuptime, _("Consult your SCR device spec sheet for this information.")))
 				else:
-					self.advancedManufacturer = getConfigListEntry(self.indent % _("Manufacturer"), currLnb.unicableManufacturer, _("Select the manufacturer of your SCR device. If the manufacturer is not listed, set 'SCR' to 'user defined' and enter the device parameters manually according to its spec sheet."))
-					self.advancedType = getConfigListEntry(self.indent % _("Model"), currLnb.unicableProduct, _("Select the model number of your SCR device. If the model number is not listed, set 'SCR' to 'user defined' and enter the device parameters manually according to its spec sheet."))
-					self.advancedSCR = getConfigListEntry(self.indent % _("Channel"), currLnb.scrList, _("Select the User Band to be assigned to this tuner. This is an index into the table of frequencies the SCR switch or SCR LNB uses to pass the requested transponder to the tuner."))
-					self.advancedPosition = getConfigListEntry(self.indent % _("Position"), currLnb.positionNumber, _("Only change this setting if you are using a SCR device that has been reprogrammed with a custom programmer. For further information check with the person that reprogrammed the device."))
+					self.advancedManufacturer = (self.indent % _("Manufacturer"), currLnb.unicableManufacturer, _("Select the manufacturer of your SCR device. If the manufacturer is not listed, set 'SCR' to 'user defined' and enter the device parameters manually according to its spec sheet."))
+					self.advancedType = (self.indent % _("Model"), currLnb.unicableProduct, _("Select the model number of your SCR device. If the model number is not listed, set 'SCR' to 'user defined' and enter the device parameters manually according to its spec sheet."))
+					self.advancedSCR = (self.indent % _("Channel"), currLnb.scrList, _("Select the User Band to be assigned to this tuner. This is an index into the table of frequencies the SCR switch or SCR LNB uses to pass the requested transponder to the tuner."))
+					self.advancedPosition = (self.indent % _("Position"), currLnb.positionNumber, _("Only change this setting if you are using a SCR device that has been reprogrammed with a custom programmer. For further information check with the person that reprogrammed the device."))
 					self.list.append(self.advancedManufacturer)
 					self.list.append(self.advancedType)
 					if currLnb.positions.value > 1:
@@ -442,33 +442,33 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 					if self.nim.isFBCLink():
 						if not self.nimConfig.advanced.unicableconnected.value:
 							self.nimConfig.advanced.unicableconnected.value = True
-					self.advancedConnected = getConfigListEntry(self.indent % _("Connected"), self.nimConfig.advanced.unicableconnected, _("Select 'yes' if this tuner is connected to the SCR device through another tuner, otherwise select 'no'."))
+					self.advancedConnected = (self.indent % _("Connected"), self.nimConfig.advanced.unicableconnected, _("Select 'yes' if this tuner is connected to the SCR device through another tuner, otherwise select 'no'."))
 					self.list.append(self.advancedConnected)
 					if self.nimConfig.advanced.unicableconnected.value:
 						self.nimConfig.advanced.unicableconnectedTo.setChoices(choices)
-						self.list.append(getConfigListEntry(self.indent % _("Connected to"), self.nimConfig.advanced.unicableconnectedTo, _("Select the tuner to which the signal cable of the SCR device is connected.")))
+						self.list.append((self.indent % _("Connected to"), self.nimConfig.advanced.unicableconnectedTo, _("Select the tuner to which the signal cable of the SCR device is connected.")))
 
 			else:	#kein Unicable
-				self.list.append(getConfigListEntry(self.indent % _("Voltage mode"), Sat.voltage, _("Select 'polarisation' if using a 'universal' LNB, otherwise consult your LNB spec sheet.")))
-				self.list.append(getConfigListEntry(self.indent % _("Increased voltage"), currLnb.increased_voltage))
-				self.list.append(getConfigListEntry(self.indent % _("Tone mode"), Sat.tonemode, _("Select 'band' if using a 'universal' LNB, otherwise consult your LNB spec sheet.")))
+				self.list.append((self.indent % _("Voltage mode"), Sat.voltage, _("Select 'polarisation' if using a 'universal' LNB, otherwise consult your LNB spec sheet.")))
+				self.list.append((self.indent % _("Increased voltage"), currLnb.increased_voltage))
+				self.list.append((self.indent % _("Tone mode"), Sat.tonemode, _("Select 'band' if using a 'universal' LNB, otherwise consult your LNB spec sheet.")))
 
 			if lnbnum < 65 or lnbnum == 71:
 				if self.nim.isFBCLink() and ("1_2", "1.2") in currLnb.diseqcMode.choices.choices:
 					currLnb.diseqcMode.setChoices([("none", _("none")), ("1_0", "1.0"), ("1_1", "1.1")], "none")
-				self.advancedDiseqcMode = getConfigListEntry(self.indent % _("DiSEqC mode"), currLnb.diseqcMode, _("Select '1.0' for standard committed switches, '1.1' for uncommitted switches, and '1.2' for systems using a positioner."))
+				self.advancedDiseqcMode = (self.indent % _("DiSEqC mode"), currLnb.diseqcMode, _("Select '1.0' for standard committed switches, '1.1' for uncommitted switches, and '1.2' for systems using a positioner."))
 				self.list.append(self.advancedDiseqcMode)
 			if currLnb.diseqcMode.value != "none":
-				self.list.append(getConfigListEntry(self.indent % _("Fast DiSEqC"), currLnb.fastDiseqc, _("Select Fast DiSEqC if your aerial system supports this. If you are unsure select 'no'.")))
-				self.toneburst = getConfigListEntry(self.indent % _("Toneburst"), currLnb.toneburst, _("Select 'A' or 'B' if your aerial system requires this, otherwise select 'none'. If you are unsure select 'none'."))
+				self.list.append((self.indent % _("Fast DiSEqC"), currLnb.fastDiseqc, _("Select Fast DiSEqC if your aerial system supports this. If you are unsure select 'no'.")))
+				self.toneburst = (self.indent % _("Toneburst"), currLnb.toneburst, _("Select 'A' or 'B' if your aerial system requires this, otherwise select 'none'. If you are unsure select 'none'."))
 				self.list.append(self.toneburst)
-				self.committedDiseqcCommand = getConfigListEntry(self.indent % _("DiSEqC 1.0 command"), currLnb.commitedDiseqcCommand, _("If you are using a DiSEqC committed switch enter the port letter required to access the LNB used for this satellite."))
+				self.committedDiseqcCommand = (self.indent % _("DiSEqC 1.0 command"), currLnb.commitedDiseqcCommand, _("If you are using a DiSEqC committed switch enter the port letter required to access the LNB used for this satellite."))
 				self.list.append(self.committedDiseqcCommand)
 				if currLnb.diseqcMode.value == "1_0":
 					if currLnb.toneburst.index and currLnb.commitedDiseqcCommand.index:
-						self.list.append(getConfigListEntry(self.indent % _("Command order"), currLnb.commandOrder1_0, _("This is the order in which DiSEqC commands are sent to the aerial system. The order must correspond exactly with the order the physical devices are arranged along the signal cable (starting from the receiver end).")))
+						self.list.append((self.indent % _("Command order"), currLnb.commandOrder1_0, _("This is the order in which DiSEqC commands are sent to the aerial system. The order must correspond exactly with the order the physical devices are arranged along the signal cable (starting from the receiver end).")))
 				else:
-					self.uncommittedDiseqcCommand = getConfigListEntry(self.indent % _("DiSEqC 1.1 command"), currLnb.uncommittedDiseqcCommand, _("If you are using a DiSEqC uncommitted switch enter the port number required to access the LNB used for this satellite."))
+					self.uncommittedDiseqcCommand = (self.indent % _("DiSEqC 1.1 command"), currLnb.uncommittedDiseqcCommand, _("If you are using a DiSEqC uncommitted switch enter the port number required to access the LNB used for this satellite."))
 					self.list.append(self.uncommittedDiseqcCommand)
 					if currLnb.uncommittedDiseqcCommand.index:
 						if currLnb.commandOrder.value == "ct":
@@ -480,54 +480,54 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 							currLnb.commandOrder.value = "tc"
 						else:
 							currLnb.commandOrder.value = "ct"
-					self.commandOrder = getConfigListEntry(self.indent % _("Command order"), currLnb.commandOrder, _("This is the order in which DiSEqC commands are sent to the aerial system. The order must correspond exactly with the order the physical devices are arranged along the signal cable (starting from the receiver end)."))
+					self.commandOrder = (self.indent % _("Command order"), currLnb.commandOrder, _("This is the order in which DiSEqC commands are sent to the aerial system. The order must correspond exactly with the order the physical devices are arranged along the signal cable (starting from the receiver end)."))
 					if 1 < ((1 if currLnb.uncommittedDiseqcCommand.index else 0) + (1 if currLnb.commitedDiseqcCommand.index else 0) + (1 if currLnb.toneburst.index else 0)):
 						self.list.append(self.commandOrder)
 					if currLnb.uncommittedDiseqcCommand.index:
-						self.list.append(getConfigListEntry(self.indent % _("DiSEqC 1.1 repeats"), currLnb.diseqcRepeats, _("If using multiple uncommitted switches the DiSEqC commands must be sent multiple times. Set to the number of uncommitted switches in the chain minus one.")))
-				self.list.append(getConfigListEntry(self.indent % _("Sequence repeat"), currLnb.sequenceRepeat, _("Set sequence repeats if your aerial system requires this. Normally if the aerial system has been configured correctly sequence repeats will not be necessary. If yours does, recheck you have command order set correctly.")))
+						self.list.append((self.indent % _("DiSEqC 1.1 repeats"), currLnb.diseqcRepeats, _("If using multiple uncommitted switches the DiSEqC commands must be sent multiple times. Set to the number of uncommitted switches in the chain minus one.")))
+				self.list.append((self.indent % _("Sequence repeat"), currLnb.sequenceRepeat, _("Set sequence repeats if your aerial system requires this. Normally if the aerial system has been configured correctly sequence repeats will not be necessary. If yours does, recheck you have command order set correctly.")))
 				if currLnb.diseqcMode.value == "1_2":
 					if SystemInfo["CanMeasureFrontendInputPower"]:
-						self.advancedPowerMeasurement = getConfigListEntry(self.indent % _("Use power measurement"), currLnb.powerMeasurement, _("Power management. Consult your receiver's manual for more information."))
+						self.advancedPowerMeasurement = (self.indent % _("Use power measurement"), currLnb.powerMeasurement, _("Power management. Consult your receiver's manual for more information."))
 						self.list.append(self.advancedPowerMeasurement)
 						if currLnb.powerMeasurement.value:
-							self.list.append(getConfigListEntry(self.indent % _("Power threshold in mA"), currLnb.powerThreshold, _("Power threshold. Consult your receiver's manual for more information.")))
-							self.turningSpeed = getConfigListEntry(self.indent % _("Rotor turning speed"), currLnb.turningSpeed, _("Select how quickly the dish should move between satellites."))
+							self.list.append((self.indent % _("Power threshold in mA"), currLnb.powerThreshold, _("Power threshold. Consult your receiver's manual for more information.")))
+							self.turningSpeed = (self.indent % _("Rotor turning speed"), currLnb.turningSpeed, _("Select how quickly the dish should move between satellites."))
 							self.list.append(self.turningSpeed)
 							if currLnb.turningSpeed.value == "fast epoch":
-								self.turnFastEpochBegin = getConfigListEntry(self.indent % _("Begin time"), currLnb.fastTurningBegin, _("Only move the dish quickly after this hour."))
-								self.turnFastEpochEnd = getConfigListEntry(self.indent % _("End time"), currLnb.fastTurningEnd, _("Only move the dish quickly before this hour."))
+								self.turnFastEpochBegin = (self.indent % _("Begin time"), currLnb.fastTurningBegin, _("Only move the dish quickly after this hour."))
+								self.turnFastEpochEnd = (self.indent % _("End time"), currLnb.fastTurningEnd, _("Only move the dish quickly before this hour."))
 								self.list.append(self.turnFastEpochBegin)
 								self.list.append(self.turnFastEpochEnd)
 					else:
 						if currLnb.powerMeasurement.value:
 							currLnb.powerMeasurement.value = False
 							currLnb.powerMeasurement.save()
-					self.advancedUsalsEntry = getConfigListEntry(self.indent % _("Use USALS for this sat"), Sat.usals, _("USALS automatically moves a motorised dish to the correct satellite based on the coordinates entered by the user. Without USALS each satellite will need to be setup and saved individually."))
+					self.advancedUsalsEntry = (self.indent % _("Use USALS for this sat"), Sat.usals, _("USALS automatically moves a motorised dish to the correct satellite based on the coordinates entered by the user. Without USALS each satellite will need to be setup and saved individually."))
 					if lnbnum < 65:
 						self.list.append(self.advancedUsalsEntry)
 					if Sat.usals.value:
-						self.list.append(getConfigListEntry(self.indent % _("Longitude"), currLnb.longitude, _("Enter your current longitude. This is the number of degrees you are from zero meridian as a decimal.")))
-						self.list.append(getConfigListEntry(" ", currLnb.longitudeOrientation, _("Enter if you are in the east or west hemisphere.")))
-						self.list.append(getConfigListEntry(self.indent % _("Latitude"), currLnb.latitude, _("Enter your current latitude. This is the number of degrees you are from the equator as a decimal.")))
-						self.list.append(getConfigListEntry(" ", currLnb.latitudeOrientation, _("Enter if you are north or south of the equator.")))
+						self.list.append((self.indent % _("Longitude"), currLnb.longitude, _("Enter your current longitude. This is the number of degrees you are from zero meridian as a decimal.")))
+						self.list.append((" ", currLnb.longitudeOrientation, _("Enter if you are in the east or west hemisphere.")))
+						self.list.append((self.indent % _("Latitude"), currLnb.latitude, _("Enter your current latitude. This is the number of degrees you are from the equator as a decimal.")))
+						self.list.append((" ", currLnb.latitudeOrientation, _("Enter if you are north or south of the equator.")))
 					else:
-						self.list.append(getConfigListEntry(self.indent % _("Stored position"), Sat.rotorposition, _("Enter the number stored in the positioner that corresponds to this satellite.")))
+						self.list.append((self.indent % _("Stored position"), Sat.rotorposition, _("Enter the number stored in the positioner that corresponds to this satellite.")))
 					if not hasattr(self, 'additionalMotorOptions'):
 						self.additionalMotorOptions = ConfigBoolean(default=any([x.value != x.default for x in (currLnb.turningspeedH, currLnb.turningspeedV, currLnb.tuningstepsize, currLnb.rotorPositions)]), descriptions={False: _("Show sub-menu"), True: _("Hide sub-menu")})
-					self.showAdditionalMotorOptions = getConfigListEntry(self.indent % _("Extra motor options"), self.additionalMotorOptions, _("Additional motor options allow you to enter details from your motor's spec sheet so enigma can work out how long it will take to move to another satellite."))
+					self.showAdditionalMotorOptions = (self.indent % _("Extra motor options"), self.additionalMotorOptions, _("Additional motor options allow you to enter details from your motor's spec sheet so enigma can work out how long it will take to move to another satellite."))
 					self.list.append(self.showAdditionalMotorOptions)
 					if self.additionalMotorOptions.value:
-						self.list.append(getConfigListEntry(self.indent % ("  %s" % _("Horizontal turning speed")) + " [" + chr(176) + "/sec]", currLnb.turningspeedH, _("Consult your motor's spec sheet for this information, or leave the default setting.")))
-						self.list.append(getConfigListEntry(self.indent % ("  %s" % _("Vertical turning speed")) + " [" + chr(176) + "/sec]", currLnb.turningspeedV, _("Consult your motor's spec sheet for this information, or leave the default setting.")))
-						self.list.append(getConfigListEntry(self.indent % ("  %s" % _("Turning step size")) + " [" + chr(176) + "]", currLnb.tuningstepsize, _("Consult your motor's spec sheet for this information, or leave the default setting.")))
-						self.list.append(getConfigListEntry(self.indent % ("  %s" % _("Max memory positions")), currLnb.rotorPositions, _("Consult your motor's spec sheet for this information, or leave the default setting.")))
+						self.list.append((self.indent % ("  %s" % _("Horizontal turning speed")) + " [" + chr(176) + "/sec]", currLnb.turningspeedH, _("Consult your motor's spec sheet for this information, or leave the default setting.")))
+						self.list.append((self.indent % ("  %s" % _("Vertical turning speed")) + " [" + chr(176) + "/sec]", currLnb.turningspeedV, _("Consult your motor's spec sheet for this information, or leave the default setting.")))
+						self.list.append((self.indent % ("  %s" % _("Turning step size")) + " [" + chr(176) + "]", currLnb.tuningstepsize, _("Consult your motor's spec sheet for this information, or leave the default setting.")))
+						self.list.append((self.indent % ("  %s" % _("Max memory positions")), currLnb.rotorPositions, _("Consult your motor's spec sheet for this information, or leave the default setting.")))
 
 	def fillAdvancedList(self):
 		self.list = []
-		self.configMode = getConfigListEntry(self.indent % _("Configuration mode"), self.nimConfig.configMode)
+		self.configMode = (self.indent % _("Configuration mode"), self.nimConfig.configMode)
 		self.list.append(self.configMode)
-		self.advancedSatsEntry = getConfigListEntry(self.indent % _("Satellite"), self.nimConfig.advanced.sats)
+		self.advancedSatsEntry = (self.indent % _("Satellite"), self.nimConfig.advanced.sats)
 		self.list.append(self.advancedSatsEntry)
 		for x in self.nimConfig.advanced.sat.keys():
 			Sat = self.nimConfig.advanced.sat[x]

--- a/lib/python/Screens/ScanSetup.py
+++ b/lib/python/Screens/ScanSetup.py
@@ -1,6 +1,6 @@
 from Screens.Screen import Screen
 from Screens.ServiceScan import ServiceScan
-from Components.config import config, ConfigSubsection, ConfigSelection, ConfigYesNo, ConfigInteger, getConfigListEntry, ConfigSlider, ConfigEnableDisable, ConfigFloat
+from Components.config import config, ConfigSubsection, ConfigSelection, ConfigYesNo, ConfigInteger, ConfigSlider, ConfigEnableDisable, ConfigFloat
 from Components.ActionMap import NumberActionMap, ActionMap
 from Components.Sources.StaticText import StaticText
 from Components.SystemInfo import SystemInfo
@@ -667,7 +667,7 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 		index_to_scan = int(self.scan_nims.value)
 		print("ID: ", index_to_scan)
 
-		self.tunerEntry = getConfigListEntry(_("Tuner"), self.scan_nims, _("Select which tuner to use for the scan."))
+		self.tunerEntry = (_("Tuner"), self.scan_nims, _("Select which tuner to use for the scan."))
 		self.list.append(self.tunerEntry)
 
 		self.DVB_type = self.nim_type_dict[index_to_scan]["selection"]
@@ -675,7 +675,7 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 		if self.scan_nims == []:
 			return
 
-		self.DVB_TypeEntry = getConfigListEntry(_("DVB type"), self.DVB_type) # multitype?
+		self.DVB_TypeEntry = (_("DVB type"), self.DVB_type) # multitype?
 		if len(self.nim_type_dict[index_to_scan]["modes"]) > 1:
 			self.list.append(self.DVB_TypeEntry)
 		self.typeOfScanEntry = None
@@ -691,26 +691,26 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 		indent = "  "
 		nim = nimmanager.nim_slots[index_to_scan]
 		if self.DVB_type.value == "DVB-S":
-			self.typeOfScanEntry = getConfigListEntry(_("Type of scan"), self.scan_type, _("Choose whether to scan a single transponder, one satellite or multiple satellites."))
+			self.typeOfScanEntry = (_("Type of scan"), self.scan_type, _("Choose whether to scan a single transponder, one satellite or multiple satellites."))
 			self.list.append(self.typeOfScanEntry)
 		elif self.DVB_type.value == "DVB-C":
 			if config.Nims[index_to_scan].cable.scan_type.value != "provider": # only show predefined transponder if in provider mode
 				if self.scan_typecable.value == "predefined_transponder" and self.last_scan_typecable in ("single_transponder", "complete"):
 					self.scan_typecable.value = self.cable_toggle[self.last_scan_typecable]
 			self.last_scan_typecable = self.scan_typecable.value
-			self.typeOfScanEntry = getConfigListEntry(_("Type of scan"), self.scan_typecable)
+			self.typeOfScanEntry = (_("Type of scan"), self.scan_typecable)
 			self.list.append(self.typeOfScanEntry)
 		elif self.DVB_type.value == "DVB-T":
-			self.typeOfScanEntry = getConfigListEntry(_("Type of scan"), self.scan_typeterrestrial)
+			self.typeOfScanEntry = (_("Type of scan"), self.scan_typeterrestrial)
 			self.list.append(self.typeOfScanEntry)
 			if self.scan_typeterrestrial.value == "single_transponder":
-				self.typeOfInputEntry = getConfigListEntry(_("Use frequency or channel"), self.scan_input_as)
+				self.typeOfInputEntry = (_("Use frequency or channel"), self.scan_input_as)
 				if self.ter_channel_input:
 					self.list.append(self.typeOfInputEntry)
 				else:
 					self.scan_input_as.value = self.scan_input_as.choices[0]
 		elif self.DVB_type.value == "ATSC":
-			self.typeOfScanEntry = getConfigListEntry(_("Type of scan"), self.scan_type_atsc)
+			self.typeOfScanEntry = (_("Type of scan"), self.scan_type_atsc)
 			self.list.append(self.typeOfScanEntry)
 
 		self.scan_networkScan.value = False
@@ -718,55 +718,55 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 			if self.scan_type.value == "single_transponder":
 				self.updateSatList()
 				if nim.isCompatible("DVB-S2"):
-					self.systemEntry = getConfigListEntry(_('System'), self.scan_sat.system)
+					self.systemEntry = (_('System'), self.scan_sat.system)
 					self.list.append(self.systemEntry)
 				else:
 					# downgrade to dvb-s, in case a -s2 config was active
 					self.scan_sat.system.value = eDVBFrontendParametersSatellite.System_DVB_S
-				self.list.append(getConfigListEntry(_('Satellite'), self.scan_satselection[index_to_scan], _("Select which satellite to scan.")))
-				self.list.append(getConfigListEntry(_('Frequency'), self.scan_sat.frequency))
-				self.list.append(getConfigListEntry(_('Inversion'), self.scan_sat.inversion))
-				self.list.append(getConfigListEntry(_('Symbol rate'), self.scan_sat.symbolrate))
-				self.list.append(getConfigListEntry(_('Polarization'), self.scan_sat.polarization))
+				self.list.append((_('Satellite'), self.scan_satselection[index_to_scan], _("Select which satellite to scan.")))
+				self.list.append((_('Frequency'), self.scan_sat.frequency))
+				self.list.append((_('Inversion'), self.scan_sat.inversion))
+				self.list.append((_('Symbol rate'), self.scan_sat.symbolrate))
+				self.list.append((_('Polarization'), self.scan_sat.polarization))
 				if self.scan_sat.system.value == eDVBFrontendParametersSatellite.System_DVB_S:
-					self.list.append(getConfigListEntry(_("FEC"), self.scan_sat.fec))
+					self.list.append((_("FEC"), self.scan_sat.fec))
 				elif self.scan_sat.system.value == eDVBFrontendParametersSatellite.System_DVB_S2:
-					self.list.append(getConfigListEntry(_("FEC"), self.scan_sat.fec_s2))
-					self.modulationEntry = getConfigListEntry(_('Modulation'), self.scan_sat.modulation)
+					self.list.append((_("FEC"), self.scan_sat.fec_s2))
+					self.modulationEntry = (_('Modulation'), self.scan_sat.modulation)
 					self.list.append(self.modulationEntry)
-					self.list.append(getConfigListEntry(_('Roll-off'), self.scan_sat.rolloff))
-					self.list.append(getConfigListEntry(_('Pilot'), self.scan_sat.pilot))
+					self.list.append((_('Roll-off'), self.scan_sat.rolloff))
+					self.list.append((_('Pilot'), self.scan_sat.pilot))
 					if nim.isMultistream():
-						self.is_id_boolEntry = getConfigListEntry(_('Transport Stream Type'), self.scan_sat.is_id_bool)
+						self.is_id_boolEntry = (_('Transport Stream Type'), self.scan_sat.is_id_bool)
 						self.list.append(self.is_id_boolEntry)
 						if self.scan_sat.is_id_bool.value:
-							self.list.append(getConfigListEntry("%s%s" % (indent, _('Input Stream ID')), self.scan_sat.is_id))
-							self.list.append(getConfigListEntry("%s%s" % (indent, _('PLS Mode')), self.scan_sat.pls_mode))
-							self.list.append(getConfigListEntry("%s%s" % (indent, _('PLS Code')), self.scan_sat.pls_code))
+							self.list.append(("%s%s" % (indent, _('Input Stream ID')), self.scan_sat.is_id))
+							self.list.append(("%s%s" % (indent, _('PLS Mode')), self.scan_sat.pls_mode))
+							self.list.append(("%s%s" % (indent, _('PLS Code')), self.scan_sat.pls_code))
 					else:
 						self.scan_sat.is_id.value = eDVBFrontendParametersSatellite.No_Stream_Id_Filter
 						self.scan_sat.pls_mode.value = eDVBFrontendParametersSatellite.PLS_Gold
 						self.scan_sat.pls_code.value = eDVBFrontendParametersSatellite.PLS_Default_Gold_Code
 					if nim.isT2MI():
-						self.t2mi_plp_id_boolEntry = getConfigListEntry(_('T2MI PLP'), self.scan_sat.t2mi_plp_id_bool)
+						self.t2mi_plp_id_boolEntry = (_('T2MI PLP'), self.scan_sat.t2mi_plp_id_bool)
 						self.list.append(self.t2mi_plp_id_boolEntry)
 						if self.scan_sat.t2mi_plp_id_bool.value:
-							self.list.append(getConfigListEntry("%s%s" % (indent, _('T2MI PLP ID')), self.scan_sat.t2mi_plp_id))
-							self.list.append(getConfigListEntry("%s%s" % (indent, _('T2MI PID')), self.scan_sat.t2mi_pid))
+							self.list.append(("%s%s" % (indent, _('T2MI PLP ID')), self.scan_sat.t2mi_plp_id))
+							self.list.append(("%s%s" % (indent, _('T2MI PID')), self.scan_sat.t2mi_pid))
 					else:
 						self.scan_sat.t2mi_plp_id.value = eDVBFrontendParametersSatellite.No_T2MI_PLP_Id
 						self.scan_sat.t2mi_pid.value = eDVBFrontendParametersSatellite.T2MI_Default_Pid
 			elif self.scan_type.value == "predefined_transponder" and self.satList[index_to_scan]:
 				self.updateSatList()
-				self.preDefSatList = getConfigListEntry(_('Satellite'), self.scan_satselection[index_to_scan], _("Select which satellite to scan."))
+				self.preDefSatList = (_('Satellite'), self.scan_satselection[index_to_scan], _("Select which satellite to scan."))
 				self.list.append(self.preDefSatList)
 				sat = self.satList[index_to_scan][self.scan_satselection[index_to_scan].index]
 				self.predefinedTranspondersList(sat[0])
-				self.list.append(getConfigListEntry(_('Transponder'), self.preDefTransponders, _("Select which transponder to scan.")))
+				self.list.append((_('Transponder'), self.preDefTransponders, _("Select which transponder to scan.")))
 			elif self.scan_type.value == "single_satellite":
 				self.updateSatList()
 				print(self.scan_satselection[index_to_scan])
-				self.list.append(getConfigListEntry(_("Satellite"), self.scan_satselection[index_to_scan], _("Select which satellite to scan.")))
+				self.list.append((_("Satellite"), self.scan_satselection[index_to_scan], _("Select which satellite to scan.")))
 				self.scan_networkScan.value = True
 			elif "multisat" in self.scan_type.value:
 				tlist = []
@@ -775,27 +775,27 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 					if self.Satexists(tlist, x[0]) == 0:
 						tlist.append(x[0])
 						sat = ConfigEnableDisable(default="_yes" in self.scan_type.value and True or False)
-						configEntry = getConfigListEntry(nimmanager.getSatDescription(x[0]), sat)
+						configEntry = (nimmanager.getSatDescription(x[0]), sat)
 						self.list.append(configEntry)
 						self.multiscanlist.append((x[0], sat))
 				self.scan_networkScan.value = True
 		elif self.DVB_type.value == "DVB-C":
 			if self.scan_typecable.value == "single_transponder":
-				self.list.append(getConfigListEntry(_("Frequency"), self.scan_cab.frequency))
-				self.list.append(getConfigListEntry(_("Inversion"), self.scan_cab.inversion))
-				self.list.append(getConfigListEntry(_("Symbol rate"), self.scan_cab.symbolrate))
-				self.list.append(getConfigListEntry(_("Modulation"), self.scan_cab.modulation))
-				self.list.append(getConfigListEntry(_("FEC"), self.scan_cab.fec))
+				self.list.append((_("Frequency"), self.scan_cab.frequency))
+				self.list.append((_("Inversion"), self.scan_cab.inversion))
+				self.list.append((_("Symbol rate"), self.scan_cab.symbolrate))
+				self.list.append((_("Modulation"), self.scan_cab.modulation))
+				self.list.append((_("FEC"), self.scan_cab.fec))
 			elif self.scan_typecable.value == "predefined_transponder":
 				self.predefinedCabTranspondersList()
-				self.list.append(getConfigListEntry(_('Transponder'), self.CableTransponders, _("Select which transponder to scan.")))
+				self.list.append((_('Transponder'), self.CableTransponders, _("Select which transponder to scan.")))
 			if config.Nims[index_to_scan].cable.scan_networkid.value:
 				self.networkid = config.Nims[index_to_scan].cable.scan_networkid.value
 				self.scan_networkScan.value = True
 		elif self.DVB_type.value == "DVB-T":
 			if self.scan_typeterrestrial.value == "single_transponder":
 				if nim.canBeCompatible("DVB-T2"):
-					self.systemEntry = getConfigListEntry(_('System'), self.scan_ter.system)
+					self.systemEntry = (_('System'), self.scan_ter.system)
 					self.list.append(self.systemEntry)
 				else:
 					self.scan_ter.system.value = eDVBFrontendParametersTerrestrial.System_DVB_T
@@ -803,65 +803,65 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 					channel = getChannelNumber(self.scan_ter.frequency.floatint * 1000, self.ter_tnumber)
 					if channel:
 						self.scan_ter.channel.value = int(channel.replace("+", "").replace("-", ""))
-					self.list.append(getConfigListEntry(_("Channel"), self.scan_ter.channel))
+					self.list.append((_("Channel"), self.scan_ter.channel))
 				else:
 					prev_val = self.scan_ter.frequency.floatint
 					self.scan_ter.frequency.floatint = channel2frequency(self.scan_ter.channel.value, self.ter_tnumber) // 1000
 					if self.scan_ter.frequency.floatint == 474000:
 						self.scan_ter.frequency.floatint = prev_val
-					self.list.append(getConfigListEntry(_("Frequency"), self.scan_ter.frequency))
-				self.list.append(getConfigListEntry(_("Inversion"), self.scan_ter.inversion))
-				self.list.append(getConfigListEntry(_("Bandwidth"), self.scan_ter.bandwidth))
-				self.list.append(getConfigListEntry(_("Code rate HP"), self.scan_ter.fechigh))
-				self.list.append(getConfigListEntry(_("Code rate LP"), self.scan_ter.feclow))
-				self.list.append(getConfigListEntry(_("Modulation"), self.scan_ter.modulation))
-				self.list.append(getConfigListEntry(_("Transmission mode"), self.scan_ter.transmission))
-				self.list.append(getConfigListEntry(_("Guard interval"), self.scan_ter.guard))
-				self.list.append(getConfigListEntry(_("Hierarchy info"), self.scan_ter.hierarchy))
+					self.list.append((_("Frequency"), self.scan_ter.frequency))
+				self.list.append((_("Inversion"), self.scan_ter.inversion))
+				self.list.append((_("Bandwidth"), self.scan_ter.bandwidth))
+				self.list.append((_("Code rate HP"), self.scan_ter.fechigh))
+				self.list.append((_("Code rate LP"), self.scan_ter.feclow))
+				self.list.append((_("Modulation"), self.scan_ter.modulation))
+				self.list.append((_("Transmission mode"), self.scan_ter.transmission))
+				self.list.append((_("Guard interval"), self.scan_ter.guard))
+				self.list.append((_("Hierarchy info"), self.scan_ter.hierarchy))
 				if self.scan_ter.system.value == eDVBFrontendParametersTerrestrial.System_DVB_T2:
-					self.list.append(getConfigListEntry(_('PLP ID'), self.scan_ter.plp_id))
+					self.list.append((_('PLP ID'), self.scan_ter.plp_id))
 			elif self.scan_typeterrestrial.value == "predefined_transponder":
 				if nim.canBeCompatible("DVB-T2"):
-					self.systemEntry = getConfigListEntry(_('System'), self.scan_ter.system)
+					self.systemEntry = (_('System'), self.scan_ter.system)
 					self.list.append(self.systemEntry)
 				else:
 					self.scan_ter.system.value = eDVBFrontendParametersTerrestrial.System_DVB_T
 				self.TerrestrialRegion = nim.config.terrestrial
-				self.TerrestrialRegionEntry = getConfigListEntry(_('Region'), self.TerrestrialRegion)
+				self.TerrestrialRegionEntry = (_('Region'), self.TerrestrialRegion)
 				self.list.append(self.TerrestrialRegionEntry)
 				self.predefinedTerrTranspondersList()
-				self.list.append(getConfigListEntry(_('Transponder'), self.TerrestrialTransponders, _("Select which transponder to scan.")))
+				self.list.append((_('Transponder'), self.TerrestrialTransponders, _("Select which transponder to scan.")))
 			elif self.scan_typeterrestrial.value == "complete":
 				self.TerrestrialRegion = nim.config.terrestrial
 				if nimmanager.getNimName(nim.slot).startswith("Sundtek"):
-					self.TerrestrialCompleteEntry = getConfigListEntry(_('Scan options'), self.scan_ter_complete_type)
+					self.TerrestrialCompleteEntry = (_('Scan options'), self.scan_ter_complete_type)
 					self.list.append(self.TerrestrialCompleteEntry)
 				elif SystemInfo["Blindscan_t2_available"] and nim.isCompatible("DVB-T2") and len(self.terrestrialTransponderGetCmd(nim.slot)):
-					self.list.append(getConfigListEntry(_('Blindscan'), self.scan_terrestrial_binary_scan))
+					self.list.append((_('Blindscan'), self.scan_terrestrial_binary_scan))
 				if self.TerrestrialCompleteEntry is None or self.scan_ter_complete_type.value == "extended":
 					if nim.canBeCompatible("DVB-T2"):
-						self.systemEntry = getConfigListEntry(_('System'), self.scan_ter.system)
+						self.systemEntry = (_('System'), self.scan_ter.system)
 						self.list.append(self.systemEntry)
 					else:
 						self.scan_ter.system.value = eDVBFrontendParametersTerrestrial.System_DVB_T
-					self.TerrestrialRegionEntry = getConfigListEntry(_('Region'), self.TerrestrialRegion)
+					self.TerrestrialRegionEntry = (_('Region'), self.TerrestrialRegion)
 					self.list.append(self.TerrestrialRegionEntry)
 		elif self.DVB_type.value == "ATSC":
 			if self.scan_type_atsc.value == "single_transponder":
-				self.systemEntry = getConfigListEntry(_("System"), self.scan_ats.system)
+				self.systemEntry = (_("System"), self.scan_ats.system)
 				self.list.append(self.systemEntry)
-				self.list.append(getConfigListEntry(_("Frequency"), self.scan_ats.frequency))
-				self.list.append(getConfigListEntry(_("Inversion"), self.scan_ats.inversion))
-				self.list.append(getConfigListEntry(_("Modulation"), self.scan_ats.modulation))
+				self.list.append((_("Frequency"), self.scan_ats.frequency))
+				self.list.append((_("Inversion"), self.scan_ats.inversion))
+				self.list.append((_("Modulation"), self.scan_ats.modulation))
 			elif self.scan_type_atsc.value == "predefined_transponder":
 				#FIXME add region
 				self.predefinedATSCTranspondersList()
-				self.list.append(getConfigListEntry(_('Transponder'), self.ATSCTransponders, _("Select which transponder to scan.")))
+				self.list.append((_('Transponder'), self.ATSCTransponders, _("Select which transponder to scan.")))
 			elif self.scan_type_atsc.value == "complete":
 				pass #FIXME
-		self.list.append(getConfigListEntry(_("Network scan"), self.scan_networkScan, _("Scan using transponders on NIT table? 'No' will use transponders in xml file.")))
-		self.list.append(getConfigListEntry(_("Clear before scan"), self.scan_clearallservices, _("Remove the services on scanned transponders before re-adding services?")))
-		self.list.append(getConfigListEntry(_("Only free scan"), self.scan_onlyfree, _("Choose whether to scan for free services only or whether to include paid/encrypted services too.")))
+		self.list.append((_("Network scan"), self.scan_networkScan, _("Scan using transponders on NIT table? 'No' will use transponders in xml file.")))
+		self.list.append((_("Clear before scan"), self.scan_clearallservices, _("Remove the services on scanned transponders before re-adding services?")))
+		self.list.append((_("Only free scan"), self.scan_onlyfree, _("Choose whether to scan for free services only or whether to include paid/encrypted services too.")))
 		self["config"].list = self.list
 
 	def Satexists(self, tlist, pos):
@@ -1765,18 +1765,18 @@ class ScanSimple(ConfigListScreen, Screen, CableTransponderSearchSupport, Terres
 		if len(nims_to_scan):
 			self.scan_networkScan = ConfigYesNo(default=True)
 			self.scan_clearallservices = ConfigSelection(default="yes", choices=[("no", _("no")), ("yes", _("yes")), ("yes_hold_feeds", _("yes (keep feeds)"))])
-			self.list.append(getConfigListEntry(_("Network scan"), self.scan_networkScan))
-			self.list.append(getConfigListEntry(_("Clear before scan"), self.scan_clearallservices))
+			self.list.append((_("Network scan"), self.scan_networkScan))
+			self.list.append((_("Clear before scan"), self.scan_clearallservices))
 
 			for nim in nims_to_scan:
 				nimconfig = ConfigYesNo(default=True)
 				nimconfig.nim_index = nim.slot
 				self.nim_enable.append(nimconfig)
-				self.list.append(getConfigListEntry(_("Scan ") + nim.slot_name + " (" + nim.friendly_type + ")", nimconfig))
+				self.list.append((_("Scan ") + nim.slot_name + " (" + nim.friendly_type + ")", nimconfig))
 
 			self.scan_terrestrial_binary_scan = ConfigYesNo(default=False)
 			if self.t2_nim_found:
-				self.list.append(getConfigListEntry(_("Blindscan terrestrial (if possible)"), self.scan_terrestrial_binary_scan))
+				self.list.append((_("Blindscan terrestrial (if possible)"), self.scan_terrestrial_binary_scan))
 
 		ConfigListScreen.__init__(self, self.list)
 		self["footer"] = Label(_("Press OK to scan"))

--- a/lib/python/Screens/SetupFallbacktuner.py
+++ b/lib/python/Screens/SetupFallbacktuner.py
@@ -4,7 +4,7 @@ from Components.ActionMap import ActionMap
 from Components.Pixmap import Pixmap
 from Components.Sources.Boolean import Boolean
 from Components.Sources.StaticText import StaticText
-from Components.config import config, configfile, ConfigSelection, ConfigIP, ConfigInteger, getConfigListEntry, ConfigBoolean
+from Components.config import config, configfile, ConfigSelection, ConfigIP, ConfigInteger, ConfigBoolean
 from Components.ConfigList import ConfigListScreen
 from Components.ImportChannels import ImportChannels
 
@@ -92,119 +92,119 @@ class SetupFallbacktuner(ConfigListScreen, Screen):
 
 	def createSetup(self):
 		self.list = []
-		self.list.append(getConfigListEntry(_("Enable fallback remote receiver"),
+		self.list.append((_("Enable fallback remote receiver"),
 			config.usage.remote_fallback_enabled,
 			_("Enable remote enigma2 receiver to be tried to tune into services that cannot be tuned into locally (e.g. tuner is occupied or service type is unavailable on the local tuner. Specify complete URL including http:// and port number (normally ...:8001), e.g. http://second_box:8001.")))
-		self.list.append(getConfigListEntry(_("Import from remote receiver URL"),
+		self.list.append((_("Import from remote receiver URL"),
 			config.usage.remote_fallback_import,
 			_("Import channels and/or EPG from remote receiver URL when receiver is booted")))
 		if config.usage.remote_fallback_enabled.value or config.usage.remote_fallback_import.value:
-			self.list.append(getConfigListEntry(_("Enable import timer from fallback tuner"),
+			self.list.append((_("Enable import timer from fallback tuner"),
 				config.usage.remote_fallback_external_timer,
 				_("When enabled the timer from the fallback tuner is imported")))
-			self.list.append(getConfigListEntry(_("Fallback remote receiver"),
+			self.list.append((_("Fallback remote receiver"),
 				self.avahiselect,
 				_("Destination of fallback remote receiver")))
 			if self.avahiselect.value == "ip":
-				self.list.append(getConfigListEntry("  %s" % _("Fallback remote receiver IP"),
+				self.list.append(("  %s" % _("Fallback remote receiver IP"),
 					self.ip,
 					_("IP of fallback remote receiver")))
-				self.list.append(getConfigListEntry("  %s" % _("Fallback remote receiver Port"),
+				self.list.append(("  %s" % _("Fallback remote receiver Port"),
 					self.port,
 					_("Port of fallback remote receiver")))
 			if self.avahiselect.value == "url":
-				self.list.append(getConfigListEntry("  %s" % _("Fallback remote receiver URL"),
+				self.list.append(("  %s" % _("Fallback remote receiver URL"),
 					config.usage.remote_fallback,
 					_("URL of fallback remote receiver")))
 		if config.usage.remote_fallback_enabled.value and config.usage.remote_fallback_import.value and config.usage.remote_fallback.value:
-			self.list.append(getConfigListEntry(_("Import remote receiver URL"),
+			self.list.append((_("Import remote receiver URL"),
 				self.avahiselect_seperate,
 				_("URL of fallback remote receiver")))
 			if self.avahiselect_seperate.value == "ip":
-				self.list.append(getConfigListEntry("  %s" % _("Fallback remote receiver IP"),
+				self.list.append(("  %s" % _("Fallback remote receiver IP"),
 					self.ip_seperate,
 					_("IP of fallback remote receiver")))
-				self.list.append(getConfigListEntry("  %s" % _("Fallback remote receiver Port"),
+				self.list.append(("  %s" % _("Fallback remote receiver Port"),
 					self.port_seperate,
 					_("Port of fallback remote receiver")))
 			if self.avahiselect_seperate.value == "url":
-				self.list.append(getConfigListEntry("  %s" % _("Fallback remote receiver URL"),
+				self.list.append(("  %s" % _("Fallback remote receiver URL"),
 					config.usage.remote_fallback_import_url,
 					_("URL of fallback remote receiver")))
 		if config.usage.remote_fallback_enabled.value and config.usage.remote_fallback_import.value:
-			self.list.append(getConfigListEntry(_("Also import at reboot/restart enigma2"),
+			self.list.append((_("Also import at reboot/restart enigma2"),
 				config.usage.remote_fallback_import_restart,
 				_("Import channels and/or EPG from remote receiver URL when receiver or enigma2 is restarted")))
-			self.list.append(getConfigListEntry(_("Also import when box is leaving standby"),
+			self.list.append((_("Also import when box is leaving standby"),
 				config.usage.remote_fallback_import_standby,
 				_("Import channels and/or EPG from remote receiver URL also when the receiver is getting out of standby")))
-			self.list.append(getConfigListEntry(_("Also import from the extension menu"),
+			self.list.append((_("Also import from the extension menu"),
 				config.usage.remote_fallback_extension_menu,
 				_("Make it possible to manually initiate the channels import and/or EPG via the extension menu")))
-			self.list.append(getConfigListEntry(_("Show notification when import channels was successful"),
+			self.list.append((_("Show notification when import channels was successful"),
 				config.usage.remote_fallback_ok,
 				_("Show notification when import channels and/or EPG from remote receiver URL is completed")))
-			self.list.append(getConfigListEntry(_("Show notification when import channels was not successful"),
+			self.list.append((_("Show notification when import channels was not successful"),
 				config.usage.remote_fallback_nok,
 				_("Show notification when import channels and/or EPG from remote receiver URL did not complete")))
-			self.list.append(getConfigListEntry(_("Customize OpenWebIF settings for fallback tuner"),
+			self.list.append((_("Customize OpenWebIF settings for fallback tuner"),
 				config.usage.remote_fallback_openwebif_customize,
 				_("When enabled you can customize the OpenWebIf settings for the fallback tuner")))
 			if config.usage.remote_fallback_openwebif_customize.value:
-				self.list.append(getConfigListEntry("  %s" % _("User ID"),
+				self.list.append(("  %s" % _("User ID"),
 					config.usage.remote_fallback_openwebif_userid,
 					_("Set the User ID of the OpenWebif from your fallback tuner")))
-				self.list.append(getConfigListEntry("  %s" % _("Password"),
+				self.list.append(("  %s" % _("Password"),
 					config.usage.remote_fallback_openwebif_password,
 					_("Set the password of the OpenWebif from your fallback tuner")))
-				self.list.append(getConfigListEntry("  %s" % _("Port"),
+				self.list.append(("  %s" % _("Port"),
 					config.usage.remote_fallback_openwebif_port,
 					"  %s" % _("Set the port of the OpenWebif from your fallback tuner")))
 		if config.usage.remote_fallback_enabled.value and config.usage.remote_fallback.value:
-			self.list.append(getConfigListEntry(_("Alternative URLs for DVB-T/C or ATSC"),
+			self.list.append((_("Alternative URLs for DVB-T/C or ATSC"),
 				config.usage.remote_fallback_alternative,
 				_("Set alternative fallback tuners for DVB-T/C or ATSC")))
 			if config.usage.remote_fallback_alternative.value:
-				self.list.append(getConfigListEntry("  %s" % _("Fallback remote receiver for DVB-T"),
+				self.list.append(("  %s" % _("Fallback remote receiver for DVB-T"),
 					self.avahi_dvb_t,
 					_("Destination of fallback remote receiver for DVB-T")))
 				if self.avahi_dvb_t.value == "ip":
-					self.list.append(getConfigListEntry("    %s" % _("Fallback remote receiver IP"),
+					self.list.append(("    %s" % _("Fallback remote receiver IP"),
 						self.ip_dvb_t,
 						_("IP of fallback remote receiver")))
-					self.list.append(getConfigListEntry("    %s" % _("Fallback remote receiver Port"),
+					self.list.append(("    %s" % _("Fallback remote receiver Port"),
 						self.port_dvb_t,
 						_("Port of fallback remote receiver")))
 				if self.avahi_dvb_t.value == "url":
-					self.list.append(getConfigListEntry("    %s" % _("Fallback remote receiver URL"),
+					self.list.append(("    %s" % _("Fallback remote receiver URL"),
 						config.usage.remote_fallback_dvb_t,
 						_("URL of fallback remote receiver")))
-				self.list.append(getConfigListEntry("  %s" % _("Fallback remote receiver for DVB-C"),
+				self.list.append(("  %s" % _("Fallback remote receiver for DVB-C"),
 					self.avahi_dvb_c,
 					_("Destination of fallback remote receiver for DVB-C")))
 				if self.avahi_dvb_c.value == "ip":
-					self.list.append(getConfigListEntry("    %s" % _("Fallback remote receiver IP"),
+					self.list.append(("    %s" % _("Fallback remote receiver IP"),
 						self.ip_dvb_c,
 						_("IP of fallback remote receiver")))
-					self.list.append(getConfigListEntry("    %s" % _("Fallback remote receiver Port"),
+					self.list.append(("    %s" % _("Fallback remote receiver Port"),
 						self.port_dvb_c,
 						_("Port of fallback remote receiver")))
 				if self.avahi_dvb_c.value == "url":
-					self.list.append(getConfigListEntry("    %s" % _("Fallback remote receiver URL"),
+					self.list.append(("    %s" % _("Fallback remote receiver URL"),
 						config.usage.remote_fallback_dvb_c,
 						_("URL of fallback remote receiver")))
-				self.list.append(getConfigListEntry("  %s" % _("Fallback remote receiver for ATSC"),
+				self.list.append(("  %s" % _("Fallback remote receiver for ATSC"),
 					self.avahi_atsc,
 					_("Destination of fallback remote receiver for ATSC")))
 				if self.avahi_atsc.value == "ip":
-					self.list.append(getConfigListEntry("    %s" % _("Fallback remote receiver IP"),
+					self.list.append(("    %s" % _("Fallback remote receiver IP"),
 						self.ip_atsc,
 						_("IP of fallback remote receiver")))
-					self.list.append(getConfigListEntry("    %s" % _("Fallback remote receiver Port"),
+					self.list.append(("    %s" % _("Fallback remote receiver Port"),
 						self.port_atsc,
 						_("Port of fallback remote receiver")))
 				if self.avahi_atsc.value == "url":
-					self.list.append(getConfigListEntry("    %s" % _("Fallback remote receiver URL"),
+					self.list.append(("    %s" % _("Fallback remote receiver URL"),
 						config.usage.remote_fallback_atsc,
 						_("URL of fallback remote receiver")))
 		self["config"].list = self.list

--- a/lib/python/Screens/SleepTimerEdit.py
+++ b/lib/python/Screens/SleepTimerEdit.py
@@ -5,7 +5,7 @@ from Components.ActionMap import ActionMap
 from Components.ConfigList import ConfigListScreen
 from Components.Label import Label
 from Components.Sources.StaticText import StaticText
-from Components.config import config, getConfigListEntry
+from Components.config import config
 from enigma import eEPGCache
 from time import time, localtime, mktime
 
@@ -37,96 +37,96 @@ class SleepTimerEdit(ConfigListScreen, Screen):
 			statusSleeptimerText = _("(activated +%d min)") % InfoBar.instance.sleepTimerState()
 		else:
 			statusSleeptimerText = _("(not activated)")
-		self.list.append(getConfigListEntry(_("Sleeptimer") + " " + statusSleeptimerText,
+		self.list.append((_("Sleeptimer") + " " + statusSleeptimerText,
 			config.usage.sleep_timer,
 			_("Configure the duration in minutes for the sleeptimer. Select this entry and click OK or green to start/stop the sleeptimer")))
-		self.list.append(getConfigListEntry(_("Inactivity Sleeptimer"),
+		self.list.append((_("Inactivity Sleeptimer"),
 			config.usage.inactivity_timer,
 			_("Configure the duration in hours the receiver should go to standby when the receiver is not controlled.")))
 		if int(config.usage.inactivity_timer.value):
-			self.list.append(getConfigListEntry(_("Specify timeframe to ignore inactivity sleeptimer"),
+			self.list.append((_("Specify timeframe to ignore inactivity sleeptimer"),
 				config.usage.inactivity_timer_blocktime,
 				_("When enabled you can specify a timeframe when the inactivity sleeptimer is ignored. Not the detection is disabled during this timeframe but the inactivity timeout is disabled")))
 			if config.usage.inactivity_timer_blocktime.value:
-				self.list.append(getConfigListEntry(_("Set blocktimes by weekday"),
+				self.list.append((_("Set blocktimes by weekday"),
 					config.usage.inactivity_timer_blocktime_by_weekdays,
 					_("Specify if you want to set the blocktimes separately by weekday")))
 				if config.usage.inactivity_timer_blocktime_by_weekdays.value:
 					for i in range(7):
-						self.list.append(getConfigListEntry([_("Monday"), _("Tuesday"), _("Wednesday"), _("Thursday"), _("Friday"), _("Saturday"), _("Sunday")][i],
+						self.list.append(([_("Monday"), _("Tuesday"), _("Wednesday"), _("Thursday"), _("Friday"), _("Saturday"), _("Sunday")][i],
 							config.usage.inactivity_timer_blocktime_day[i]))
 						if config.usage.inactivity_timer_blocktime_day[i].value:
-							self.list.append(getConfigListEntry(_("Start time to ignore inactivity sleeptimer"),
+							self.list.append((_("Start time to ignore inactivity sleeptimer"),
 								config.usage.inactivity_timer_blocktime_begin_day[i],
 								_("Specify the start time when the inactivity sleeptimer should be ignored")))
-							self.list.append(getConfigListEntry(_("End time to ignore inactivity sleeptimer"),
+							self.list.append((_("End time to ignore inactivity sleeptimer"),
 								config.usage.inactivity_timer_blocktime_end_day[i],
 								_("Specify the end time until the inactivity sleeptimer should be ignored")))
-							self.list.append(getConfigListEntry(_("Specify extra timeframe to ignore inactivity sleeptimer"),
+							self.list.append((_("Specify extra timeframe to ignore inactivity sleeptimer"),
 								config.usage.inactivity_timer_blocktime_extra_day[i],
 								_("When enabled you can specify an extra timeframe when the inactivity sleeptimer is ignored. Not the detection is disabled during this timeframe but the inactivity timeout is disabled")))
 							if config.usage.inactivity_timer_blocktime_extra_day[i].value:
-								self.list.append(getConfigListEntry(_("Extra start time to ignore inactivity sleeptimer"),
+								self.list.append((_("Extra start time to ignore inactivity sleeptimer"),
 									config.usage.inactivity_timer_blocktime_extra_begin_day[i],
 									_("Specify the extra start time when the inactivity sleeptimer should be ignored")))
-								self.list.append(getConfigListEntry(_("Extra end time to ignore inactivity sleeptimer"),
+								self.list.append((_("Extra end time to ignore inactivity sleeptimer"),
 									config.usage.inactivity_timer_blocktime_extra_end_day[i],
 									_("Specify the extra end time until the inactivity sleeptimer should be ignored")))
 				else:
-					self.list.append(getConfigListEntry(_("Start time to ignore inactivity sleeptimer"),
+					self.list.append((_("Start time to ignore inactivity sleeptimer"),
 						config.usage.inactivity_timer_blocktime_begin,
 						_("Specify the start time when the inactivity sleeptimer should be ignored")))
-					self.list.append(getConfigListEntry(_("End time to ignore inactivity sleeptimer"),
+					self.list.append((_("End time to ignore inactivity sleeptimer"),
 						config.usage.inactivity_timer_blocktime_end,
 						_("Specify the end time until the inactivity sleeptimer should be ignored")))
-					self.list.append(getConfigListEntry(_("Specify extra timeframe to ignore inactivity sleeptimer"),
+					self.list.append((_("Specify extra timeframe to ignore inactivity sleeptimer"),
 						config.usage.inactivity_timer_blocktime_extra,
 						_("When enabled you can specify an extra timeframe when the inactivity sleeptimer is ignored. Not the detection is disabled during this timeframe but the inactivity timeout is disabled")))
 					if config.usage.inactivity_timer_blocktime_extra.value:
-						self.list.append(getConfigListEntry(_("Extra start time to ignore inactivity sleeptimer"),
+						self.list.append((_("Extra start time to ignore inactivity sleeptimer"),
 							config.usage.inactivity_timer_blocktime_extra_begin,
 							_("Specify the extra start time when the inactivity sleeptimer should be ignored")))
-						self.list.append(getConfigListEntry(_("Extra end time to ignore inactivity sleeptimer"),
+						self.list.append((_("Extra end time to ignore inactivity sleeptimer"),
 							config.usage.inactivity_timer_blocktime_extra_end,
 							_("Specify the extra end time until the inactivity sleeptimer should be ignored")))
-		self.list.append(getConfigListEntry(_("Shutdown when in Standby"),
+		self.list.append((_("Shutdown when in Standby"),
 			config.usage.standby_to_shutdown_timer,
 			_("Configure the duration when the receiver should go to shut down in case the receiver is in standby mode.")))
 		if int(config.usage.standby_to_shutdown_timer.value):
-			self.list.append(getConfigListEntry(_("Specify timeframe to ignore the shutdown in standby"),
+			self.list.append((_("Specify timeframe to ignore the shutdown in standby"),
 				config.usage.standby_to_shutdown_timer_blocktime,
 				_("When enabled you can specify a timeframe to ignore the shutdown timer when the receiver is in standby mode")))
 			if config.usage.standby_to_shutdown_timer_blocktime.value:
-				self.list.append(getConfigListEntry(_("Start time to ignore shutdown in standby"),
+				self.list.append((_("Start time to ignore shutdown in standby"),
 					config.usage.standby_to_shutdown_timer_blocktime_begin,
 					_("Specify the start time to ignore the shutdown timer when the receiver is in standby mode")))
-				self.list.append(getConfigListEntry(_("End time to ignore shutdown in standby"),
+				self.list.append((_("End time to ignore shutdown in standby"),
 					config.usage.standby_to_shutdown_timer_blocktime_end,
 					_("Specify the end time to ignore the shutdown timer when the receiver is in standby mode")))
-		self.list.append(getConfigListEntry(_("Enable wakeup timer"),
+		self.list.append((_("Enable wakeup timer"),
 			config.usage.wakeup_enabled,
 			_("Note: when enabled, and you do want standby mode after wake up, set option 'Startup to Standby' as 'No, except Wakeup timer'.")))
 		if config.usage.wakeup_enabled.value != "no":
 			for i in range(7):
-				self.list.append(getConfigListEntry([_("Monday"), _("Tuesday"), _("Wednesday"), _("Thursday"), _("Friday"), _("Saturday"), _("Sunday")][i],
+				self.list.append(([_("Monday"), _("Tuesday"), _("Wednesday"), _("Thursday"), _("Friday"), _("Saturday"), _("Sunday")][i],
 					config.usage.wakeup_day[i]))
 				if config.usage.wakeup_day[i].value:
-					self.list.append(getConfigListEntry(_("Wakeup time"),
+					self.list.append((_("Wakeup time"),
 						config.usage.wakeup_time[i]))
-		self.list.append(getConfigListEntry(_("Enable power off timer"),
+		self.list.append((_("Enable power off timer"),
 			config.usage.poweroff_enabled,
 			_("Automatically power off box to deep standby mode.")))
 		if config.usage.poweroff_enabled.value:
 			for i in range(7):
-				self.list.append(getConfigListEntry([_("Monday"), _("Tuesday"), _("Wednesday"), _("Thursday"), _("Friday"), _("Saturday"), _("Sunday")][i],
+				self.list.append(([_("Monday"), _("Tuesday"), _("Wednesday"), _("Thursday"), _("Friday"), _("Saturday"), _("Sunday")][i],
 					config.usage.poweroff_day[i]))
 				if config.usage.poweroff_day[i].value:
-					self.list.append(getConfigListEntry(_("Power off time"),
+					self.list.append((_("Power off time"),
 						config.usage.poweroff_time[i]))
-			self.list.append(getConfigListEntry(_("Next day starts at"),
+			self.list.append((_("Next day starts at"),
 				config.usage.poweroff_nextday,
 				_("If the box is supposed to enter deep standby e.g. monday night at 1 AM, it actually is already tuesday. To enable this anyway, differing next day start time can be specified here.")))
-			self.list.append(getConfigListEntry(_("Force power off (even when not in standby)"),
+			self.list.append((_("Force power off (even when not in standby)"),
 				config.usage.poweroff_force,
 				_("Forces deep standby, even when not in standby mode. Scheduled recordings remain unaffected.")))
 		self["config"].list = self.list

--- a/lib/python/Screens/SoftcamSetup.py
+++ b/lib/python/Screens/SoftcamSetup.py
@@ -2,7 +2,7 @@ from Screens.Screen import Screen
 from Screens.MessageBox import MessageBox
 from Components.ConfigList import ConfigListScreen
 from Components.ActionMap import ActionMap
-from Components.config import ConfigSelection, getConfigListEntry, ConfigAction
+from Components.config import ConfigSelection, ConfigAction
 from Components.ScrollLabel import ScrollLabel
 from Tools.Directories import resolveFilename, SCOPE_PLUGINS
 from Tools.GetEcmInfo import GetEcmInfo
@@ -61,16 +61,16 @@ class SoftcamSetup(Screen, ConfigListScreen):
 		self.softcams.value = self.softcam.current()
 
 		self.softcams_text = _("Select Softcam")
-		self.list.append(getConfigListEntry(self.softcams_text, self.softcams))
+		self.list.append((self.softcams_text, self.softcams))
 		if cardservers:
 			self.cardservers = ConfigSelection(choices=cardservers)
 			self.cardservers.value = self.cardserver.current()
-			self.list.append(getConfigListEntry(_("Select Card Server"), self.cardservers))
+			self.list.append((_("Select Card Server"), self.cardservers))
 
-		self.list.append(getConfigListEntry(_("Restart softcam"), ConfigAction(self.restart, "s")))
+		self.list.append((_("Restart softcam"), ConfigAction(self.restart, "s")))
 		if cardservers:
-			self.list.append(getConfigListEntry(_("Restart cardserver"), ConfigAction(self.restart, "c")))
-			self.list.append(getConfigListEntry(_("Restart both"), ConfigAction(self.restart, "sc")))
+			self.list.append((_("Restart cardserver"), ConfigAction(self.restart, "c")))
+			self.list.append((_("Restart both"), ConfigAction(self.restart, "sc")))
 
 		self["key_red"] = StaticText(_("Cancel"))
 		self["key_green"] = StaticText(_("OK"))

--- a/lib/python/Screens/TaskView.py
+++ b/lib/python/Screens/TaskView.py
@@ -1,5 +1,5 @@
 from Components.ActionMap import ActionMap
-from Components.config import config, ConfigSubsection, ConfigSelection, getConfigListEntry
+from Components.config import config, ConfigSubsection, ConfigSelection
 from Components.ConfigList import ConfigListScreen
 from Components.Sources.Progress import Progress
 from Components.Sources.StaticText import StaticText
@@ -69,7 +69,7 @@ class JobView(InfoBarNotifications, ConfigListScreen, Screen):
 
 	def setupList(self):
 		if self.afterEventChangeable:
-			self["config"].setList([getConfigListEntry(_("After event"), self.settings.afterEvent)])
+			self["config"].setList([(_("After event"), self.settings.afterEvent)])
 		else:
 			self["config"].hide()
 		self.job.afterEvent = self.settings.afterEvent.getValue()

--- a/lib/python/Screens/TimeDateInput.py
+++ b/lib/python/Screens/TimeDateInput.py
@@ -1,5 +1,5 @@
 from Screens.Screen import Screen
-from Components.config import ConfigClock, ConfigDateTime, getConfigListEntry
+from Components.config import ConfigClock, ConfigDateTime
 from Components.ActionMap import NumberActionMap
 from Components.ConfigList import ConfigListScreen
 from Components.Sources.StaticText import StaticText
@@ -44,8 +44,8 @@ class TimeDateInput(ConfigListScreen, Screen):
 
 	def createSetup(self, configlist):
 		self.list = [
-			getConfigListEntry(_("Date"), self.timeinput_date),
-			getConfigListEntry(_("Time"), self.timeinput_time)
+			(_("Date"), self.timeinput_date),
+			(_("Time"), self.timeinput_time)
 		]
 		configlist.list = self.list
 		configlist.l.setList(self.list)

--- a/lib/python/Screens/TimerEntry.py
+++ b/lib/python/Screens/TimerEntry.py
@@ -1,7 +1,7 @@
 from Screens.Screen import Screen
 from Screens import ChannelSelection
 from ServiceReference import ServiceReference
-from Components.config import config, ConfigSelection, ConfigText, ConfigSubList, ConfigDateTime, ConfigClock, ConfigYesNo, getConfigListEntry
+from Components.config import config, ConfigSelection, ConfigText, ConfigSubList, ConfigDateTime, ConfigClock, ConfigYesNo
 from Components.ActionMap import NumberActionMap
 from Components.ConfigList import ConfigListScreen
 from Components.MenuList import MenuList
@@ -164,82 +164,82 @@ class TimerEntry(ConfigListScreen, Screen):
 
 	def createSetup(self, widget):
 		self.list = []
-		self.entryFallbackTimer = getConfigListEntry(_("Fallback Timer"), self.timerentry_fallback)
+		self.entryFallbackTimer = (_("Fallback Timer"), self.timerentry_fallback)
 		if config.usage.remote_fallback_external_timer.value and config.usage.remote_fallback.value and not hasattr(self, "timerentry_remote"):
 			self.list.append(self.entryFallbackTimer)
-		self.entryName = getConfigListEntry(_("Name"), self.timerentry_name)
+		self.entryName = (_("Name"), self.timerentry_name)
 		self.list.append(self.entryName)
-		self.entryDescription = getConfigListEntry(_("Description"), self.timerentry_description)
+		self.entryDescription = (_("Description"), self.timerentry_description)
 		self.list.append(self.entryDescription)
-		self.timerJustplayEntry = getConfigListEntry(_("Timer type"), self.timerentry_justplay)
+		self.timerJustplayEntry = (_("Timer type"), self.timerentry_justplay)
 		if config.usage.setup_level.index >= 1:
 			self.list.append(self.timerJustplayEntry)
-		self.timerTypeEntry = getConfigListEntry(_("Repeat type"), self.timerentry_type)
+		self.timerTypeEntry = (_("Repeat type"), self.timerentry_type)
 		self.list.append(self.timerTypeEntry)
 
 		if self.timerentry_type.value == "once":
 			self.frequencyEntry = None
 		else: # repeated
-			self.frequencyEntry = getConfigListEntry(_("Repeats"), self.timerentry_repeated)
+			self.frequencyEntry = (_("Repeats"), self.timerentry_repeated)
 			self.list.append(self.frequencyEntry)
-			self.repeatedbegindateEntry = getConfigListEntry(_("Starting on"), self.timerentry_repeatedbegindate)
+			self.repeatedbegindateEntry = (_("Starting on"), self.timerentry_repeatedbegindate)
 			self.list.append(self.repeatedbegindateEntry)
 			if self.timerentry_repeated.value == "daily":
 				pass
 			if self.timerentry_repeated.value == "weekdays":
 				pass
 			if self.timerentry_repeated.value == "weekly":
-				self.list.append(getConfigListEntry(_("Weekday"), self.timerentry_weekday))
+				self.list.append((_("Weekday"), self.timerentry_weekday))
 
 			if self.timerentry_repeated.value == "user":
-				self.list.append(getConfigListEntry(_("Monday"), self.timerentry_day[0]))
-				self.list.append(getConfigListEntry(_("Tuesday"), self.timerentry_day[1]))
-				self.list.append(getConfigListEntry(_("Wednesday"), self.timerentry_day[2]))
-				self.list.append(getConfigListEntry(_("Thursday"), self.timerentry_day[3]))
-				self.list.append(getConfigListEntry(_("Friday"), self.timerentry_day[4]))
-				self.list.append(getConfigListEntry(_("Saturday"), self.timerentry_day[5]))
-				self.list.append(getConfigListEntry(_("Sunday"), self.timerentry_day[6]))
+				self.list.append((_("Monday"), self.timerentry_day[0]))
+				self.list.append((_("Tuesday"), self.timerentry_day[1]))
+				self.list.append((_("Wednesday"), self.timerentry_day[2]))
+				self.list.append((_("Thursday"), self.timerentry_day[3]))
+				self.list.append((_("Friday"), self.timerentry_day[4]))
+				self.list.append((_("Saturday"), self.timerentry_day[5]))
+				self.list.append((_("Sunday"), self.timerentry_day[6]))
 			if self.timerentry_justplay.value != "zap":
-				self.list.append(getConfigListEntry(_("Rename name and description for new events"), self.timerentry_renamerepeat))
+				self.list.append((_("Rename name and description for new events"), self.timerentry_renamerepeat))
 
-		self.entryDate = getConfigListEntry(_("Date"), self.timerentry_date)
+		self.entryDate = (_("Date"), self.timerentry_date)
 		if self.timerentry_type.value == "once":
 			self.list.append(self.entryDate)
 
-		self.entryStartTime = getConfigListEntry(_("Start time"), self.timerentry_starttime)
+		self.entryStartTime = (_("Start time"), self.timerentry_starttime)
 		self.list.append(self.entryStartTime)
 
-		self.entryShowEndTime = getConfigListEntry(_("Set end time"), self.timerentry_showendtime)
-		self.entryZapWakeup = getConfigListEntry(_("Wakeup receiver for start timer"), self.timerentry_zapwakeup)
+		self.entryShowEndTime = (_("Set end time"), self.timerentry_showendtime)
+		self.entryZapWakeup = (_("Wakeup receiver for start timer"), self.timerentry_zapwakeup)
 		if self.timerentry_justplay.value == "zap":
 			self.list.append(self.entryZapWakeup)
 			if SystemInfo["PIPAvailable"]:
-				self.list.append(getConfigListEntry(_("Use as PiP if possible"), self.timerentry_pipzap))
+				self.list.append((_("Use as PiP if possible"), self.timerentry_pipzap))
 			self.list.append(self.entryShowEndTime)
 			self["key_blue"].setText(_("Wakeup type"))
 		else:
 			self["key_blue"].setText("")
-		self.entryEndTime = getConfigListEntry(_("End time"), self.timerentry_endtime)
+		self.entryEndTime = (_("End time"), self.timerentry_endtime)
 		if self.timerentry_justplay.value != "zap" or self.timerentry_showendtime.value:
 			self.list.append(self.entryEndTime)
 
-		self.channelEntry = getConfigListEntry(_("Channel"), self.timerentry_service)
+		self.channelEntry = (_("Channel"), self.timerentry_service)
 		self.list.append(self.channelEntry)
 
-		self.dirname = getConfigListEntry(_("Location"), self.timerentry_fallbackdirname) if self.timerentry_fallback.value and self.timerentry_fallbackdirname.value else getConfigListEntry(_("Location"), self.timerentry_dirname)
+		self.dirname = (_("Location"), self.timerentry_fallbackdirname) if self.timerentry_fallback.value and self.timerentry_fallbackdirname.value else (_("Location"), self.timerentry_dirname)
 		if config.usage.setup_level.index >= 2 and ((self.timerentry_fallback.value and self.timerentry_fallbackdirname.value) or (self.timerentry_justplay.value != "zap" and self.timerentry_dirname.value)): # expert+
 			self.list.append(self.dirname)
 
-		self.conflictDetectionEntry = getConfigListEntry(_("Enable timer conflict detection"), self.timerentry_conflictdetection)
+		self.conflictDetectionEntry = (_("Enable timer conflict detection"), self.timerentry_conflictdetection)
 		if not self.timerentry_fallback.value:
 			self.list.append(self.conflictDetectionEntry)
 
-		self.tagsSet = getConfigListEntry(_("Tags"), self.timerentry_tagsset)
+		self.tagsSet = (_("Tags"), self.timerentry_tagsset)
 		if self.timerentry_justplay.value != "zap" and not self.timerentry_fallback.value:
 			if getPreferredTagEditor():
 				self.list.append(self.tagsSet)
-			self.list.append(getConfigListEntry(_("After event"), self.timerentry_afterevent))
-			self.list.append(getConfigListEntry(_("Recording type"), self.timerentry_recordingtype))
+			self.list.append((_("After event"), self.timerentry_afterevent))
+			self.list.append((_("Recording type"), self.timerentry_recordingtype))
 
 		self[widget].list = self.list
 
@@ -492,7 +492,7 @@ class TimerEntry(ConfigListScreen, Screen):
 
 	def changeTimerType(self):
 		self.timerentry_justplay.selectNext()
-		self.timerJustplayEntry = getConfigListEntry(_("Timer type"), self.timerentry_justplay)
+		self.timerJustplayEntry = (_("Timer type"), self.timerentry_justplay)
 		self["config"].invalidate(self.timerJustplayEntry)
 		self.createSetup("config")
 


### PR DESCRIPTION
No need to check the number of arguments when they are fixed in the function call.
Assertion is disabled in OpenPLi oe-core as well.

Remain all brackets to create a tuple with the arguments. Except Autodiseqc.py since it has one argument.