### PR TITLE
Update hr.po

### DIFF
--- a/po/hr.po
+++ b/po/hr.po
@@ -7196,7 +7196,7 @@ msgid "Sao Tome and Principe"
 msgstr "Sao Tome i Principe"
 
 msgid "Sat"
-msgstr "Sat"
+msgstr "Sub"
 
 msgid "Satellite"
 msgstr "Satelit"
@@ -8819,7 +8819,7 @@ msgid "Sudan"
 msgstr "Sudan"
 
 msgid "Sun"
-msgstr "Sunce"
+msgstr "Ned"
 
 msgid "Sunday"
 msgstr "Nedjelja"


### PR DESCRIPTION
Hi! Shows the days of the week (only Saturday and Sunday) in the EPG incorrectly for Croatian language, item number 7198 and 8821

Translation must be:
7198 msgid "Sat"
7199 msgstr "Sub"
and
8821 msgid "Sun"
8822 msgstr "Ned"

 Wrong is current settings: 
"Sat" = "Sat"
and
"Sun" = "Sunce"

Please fix it. Thanks.