### PR TITLE
New Pager functionality

### DIFF
--- a/lib/python/Components/Addons/GUIAddon.py
+++ b/lib/python/Components/Addons/GUIAddon.py
@@ -1,0 +1,16 @@
+from Components.GUIComponent import GUIComponent
+
+class GUIAddon(GUIComponent):
+	def __init__(self):
+		GUIComponent.__init__(self)
+
+	def connectRelatedElement(self, relatedElementName, container):
+		self.source = container[relatedElementName]
+		self.bindKeys(container)
+		container.onShow.append(self.onContainerShown)
+
+	def onContainerShown(self):
+		pass
+	
+	def bindKeys(self, container):
+		pass

--- a/lib/python/Components/Addons/Makefile.am
+++ b/lib/python/Components/Addons/Makefile.am
@@ -1,0 +1,3 @@
+installdir = $(pkglibdir)/python/Components/Addons
+
+install_PYTHON = *.py

--- a/lib/python/Components/Addons/Pager.py
+++ b/lib/python/Components/Addons/Pager.py
@@ -1,13 +1,12 @@
 from Components.Addons.GUIAddon import GUIAddon
-from Components.ActionMap import ActionMap
-from skin import parseColor, parseFont, parseScale
+from skin import parseColor
 import math
 
-from enigma import eListbox, gFont, eListboxPythonMultiContent, RT_WRAP, RT_VALIGN_TOP, RT_VALIGN_CENTER, RT_HALIGN_LEFT, RT_HALIGN_CENTER, RT_HALIGN_RIGHT, BT_SCALE, BT_ALPHABLEND, BT_KEEP_ASPECT_RATIO, BT_ALIGN_CENTER
+from enigma import eListbox, eListboxPythonMultiContent, BT_ALIGN_CENTER
 from Tools.LoadPixmap import LoadPixmap
 
 from Tools.Directories import resolveFilename, SCOPE_GUISKIN
-from Components.MultiContent import MultiContentEntryText, MultiContentEntryPixmapAlphaBlend
+from Components.MultiContent import MultiContentEntryPixmapAlphaBlend
 
 
 class Pager(GUIAddon):

--- a/lib/python/Components/Addons/Pager.py
+++ b/lib/python/Components/Addons/Pager.py
@@ -1,4 +1,4 @@
-from Components.Renderer.Renderer import Renderer
+from Components.Addons.GUIAddon import GUIAddon
 from Components.ActionMap import ActionMap
 from skin import parseColor, parseFont, parseScale
 import math
@@ -10,9 +10,9 @@ from Tools.Directories import resolveFilename, SCOPE_GUISKIN
 from Components.MultiContent import MultiContentEntryText, MultiContentEntryPixmapAlphaBlend
 
 
-class Pager(Renderer):
+class Pager(GUIAddon):
 	def __init__(self):
-		Renderer.__init__(self)
+		GUIAddon.__init__(self)
 		self.l = eListboxPythonMultiContent()
 		self.l_list = []
 		self.l.setBuildFunc(self.buildEntry)
@@ -34,24 +34,11 @@ class Pager(Renderer):
 			self.source.onSelectionChanged.append(self.initPager)
 		self.initPager()
 
-	def bindKeys(self, container):
-		container["pager_actions"] = ActionMap(["DirectionActions"], {
-			"left": self.keyPageUp,
-			"right": self.keyPageDown,
-			"up": self.keyUp,
-			"down": self.keyDown,
-			"upRepeated": self.keyUp,
-		 	"downRepeated": self.keyDown,
-		 	"leftRepeated": self.keyPageUp,
-		 	"rightRepeated": self.keyPageDown
-		}, -1)
-		
 	GUI_WIDGET = eListbox
 
 	def buildEntry(self, currentPage, pageCount):
 		width = self.l.getItemSize().width()
 		xPos = width
-		height = self.l.getItemSize().height()
 
 		if self.picDotPage:
 			pixd_size = self.picDotPage.size()
@@ -113,22 +100,6 @@ class Pager(Renderer):
 				pagesCount = math.ceil(listCount/items_per_page) - 1
 				self.selChange(currentPageIndex,pagesCount)
 
-	def keyUp(self):
-		if self.source.instance is not None:
-			self.source.instance.moveSelection(self.source.instance.moveUp)
-
-	def keyDown(self):
-		if self.source.instance is not None:
-			self.source.instance.moveSelection(self.source.instance.moveDown)
-
-	def keyPageDown(self):
-		if self.source.instance is not None:
-			self.source.instance.moveSelection(self.source.instance.pageDown)
-
-	def keyPageUp(self):
-		if self.source.instance is not None:
-			self.source.instance.moveSelection(self.source.instance.pageUp)
-		
 	def applySkin(self, desktop, parent):
 		attribs = [ ]
 		for (attrib, value) in self.skinAttributes:
@@ -144,12 +115,9 @@ class Pager(Renderer):
 				pic = LoadPixmap(resolveFilename(SCOPE_GUISKIN, value))
 				if pic:
 					self.picDotCurPage = pic
-			# elif attrib == "connection":
-			# 	self.source = parent[value]
-			# 	self.initializeKeyBindings(parent)
 			else:
 				attribs.append((attrib, value))
 		self.skinAttributes = attribs
-		return Renderer.applySkin(self, desktop, parent)
+		return GUIAddon.applySkin(self, desktop, parent)
 
 	

