### PR TITLE
Use the latest checkout actions in workflow CI

### DIFF
--- a/.github/workflows/enigma2.yml
+++ b/.github/workflows/enigma2.yml
@@ -17,7 +17,7 @@ jobs:
       CC: "gcc-10"
       CXX: "g++-10"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: install python packages
       run: |
         pip3 install netifaces pyopenssl python-wifi service_identity twisted


### PR DESCRIPTION
To disable Node.js 12 actions are deprecated warning in annotations.