### PR TITLE
[ConfigList] add sanity check in getCurrentValue

### DIFF
--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -184,7 +184,7 @@ class ConfigListScreen:
 		return self["config"].getCurrent() and self["config"].getCurrent()[0] or ""
 
 	def getCurrentValue(self):
-		return self["config"].getCurrent() and str(self["config"].getCurrent()[1].getText()) or ""
+		return self["config"].getCurrent() and len(self["config"].getCurrent()) > 1 and str(self["config"].getCurrent()[1].getText()) or ""
 
 	def getCurrentDescription(self):
 		return self["config"].getCurrent() and len(self["config"].getCurrent()) > 2 and self["config"].getCurrent()[2] or ""


### PR DESCRIPTION
 crash log when entering the audio selection:
File "/usr/lib/enigma2/python/Components/ConfigList.py", line 187, in getCurrentValue
IndexError: tuple index out of range
+
https://github.com/OpenPLi/enigma2/pull/3604#issuecomment-1426793855