### PR TITLE
Introduce extended info also for iptv in ServiceInfo

### DIFF
--- a/lib/python/Screens/ServiceInfo.py
+++ b/lib/python/Screens/ServiceInfo.py
@@ -114,8 +114,12 @@ class ServiceInfo(Screen):
 				reftype = self.play_service.type
 				if "%3a//" in refstr and reftype not in (1, 257, 4098, 4114):
 					self.IPTV = True
+			self.audio = self.service and self.service.audioTracks()
+			self.number_of_tracks = self.audio and self.audio.getNumberOfTracks() or 0
+			self.sub_list = self.getSubtitleList()
 			if not self.IPTV:
 				self["key_green"] = self["green"] = Label(_("ECM Info"))
+			if not self.IPTV or self.number_of_tracks > 1 or self.sub_list:
 				self["key_yellow"] = self["yellow"] = Label(_("Service & PIDs"))
 			if self.feinfo or self.transponder_info:
 				self["key_blue"] = self["blue"] = Label(_("Tuner setting values"))
@@ -155,9 +159,6 @@ class ServiceInfo(Screen):
 				gamma = ("SDR", "HDR", "HDR10", "HLG", "")[self.info.getInfo(iServiceInformation.sGamma)]
 				if gamma:
 					resolution += " - %s" % gamma
-			self.audio = self.service and self.service.audioTracks()
-			self.number_of_tracks = self.audio and self.audio.getNumberOfTracks() or 0
-			self.sub_list = self.getSubtitleList()
 			self.toggle_pid_button()
 			track_list = self.get_track_list()
 			fillList = [
@@ -219,11 +220,11 @@ class ServiceInfo(Screen):
 				audio_pid = self.audio.getTrackInfo(i).getPID()
 				audio_lang = self.audio.getTrackInfo(i).getLanguage() or _("Not defined")
 				if self.IPTV:
-					return (_("Codec & lang"), "%s - %s" % (audio_desc, audio_lang), TYPE_TEXT)
+					return (_("Codec & lang %s") % ((i + 1) if self.number_of_tracks > 1 and self.show_all else ""), "%s - %s" % (audio_desc, audio_lang), TYPE_TEXT)
 				else:
 					return (_("Audio PID%s, codec & lang") % ((" %s") % (i + 1) if self.number_of_tracks > 1 and self.show_all else ""), "%04X (%d) - %s - %s" % (to_unsigned(audio_pid), audio_pid, audio_desc, audio_lang), TYPE_TEXT)
 
-			if self.IPTV or not self.show_all:
+			if not self.show_all:
 				return [create_list(self.audio.getCurrentTrack())]
 			else:
 				track_list = []
@@ -236,11 +237,11 @@ class ServiceInfo(Screen):
 		if self.number_of_tracks > 1 or self.sub_list:
 			if self.show_all is True:
 				self.show_all = False
-				self["key_yellow"].text = self["yellow"].text = _("Extended PID info")
+				self["key_yellow"].text = self["yellow"].text = _("Extended info") if self.IPTV else _("Extended PID info")
 				self["Title"].text = _("Service info - service & Basic PID Info")
 			else:
 				self.show_all = True
-				self["key_yellow"].text = self["yellow"].text = _("Basic PID info")
+				self["key_yellow"].text = self["yellow"].text = _("Basic info") if self.IPTV else _("Basic PID info")
 				self["Title"].text = _("Service info - service & Extended PID Info")
 		else:
 			self.show_all = False


### PR DESCRIPTION
In extended info for iptv displays all audio tracks and subtitles if they are available.
This also fixes GSOD if multiple audio tracks are available in iptv.