--- a/lib/python/Components/Renderer/Makefile.am
+++ b/lib/python/Components/Renderer/Makefile.am
@@ -3,6 +3,5 @@ installdir = $(pkglibdir)/python/Components/Renderer
 install_PYTHON = \
 	__init__.py Label.py Progress.py Listbox.py Renderer.py Pixmap.py \
 	FixedLabel.py PositionGauge.py Canvas.py CiModuleControl.py Picon.py Pig.py \
-	FrontpanelLed.py ChannelNumber.py VideoSize.py NextEpgInfo.py GaugeRender.py \
-	Pager.py
+	FrontpanelLed.py ChannelNumber.py VideoSize.py NextEpgInfo.py GaugeRender.py
 

--- a/lib/python/Components/Renderer/Pager.py
+++ b/lib/python/Components/Renderer/Pager.py
@@ -22,11 +22,6 @@ class Pager(Renderer):
 		self.pagerForeground = 15774720
 		self.pagerBackground = 624318628
 		self.l.setItemHeight(self.itemHeight)
-		self.l.setFont(1, gFont('Regular', 18))
-		self.l.setFont(2, gFont('Regular', 22))
-		self.l.setFont(3, gFont('Regular', 22))
-		self.l.setFont(4, gFont('Regular', 22))
-		self.l.setFont(5, gFont('Regular', 22))
 		self.picDotPage = LoadPixmap(resolveFilename(SCOPE_GUISKIN, "icons/dot.png"))
 		self.picDotCurPage = LoadPixmap(resolveFilename(SCOPE_GUISKIN, "icons/dotfull.png"))
 
@@ -108,15 +103,11 @@ class Pager(Renderer):
 	
 	def initPager(self):
 		listH = self.getSourceHeight()
-		print("srcH: " + str(listH))
 		if listH > 0:
 			current_index = self.getCurrentIndex()
-			print("current_index: " + str(current_index))
 			listCount = self.getListCount()
-			print("listCount: " + str(listCount))
 			itemHeight = self.getListItemHeight()
-			print("itemHeight: " + str(itemHeight))
-			items_per_page = math.ceil(listH/itemHeight) - 1
+			items_per_page = listH//itemHeight
 			if items_per_page > 0:
 				currentPageIndex = math.floor(current_index/items_per_page)
 				pagesCount = math.ceil(listCount/items_per_page) - 1

--- a/lib/python/Components/Renderer/Pager.py
+++ b/lib/python/Components/Renderer/Pager.py
@@ -99,7 +99,7 @@ class Pager(Renderer):
 		elif hasattr(self.source, 'list'):
 			return len(self.source.list)
 		else:
-			return len(self.source.list)
+			return 0
 
 	def getListItemHeight(self):
 		if hasattr(self.source, 'content'):

--- a/lib/python/Components/Renderer/Renderer.py
+++ b/lib/python/Components/Renderer/Renderer.py
@@ -12,14 +12,3 @@ class Renderer(GUIComponent, Element):
 
 	def onHide(self):
 		self.suspended = True
-
-	def onContainerShown(self):
-		pass
-	
-	def bindKeys(self, container):
-		pass
-
-	def connectRelatedElement(self, relatedElementName, container):
-		self.source = container[relatedElementName]
-		self.bindKeys(container)
-		container.onShow.append(self.onContainerShown)

--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -1118,10 +1118,6 @@ def readSkin(screen, skin, names, desktop):
 			# print("[Skin] DEBUG: Widget name='%s'." % wname)
 			usedComponents.add(wname)
 			try:  # Get corresponding "gui" object.
-				# if wclass:
-				# 	relClass = my_import(".".join(("Components", wclass))).__dict__.get(wclass)
-				# 	screen[wname] = relClass()
-				# 	screen[wname].connectRelatedElement(wconnection, screen)
 				attributes = screen[wname].skinAttributes = []
 			except Exception:
 				raise SkinError("Component with name '%s' was not found in skin of screen '%s'" % (wname, name))
@@ -1199,12 +1195,12 @@ def readSkin(screen, skin, names, desktop):
 			if not wconnection:
 				raise SkinError("The widget is from addon type: %s , but no connection is specified." % wclass)
 			
-			wclassname = wclass + "_" + wconnection
+			wclassname = name + "_" + wclass + "_" + wconnection #form a name for the GUI Addon so to be possible to be inited in screen
 
 			usedComponents.add(wclassname)
 
-			screen[wclassname] = addonClass()
-			screen[wclassname].connectRelatedElement(wconnection, screen)
+			screen[wclassname] = addonClass() #init the addon
+			screen[wclassname].connectRelatedElement(wconnection, screen) #connect it to related ellement
 			attributes = screen[wclassname].skinAttributes = []
 			collectAttributes(attributes, widget, context, skinPath, ignore=("addon",))
 


### PR DESCRIPTION
Hello,

So here is a new version of Pager without the Actionmap issue (hijacking the keypress).
The main reason for the actionmap issue is this https://github.com/OpenPLi/enigma2/blob/42090e57e9ee8340836263264172a4e37be20b08/lib/gui/elistbox.cpp#L18
Since initially the eListbox adds default Actionmap with prio=0 and the pager also generates eListbox it overwrite the actionmap for actions that are not binded with higher priority.

So the new approach is to add a completely new type of element GUIAddon which to be added to the screen based on definition in the skin like that
`<widget addon="Pager" connection="config" position="396,849" size="1130,25" transparent="1" backgroundColor="background" pagerForeground="white" pagerBackground="background" />`

So it no longer use a renderer but the new type **addon**. This is no longer overwrites the actionmaps and work exactly the same.

This approach can have issues in the images that use prio > 0 for their Actionmaps because in this way it will be overwriten by the eListbox in the Pager.

For that images there should be extended the code (c++) of eListbox to support suppressing the default Actionmap.