### PR TITLE
Remove NameserverSetup screen

### DIFF
--- a/data/skin_default/skin.xml
+++ b/data/skin_default/skin.xml
@@ -991,18 +991,6 @@ self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth) // 2, orgpos.y() + 
 	<screen name="Mute" position="50,50" zPosition="10" size="34,45" backgroundColor="transparent" title="Mute" flags="wfNoBorder">
 		<ePixmap position="0,0" size="34,45" pixmap="mute.png" alphatest="on"/>
 	</screen>
-	<!-- Nameserver -->
-	<screen name="NameserverSetup" position="center,center" size="560,400" title="Nameserver setup">
-		<ePixmap pixmap="buttons/red.png" position="0,0" size="140,40" alphatest="on"/>
-		<ePixmap pixmap="buttons/green.png" position="140,0" size="140,40" alphatest="on"/>
-		<ePixmap pixmap="buttons/yellow.png" position="280,0" size="140,40" alphatest="on"/>
-		<widget source="key_red" render="Label" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1"/>
-		<widget source="key_green" render="Label" position="140,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" transparent="1"/>
-		<widget source="key_yellow" render="Label" position="280,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#a08500" transparent="1"/>
-		<widget name="config" position="5,50" size="550,280" scrollbarMode="showOnDemand"/>
-		<ePixmap pixmap="div-h.png" position="0,340" zPosition="1" size="560,2"/>
-		<widget source="introduction" render="Label" position="0,350" size="560,50" zPosition="10" font="Regular;21" halign="center" valign="center" backgroundColor="#25062748" transparent="1"/>
-	</screen>
 	<!-- Network adapter selection -->
 	<screen name="NetworkAdapterSelection" position="center,center" size="560,400" title="Select a network adapter">
 		<ePixmap pixmap="buttons/red.png" position="0,0" size="140,40" alphatest="on"/>

--- a/lib/python/Components/Network.py
+++ b/lib/python/Components/Network.py
@@ -326,6 +326,15 @@ class Network:
 		print("[Network] get %s nameserver list: %s" % (iface, servers))
 		return servers
 
+	def getIfaceNameservers(self, iface):
+		dns_servers = self.getAdapterAttribute(iface, "dns-nameservers") or []
+		servers = dns_servers[:]
+		return servers
+
+	def getNameservers(self):
+		servers = self.nameservers[:]
+		return servers
+
 	def clearNameservers(self):
 		self.nameservers = []
 

--- a/lib/python/Plugins/SystemPlugins/NetworkWizard/NetworkWizard.py
+++ b/lib/python/Plugins/SystemPlugins/NetworkWizard/NetworkWizard.py
@@ -202,8 +202,7 @@ class NetworkWizard(WizardLanguage, Rc):
 			iNetwork.checkNetworkState(self.AdapterSetupEndFinished)
 			self.AdapterRef = self.session.openWithCallback(self.AdapterSetupEndCB, MessageBox, _("Please wait while we test your network..."), type=MessageBox.TYPE_INFO, enable_input=False)
 		else:
-			self.currStep = self.getStepWithID("confdns")
-			self.afterAsyncCode()
+			self.checkNetwork()
 
 	def AdapterSetupEndCB(self, data):
 		if data:

--- a/lib/python/Plugins/SystemPlugins/NetworkWizard/networkwizard.xml
+++ b/lib/python/Plugins/SystemPlugins/NetworkWizard/networkwizard.xml
@@ -41,18 +41,6 @@ self.selectKey("RIGHT")
 self.AdapterSetupEnd(self.selectedInterface)
                 </code>
         </step>
-        <step id="confdns" nextstep="checklanstatusend">
-                <text value="Please configure or verify your Nameservers by filling out the required values.\nWhen you are ready press OK to continue." />
-                <displaytext value="Configure nameservers" />
-                <config screen="NameserverSetup" module="NetworkSetup" type="ConfigList" />
-                <code>
-self.clearSelectedKeys()
-self.selectKey("OK")
-                </code>
-                <code pos="after" async="yes">
-self.checkNetwork()
-                </code>
-        </step>
         <step id="checklanstatusend" nextstep="end">
 		<condition>
 self.condition = (self.InterfaceState == True )


### PR DESCRIPTION
Move nameserver setup to AdapterSetup.

It is possible that some skins will need to be adjusted to have additional space for two config entries.