### PR TITLE
[AdapterSetup] delete static nameservers if dhcp is enabled

### DIFF
--- a/lib/python/Screens/NetworkSetup.py
+++ b/lib/python/Screens/NetworkSetup.py
@@ -423,7 +423,10 @@ class AdapterSetup(ConfigListScreen, HelpableScreen, Screen):
 				dns.append(self.primaryDNS.value)
 			if self.secondaryDNS.value != [0, 0, 0, 0] and self.secondaryDNS.value not in dns:
 				dns.append(self.secondaryDNS.value)
-			iNetwork.setAdapterAttribute(self.iface, "dns-nameservers", dns)
+			if dns and not self.dhcpConfigEntry.value:
+				iNetwork.setAdapterAttribute(self.iface, "dns-nameservers", dns)
+			else:
+				iNetwork.removeAdapterAttribute(self.iface, "dns-nameservers")
 			if self.extended is not None and self.configStrings is not None:
 				iNetwork.setAdapterAttribute(self.iface, "configStrings", self.configStrings(self.iface))
 				self.ws.writeConfig(self.iface)


### PR DESCRIPTION
If you switch to dhcp and save the setting, but before that static nameservers have been set, delete these static nameservers to obtain nameservers only from dhcp.
Otherwise, the previous static nameservers are used, but you cannot set them and may not understand why they are used.