### PR TITLE
Fix nameserver remove in NameserverSetup

### DIFF
--- a/lib/python/Components/Network.py
+++ b/lib/python/Components/Network.py
@@ -337,6 +337,9 @@ class Network:
 		if nameserver in self.nameservers:
 			self.nameservers.remove(nameserver)
 
+	def removeNameserverIndex(self, index):
+		self.nameservers.pop(index)
+
 	def changeNameserver(self, oldnameserver, newnameserver):
 		if oldnameserver in self.nameservers:
 			self.nameservers[self.nameservers.index(oldnameserver)] = newnameserver

--- a/lib/python/Screens/NetworkSetup.py
+++ b/lib/python/Screens/NetworkSetup.py
@@ -289,10 +289,9 @@ class NameserverSetup(ConfigListScreen, HelpableScreen, Screen):
 		index = self["config"].getCurrentIndex()
 		if index < len(self.nameservers):
 			if self.iface:
-				if self.nameservers[index] in self.nameservers:
-					self.nameservers.remove(self.nameservers[index])
+				self.nameservers.pop(index)
 			else:
-				iNetwork.removeNameserver(self.nameservers[index])
+				iNetwork.removeNameserverIndex(index)
 			self.createConfig(update=True)
 			self.createSetup()
 


### PR DESCRIPTION
Remove nameserver by index not by element.
If you accidentally specified the same nameservers, then on remove removed the first matching one, not the one you selected in list.