### PR TITLE
[Navigation] save to variable config.misc.prev_wakeup_time.value

### DIFF
--- a/lib/python/Navigation.py
+++ b/lib/python/Navigation.py
@@ -41,13 +41,14 @@ class Navigation:
 		self.RecordTimer = RecordTimer.RecordTimer()
 		self.__wasTimerWakeup = getFPWasTimerWakeup()
 		self.__isRestartUI = config.misc.RestartUI.value
+		self.__prevWakeupTime = config.misc.prev_wakeup_time.value
 		startup_to_standby = config.usage.startup_to_standby.value
 		wakeup_time_type = config.misc.prev_wakeup_time_type.value
 		self.wakeup_timer_enabled = False
 		if config.usage.remote_fallback_import_restart.value:
 			ImportChannels()
 		if self.__wasTimerWakeup:
-			self.wakeup_timer_enabled = wakeup_time_type == 3 and config.misc.prev_wakeup_time.value
+			self.wakeup_timer_enabled = wakeup_time_type == 3 and self.__prevWakeupTime
 			if not self.wakeup_timer_enabled:
 				RecordTimer.RecordTimerEntry.setWasInDeepStandby()
 		if config.misc.RestartUI.value:
@@ -57,12 +58,12 @@ class Navigation:
 		else:
 			if config.usage.remote_fallback_import.value and not config.usage.remote_fallback_import_restart.value:
 				ImportChannels()
-			if startup_to_standby == "yes" or self.__wasTimerWakeup and config.misc.prev_wakeup_time.value and (wakeup_time_type == 0 or wakeup_time_type == 1 or (wakeup_time_type == 3 and startup_to_standby == "except")):
+			if startup_to_standby == "yes" or self.__wasTimerWakeup and self.__prevWakeupTime and (wakeup_time_type == 0 or wakeup_time_type == 1 or (wakeup_time_type == 3 and startup_to_standby == "except")):
 				if not Screens.Standby.inTryQuitMainloop:
 					self.standbytimer = eTimer()
 					self.standbytimer.callback.append(self.gotostandby)
 					self.standbytimer.start(15000, True) # Time increse 15 second for standby.
-		if config.misc.prev_wakeup_time.value:
+		if self.__prevWakeupTime:
 			config.misc.prev_wakeup_time.value = 0
 			config.misc.prev_wakeup_time.save()
 			configfile.save()
@@ -76,6 +77,9 @@ class Navigation:
 
 	def isRestartUI(self):
 		return self.__isRestartUI
+
+	def prevWakeupTime(self):
+		return self.__prevWakeupTime
 
 	def dispatchEvent(self, i):
 		for x in self.event:


### PR DESCRIPTION
-needed for some plugins that use wakeup timer
-just saves the first value of the until new start E2
-then we can compare this value with the plugin's wakeup time
-determining who wakeup the receiver