### PR TITLE
elistbox horizontal

### DIFF
--- a/lib/gui/elistbox.cpp
+++ b/lib/gui/elistbox.cpp
@@ -132,28 +132,27 @@ void eListbox::moveToEnd()
 void eListbox::moveSelection(long dir)
 {
 	long r_dir = dir;
-	switch (dir)
-	{
-	case moveUp:
-		if (m_orientation == orHorizontal){
-			r_dir = pageUp;
-		}
-		break;
-	case moveDown:
-		if (m_orientation == orHorizontal){
-			r_dir = pageDown;
-		}
-		break;
-	case pageUp:
-		if (m_orientation == orHorizontal){
-			r_dir = moveUp;
-		}
-		break;
-	case pageDown:
-		if (m_orientation == orHorizontal){
-			r_dir = moveDown;
-		}
-		break;
+	switch (dir) {
+		case moveUp:
+			if (m_orientation == orHorizontal){
+				r_dir = pageUp;
+			}
+			break;
+		case moveDown:
+			if (m_orientation == orHorizontal){
+				r_dir = pageDown;
+			}
+			break;
+		case pageUp:
+			if (m_orientation == orHorizontal){
+				r_dir = moveUp;
+			}
+			break;
+		case pageDown:
+			if (m_orientation == orHorizontal){
+				r_dir = moveDown;
+			}
+			break;
 	}
 	/* refuse to do anything without a valid list. */
 	if (!m_content)
@@ -168,140 +167,137 @@ void eListbox::moveSelection(long dir)
 	int prevsel = oldsel;
 	int newsel;
 
-	switch (r_dir)
-	{
-	case moveEnd:
-		m_content->cursorEnd();
-		[[fallthrough]];
-	case moveUp:
-		do
-		{
-			m_content->cursorMove(-1);
-			newsel = m_content->cursorGet();
-			if (newsel == prevsel) {  // cursorMove reached top and left cursor position the same. Must wrap around ?
-				if (m_enabled_wrap_around)
-				{
-					m_content->cursorEnd();
-					m_content->cursorMove(-1);
-					newsel = m_content->cursorGet();
+	switch (r_dir) {
+		case moveEnd:
+			m_content->cursorEnd();
+			[[fallthrough]];
+		case moveUp:
+			do
+			{
+				m_content->cursorMove(-1);
+				newsel = m_content->cursorGet();
+				if (newsel == prevsel) {  // cursorMove reached top and left cursor position the same. Must wrap around ?
+					if (m_enabled_wrap_around)
+					{
+						m_content->cursorEnd();
+						m_content->cursorMove(-1);
+						newsel = m_content->cursorGet();
+					}
+					else
+					{
+						m_content->cursorSet(oldsel);
+						break;
+					}
 				}
-				else
-				{
-					m_content->cursorSet(oldsel);
-					break;
-				}
+				prevsel = newsel;
 			}
-			prevsel = newsel;
-		}
-		while (newsel != oldsel && !m_content->currentCursorSelectable());
-		break;
-	case moveTop:
-		m_content->cursorHome();
-		[[fallthrough]];
-	case justCheck:
-		if (m_content->cursorValid() && m_content->currentCursorSelectable())
+			while (newsel != oldsel && !m_content->currentCursorSelectable());
 			break;
-		[[fallthrough]];
-	case moveDown:
-		do
-		{
-			m_content->cursorMove(1);
-			if (!m_content->cursorValid()) { //cursorMove reached end and left cursor position past the list. Must wrap around ?
-				if (m_enabled_wrap_around)
-					m_content->cursorHome();
-				else
-					m_content->cursorSet(oldsel);
-			}
-			newsel = m_content->cursorGet();
-		}
-		while (newsel != oldsel && !m_content->currentCursorSelectable());
-		break;
-	case pageUp:
-	{
-		int pageind;
-		do
-		{
-			m_content->cursorMove(-m_items_per_page);
-			newsel = m_content->cursorGet();
-			pageind = newsel % m_items_per_page; // rememer were we land in thsi page (could be different on topmost page)
-			prevsel = newsel - pageind; // get top of page index
-			// find first selectable entry in new page. First check bottom part, than upper part
-			while (newsel != prevsel + m_items_per_page && m_content->cursorValid() && !m_content->currentCursorSelectable())
+		case moveTop:
+			m_content->cursorHome();
+			[[fallthrough]];
+		case justCheck:
+			if (m_content->cursorValid() && m_content->currentCursorSelectable())
+				break;
+			[[fallthrough]];
+		case moveDown:
+			do
 			{
 				m_content->cursorMove(1);
+				if (!m_content->cursorValid()) { //cursorMove reached end and left cursor position past the list. Must wrap around ?
+					if (m_enabled_wrap_around)
+						m_content->cursorHome();
+					else
+						m_content->cursorSet(oldsel);
+				}
 				newsel = m_content->cursorGet();
 			}
-			if (!m_content->currentCursorSelectable()) // no selectable found in bottom part of page
+			while (newsel != oldsel && !m_content->currentCursorSelectable());
+			break;
+		case pageUp: {
+			int pageind;
+			do
 			{
+				m_content->cursorMove(-m_items_per_page);
+				newsel = m_content->cursorGet();
+				pageind = newsel % m_items_per_page; // rememer were we land in thsi page (could be different on topmost page)
+				prevsel = newsel - pageind; // get top of page index
+				// find first selectable entry in new page. First check bottom part, than upper part
+				while (newsel != prevsel + m_items_per_page && m_content->cursorValid() && !m_content->currentCursorSelectable())
+				{
+					m_content->cursorMove(1);
+					newsel = m_content->cursorGet();
+				}
+				if (!m_content->currentCursorSelectable()) // no selectable found in bottom part of page
+				{
+					m_content->cursorSet(prevsel + pageind);
+					while (newsel != prevsel && !m_content->currentCursorSelectable())
+					{
+						m_content->cursorMove(-1);
+						newsel = m_content->cursorGet();
+					}
+				}
+				if (m_content->currentCursorSelectable())
+					break;
+				if (newsel == 0) // at top and nothing found . Go down till something selectable or old location
+				{
+					while (newsel != oldsel && !m_content->currentCursorSelectable())
+					{
+						m_content->cursorMove(1);
+						newsel = m_content->cursorGet();
+					}
+					break;
+				}
 				m_content->cursorSet(prevsel + pageind);
+			}
+			while (newsel == prevsel);
+			break;
+		}
+		case pageDown: {
+			int pageind;
+			do
+			{
+				m_content->cursorMove(m_items_per_page);
+				if (!m_content->cursorValid())
+					m_content->cursorMove(-1);
+				newsel = m_content->cursorGet();
+				pageind = newsel % m_items_per_page;
+				prevsel = newsel - pageind; // get top of page index
+				// find a selectable entry in the new page. first look up then down from current screenlocation on the page
 				while (newsel != prevsel && !m_content->currentCursorSelectable())
 				{
 					m_content->cursorMove(-1);
 					newsel = m_content->cursorGet();
 				}
-			}
-			if (m_content->currentCursorSelectable())
-				break;
-			if (newsel == 0) // at top and nothing found . Go down till something selectable or old location
-			{
-				while (newsel != oldsel && !m_content->currentCursorSelectable())
+				if (!m_content->currentCursorSelectable()) // no selectable found in top part of page
 				{
-					m_content->cursorMove(1);
-					newsel = m_content->cursorGet();
+					m_content->cursorSet(prevsel + pageind);
+					do {
+						m_content->cursorMove(1);
+						newsel = m_content->cursorGet();
+					}
+						while (newsel != prevsel + m_items_per_page && m_content->cursorValid() && !m_content->currentCursorSelectable());
 				}
-				break;
-			}
-			m_content->cursorSet(prevsel + pageind);
-		}
-		while (newsel == prevsel);
-		break;
-	}
-	case pageDown:
-	{
-		int pageind;
-		do
-		{
-			m_content->cursorMove(m_items_per_page);
-			if (!m_content->cursorValid())
-				m_content->cursorMove(-1);
-			newsel = m_content->cursorGet();
-			pageind = newsel % m_items_per_page;
-			prevsel = newsel - pageind; // get top of page index
-			// find a selectable entry in the new page. first look up then down from current screenlocation on the page
-			while (newsel != prevsel && !m_content->currentCursorSelectable())
-			{
-				m_content->cursorMove(-1);
-				newsel = m_content->cursorGet();
-			}
-			if (!m_content->currentCursorSelectable()) // no selectable found in top part of page
-			{
-				m_content->cursorSet(prevsel + pageind);
-				do {
-					m_content->cursorMove(1);
-					newsel = m_content->cursorGet();
-				}
-			        while (newsel != prevsel + m_items_per_page && m_content->cursorValid() && !m_content->currentCursorSelectable());
-			}
-			if (!m_content->cursorValid())
-			{
-				// we reached the end of the list
-				// Back up till something selectable or we reach oldsel again
-				// E.g this should bring us back to the last selectable item on the original page
-				do
+				if (!m_content->cursorValid())
 				{
-					m_content->cursorMove(-1);
-					newsel = m_content->cursorGet();
+					// we reached the end of the list
+					// Back up till something selectable or we reach oldsel again
+					// E.g this should bring us back to the last selectable item on the original page
+					do
+					{
+						m_content->cursorMove(-1);
+						newsel = m_content->cursorGet();
+					}
+					while (newsel != oldsel && !m_content->currentCursorSelectable());
+					break;
 				}
-				while (newsel != oldsel && !m_content->currentCursorSelectable());
-				break;
+				if (newsel != prevsel + m_items_per_page)
+					break;
+				m_content->cursorSet(prevsel + pageind); // prepare for next page down
 			}
-			if (newsel != prevsel + m_items_per_page)
-				break;
-			m_content->cursorSet(prevsel + pageind); // prepare for next page down
+			while (newsel == prevsel + m_items_per_page);
+			break;
 		}
-		while (newsel == prevsel + m_items_per_page);
-		break;
-	}
 	}
 
 	/* now, look wether the current selection is out of screen */
@@ -592,7 +588,6 @@ void eListbox::recalcSize()
 
 void eListbox::setItemHeight(int h)
 {
-	eDebug("[eListBox] setItemHeight %d", h);
 	if (h)
 		m_itemheight = h;
 	else
@@ -601,7 +596,6 @@ void eListbox::setItemHeight(int h)
 }
 void eListbox::setItemWidth(int w)
 {
-	eDebug("[eListBox] setItemWidth %d", w);
 	if (w)
 		m_itemwidth = w;
 	else
@@ -825,6 +819,11 @@ void eListbox::setBackgroundPicture(ePtr<gPixmap> &pm)
 void eListbox::setSelectionPicture(ePtr<gPixmap> &pm)
 {
 	m_style.m_selection = pm;
+}
+
+void eListbox::setSelectionBorderHidden()
+{
+	m_style.m_border_set = 1;
 }
 
 void eListbox::setSliderPicture(ePtr<gPixmap> &pm)

--- a/lib/gui/elistbox.h
+++ b/lib/gui/elistbox.h
@@ -52,6 +52,7 @@ protected:
 
 	virtual int getItemHeight()=0;
 	virtual int getItemWidth() { return -1; }
+	virtual int getOrientation() { return 1; }
 
 	eListbox *m_listbox;
 #endif
@@ -62,6 +63,7 @@ struct eListboxStyle
 {
 	ePtr<gPixmap> m_background, m_selection;
 	int m_transparent_background;
+	int m_border_set;
 	gRGB m_background_color, m_background_color_selected,
 	m_foreground_color, m_foreground_color_selected, m_border_color, m_sliderborder_color, m_sliderforeground_color;
 	int m_background_color_set, m_foreground_color_set, m_background_color_selected_set, m_foreground_color_selected_set, m_sliderforeground_color_set, m_sliderborder_color_set, m_scrollbarsliderborder_size_set;
@@ -151,6 +153,7 @@ public:
 	void setBorderWidth(int size);
 	void setBackgroundPicture(ePtr<gPixmap> &pixmap);
 	void setSelectionPicture(ePtr<gPixmap> &pixmap);
+	void setSelectionBorderHidden();
 
 	void setSliderPicture(ePtr<gPixmap> &pm);
 	void setScrollbarBackgroundPicture(ePtr<gPixmap> &pm);

--- a/lib/gui/elistbox.h
+++ b/lib/gui/elistbox.h
@@ -51,6 +51,7 @@ protected:
 	virtual void paint(gPainter &painter, eWindowStyle &style, const ePoint &offset, int selected)=0;
 
 	virtual int getItemHeight()=0;
+	virtual int getItemWidth() { return -1; }
 
 	eListbox *m_listbox;
 #endif
@@ -105,6 +106,8 @@ public:
 	};
 	void setScrollbarMode(int mode);
 	void setWrapAround(bool);
+	enum { orHorizontal, orVertical };
+	void setOrientation(int orientation);
 
 	void setContent(iListboxContent *content);
 
@@ -119,6 +122,7 @@ public:
 	}; */
 
 	int getCurrentIndex();
+	int getOrientation();
 	void moveSelection(long how);
 	void moveSelectionTo(int index);
 	void moveToEnd();
@@ -136,6 +140,7 @@ public:
 	};
 
 	void setItemHeight(int h);
+	void setItemWidth(int w);
 	void setSelectionEnable(int en);
 
 	void setBackgroundColor(gRGB &col);
@@ -188,10 +193,12 @@ private:
 	bool m_enabled_wrap_around;
 
 	int m_scrollbar_width;
-	int m_top, m_selected;
+	int m_top, m_left, m_selected;
 	int m_itemheight;
+	int m_itemwidth;
 	int m_items_per_page;
 	int m_selection_enabled;
+	int m_orientation;
 
 	bool m_native_keys_bound;
 

--- a/lib/gui/elistbox.h
+++ b/lib/gui/elistbox.h
@@ -104,7 +104,8 @@ public:
 		showOnDemand,
 		showAlways,
 		showNever,
-		showLeft
+		showLeft,
+		showTop
 	};
 	void setScrollbarMode(int mode);
 	void setWrapAround(bool);
@@ -159,6 +160,7 @@ public:
 	void setScrollbarBackgroundPicture(ePtr<gPixmap> &pm);
 	void setScrollbarSliderBorderWidth(int size);
 	void setScrollbarWidth(int size);
+	void setScrollbarHeight(int size);
 
 	void setFont(gFont *font);
 	void setSecondFont(gFont *font);
@@ -171,6 +173,7 @@ public:
 	void setSliderForegroundColor(gRGB &col);
 
 	int getScrollbarWidth() { return m_scrollbar_width; }
+	int getScrollbarHeight() { return m_scrollbar_height; }
 
 #ifndef SWIG
 	struct eListboxStyle *getLocalStyle(void);
@@ -196,12 +199,13 @@ private:
 	bool m_enabled_wrap_around;
 
 	int m_scrollbar_width;
+	int m_scrollbar_height;
 	int m_top, m_left, m_selected;
 	int m_itemheight;
 	int m_itemwidth;
+	int m_orientation;
 	int m_items_per_page;
 	int m_selection_enabled;
-	int m_orientation;
 
 	bool m_native_keys_bound;
 

--- a/lib/gui/elistboxcontent.cpp
+++ b/lib/gui/elistboxcontent.cpp
@@ -207,6 +207,10 @@ void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, 
 			painter.clear();
 	}
 
+	// Draw frame here so to be under the content
+	if (selected && (!local_style || !local_style->m_selection) && (!local_style || !local_style->m_border_set))
+		style.drawFrame(painter, eRect(offset, m_itemsize), eWindowStyle::frameListboxEntry);
+
 	if (validitem)
 	{
 		int gray = 0;
@@ -274,9 +278,6 @@ void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, 
 			painter.renderText(eRect(text_offset, m_itemsize),
 			 string, flags, border_color, border_size);
 		}
-
-		if (selected && (!local_style || !local_style->m_selection) && (!local_style || !local_style->m_border_set))
-			style.drawFrame(painter, eRect(offset, m_itemsize), eWindowStyle::frameListboxEntry);
 	}
 
 	painter.clippop();
@@ -422,6 +423,10 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 			painter.clear();
 	}
 
+	// Draw frame here so to be drawn under icons
+	if (selected && (!local_style || !local_style->m_selection) && (!local_style || !local_style->m_border_set))
+			style.drawFrame(painter, eRect(offset, m_itemsize), eWindowStyle::frameListboxEntry);
+
 	if (m_list && cursorValid)
 	{
 			/* get current list item */
@@ -429,12 +434,12 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 		ePyObject text, value;
 		painter.setFont(fnt);
 
-		if (selected && local_style && local_style->m_selection)
+		if (selected && local_style && local_style->m_selection){
 			if (m_listbox && m_listbox->getOrientation() == 1)
 				painter.blit(local_style->m_selection, ePoint(offset.x(), offset.y() + (m_itemsize.height() - local_style->m_selection->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
 			else
 				painter.blit(local_style->m_selection, ePoint(offset.x() + (m_itemsize.width() - local_style->m_selection->size().width()) / 2, offset.y()), eRect(), gPainter::BT_ALPHATEST);
-
+		}
 			/* the first tuple element is a string for the left side.
 			   the second one will be called, and the result shall be an tuple.
 
@@ -580,11 +585,12 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 								}
 								para->setGlyphFlag(num, GS_INVERT);
 								bbox = para->getGlyphBBox(num);
-								if (last+1 != num || last == -1)
+								if (last+1 != num || last == -1){
 									if (isVertLB)
 										left = bbox.left();
 									else
 										top = bbox.top();
+								}
 								if (isVertLB)
 									right = bbox.left() + bbox.width();
 								else
@@ -642,8 +648,6 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 				Py_DECREF(value);
 		}
 
-		if (selected && (!local_style || !local_style->m_selection) && (!local_style || !local_style->m_border_set))
-			style.drawFrame(painter, eRect(offset, m_itemsize), eWindowStyle::frameListboxEntry);
 	}
 
 	painter.clippop();
@@ -781,11 +785,12 @@ static void clearRegion(gPainter &painter, eWindowStyle &style, eListboxStyle *l
 	{
 		style.setStyle(painter, eWindowStyle::styleListboxSelected);
 		clearRegionSelectedHelper(painter, local_style, offset, size, pbackColorSelected, cursorValid, clear, isverticallb);
-		if (local_style && local_style->m_selection)
+		if (local_style && local_style->m_selection) {
 			if (isverticallb)
 				painter.blit(local_style->m_selection, ePoint(offset.x(), offset.y() + (size.height() - local_style->m_selection->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
 			else
 				painter.blit(local_style->m_selection, ePoint(offset.x() + (size.width() - local_style->m_selection->size().width()) / 2, offset.y()), eRect(), gPainter::BT_ALPHATEST);
+		}
 	}
 	else
 	{
@@ -866,6 +871,10 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 	
 	painter.clip(itemregion);
 	clearRegion(painter, style, local_style, ePyObject(), ePyObject(), ePyObject(), ePyObject(), selected, itemregion, sel_clip, offset, m_itemsize, cursorValid, true, isverticallb);
+	
+	// Draw frame here so to be under the content
+	if (selected && !sel_clip.valid() && (!local_style || !local_style->m_selection) && (!local_style || !local_style->m_border_set))
+			style.drawFrame(painter, eRect(offset, m_itemsize), eWindowStyle::frameListboxEntry);
 
 	ePyObject items, buildfunc_ret;
 
@@ -1257,8 +1266,7 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 		}
 	}
 
-	if (selected && !sel_clip.valid() && (!local_style || !local_style->m_selection) && (!local_style || !local_style->m_border_set))
-		style.drawFrame(painter, eRect(offset, m_itemsize), eWindowStyle::frameListboxEntry);
+	
 
 error_out:
 	if (buildfunc_ret)

--- a/lib/gui/elistboxcontent.cpp
+++ b/lib/gui/elistboxcontent.cpp
@@ -37,9 +37,9 @@ iListboxContent::iListboxContent(): m_listbox(0)
 void iListboxContent::setListbox(eListbox *lb)
 {
 	m_listbox = lb;
-	eDebug("[eListBox] setListbox + getItemWidth +  getItemHeight");
 	m_listbox->setItemHeight(getItemHeight());
 	m_listbox->setItemWidth(getItemWidth());
+	m_listbox->setOrientation(getOrientation());
 }
 
 int iListboxContent::currentCursorSelectable()
@@ -52,7 +52,7 @@ int iListboxContent::currentCursorSelectable()
 DEFINE_REF(eListboxPythonStringContent);
 
 eListboxPythonStringContent::eListboxPythonStringContent()
-	:m_cursor(0), m_saved_cursor(0), m_itemheight(25), m_itemwidth(25)
+	:m_cursor(0), m_saved_cursor(0), m_itemheight(25), m_itemwidth(25), m_orientation(1)
 {
 }
 
@@ -275,7 +275,7 @@ void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, 
 			 string, flags, border_color, border_size);
 		}
 
-		if (selected && (!local_style || !local_style->m_selection))
+		if (selected && (!local_style || !local_style->m_selection) && (!local_style || !local_style->m_border_set))
 			style.drawFrame(painter, eRect(offset, m_itemsize), eWindowStyle::frameListboxEntry);
 	}
 
@@ -298,10 +298,17 @@ void eListboxPythonStringContent::setList(ePyObject list)
 		m_listbox->entryReset(false);
 }
 
+void eListboxPythonStringContent::setOrientation(int orientation)
+{
+	m_orientation = orientation;
+	if (m_listbox){
+		m_listbox->setOrientation(orientation);
+	}
+}
+
 void eListboxPythonStringContent::setItemHeight(int height)
 {
 	m_itemheight = height;
-	eDebug("[eListboxPythonStringContent] setItemHeight %d", height);
 	if (m_listbox)
 		m_listbox->setItemHeight(height);
 }
@@ -309,7 +316,6 @@ void eListboxPythonStringContent::setItemHeight(int height)
 void eListboxPythonStringContent::setItemWidth(int width)
 {
 	m_itemwidth = width;
-	eDebug("[eListboxPythonStringContent] setItemWidth %d", width);
 	if (m_listbox)
 		m_listbox->setItemWidth(width);
 }
@@ -636,7 +642,7 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 				Py_DECREF(value);
 		}
 
-		if (selected && (!local_style || !local_style->m_selection))
+		if (selected && (!local_style || !local_style->m_selection) && (!local_style || !local_style->m_border_set))
 			style.drawFrame(painter, eRect(offset, m_itemsize), eWindowStyle::frameListboxEntry);
 	}
 
@@ -1251,7 +1257,7 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 		}
 	}
 
-	if (selected && !sel_clip.valid() && (!local_style || !local_style->m_selection))
+	if (selected && !sel_clip.valid() && (!local_style || !local_style->m_selection) && (!local_style || !local_style->m_border_set))
 		style.drawFrame(painter, eRect(offset, m_itemsize), eWindowStyle::frameListboxEntry);
 
 error_out:
@@ -1326,12 +1332,18 @@ void eListboxPythonMultiContent::setFont(int fnt, gFont *font)
 		m_font.erase(fnt);
 }
 
+void eListboxPythonMultiContent::setOrientation(int orientation)
+{
+	m_orientation = orientation;
+	if (m_listbox){
+		m_listbox->setOrientation(orientation);
+	}
+}
+
 void eListboxPythonMultiContent::setItemHeight(int height)
 {
 	m_itemheight = height;
-	eDebug("[eListboxPythonMultiContent] setItemHeight %d", height);
 	if (m_listbox){
-		eDebug("[eListboxPythonMultiContent] Send height to eListBox!!!");
 		m_listbox->setItemHeight(height);
 	}
 }
@@ -1339,9 +1351,7 @@ void eListboxPythonMultiContent::setItemHeight(int height)
 void eListboxPythonMultiContent::setItemWidth(int width)
 {
 	m_itemwidth = width;
-	eDebug("[eListboxPythonMultiContent] setItemWidth %d", width);
 	if (m_listbox){
-		eDebug("[eListboxPythonMultiContent] Send width to eListBox!!!");
 		m_listbox->setItemWidth(width);
 	}
 }

--- a/lib/gui/elistboxcontent.cpp
+++ b/lib/gui/elistboxcontent.cpp
@@ -37,7 +37,9 @@ iListboxContent::iListboxContent(): m_listbox(0)
 void iListboxContent::setListbox(eListbox *lb)
 {
 	m_listbox = lb;
+	eDebug("[eListBox] setListbox + getItemWidth +  getItemHeight");
 	m_listbox->setItemHeight(getItemHeight());
+	m_listbox->setItemWidth(getItemWidth());
 }
 
 int iListboxContent::currentCursorSelectable()
@@ -50,7 +52,7 @@ int iListboxContent::currentCursorSelectable()
 DEFINE_REF(eListboxPythonStringContent);
 
 eListboxPythonStringContent::eListboxPythonStringContent()
-	:m_cursor(0), m_saved_cursor(0), m_itemheight(25)
+	:m_cursor(0), m_saved_cursor(0), m_itemheight(25), m_itemwidth(25)
 {
 }
 
@@ -176,14 +178,18 @@ void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, 
 		}
 	}
 	if (!fnt) fnt = new gFont("Regular", 20);
-
+	bool isverticallb = m_listbox && m_listbox->getOrientation() == 1;
 	/* if we have no transparent background */
 	if (!local_style || !local_style->m_transparent_background)
 	{
 			/* blit background picture, if available (otherwise, clear only) */
 		if (local_style && local_style->m_background && cursorValid)
 		{
-			if (validitem) painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (m_itemsize.height() - local_style->m_background->size().height()) / 2), eRect(), 0);
+			if (isverticallb){
+				if (validitem) painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (m_itemsize.height() - local_style->m_background->size().height()) / 2), eRect(), 0);
+			} else {
+				if (validitem) painter.blit(local_style->m_background, ePoint(offset.x() + (m_itemsize.width() - local_style->m_background->size().width()) / 2, offset.y()), eRect(), 0);
+			}
 		}
 		else
 			painter.clear();
@@ -191,7 +197,11 @@ void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, 
 	{
 		if (local_style->m_background && cursorValid)
 		{
-			if (validitem) painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (m_itemsize.height() - local_style->m_background->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
+			if (isverticallb){
+				if (validitem) painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (m_itemsize.height() - local_style->m_background->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
+			} else {
+				if (validitem) painter.blit(local_style->m_background, ePoint(offset.x() + (m_itemsize.width() - local_style->m_background->size().width()) / 2, offset.y()), eRect(), gPainter::BT_ALPHATEST);
+			}
 		}
 		else if (selected && !local_style->m_selection)
 			painter.clear();
@@ -212,13 +222,26 @@ void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, 
 		}
 
 		if (selected && local_style && local_style->m_selection)
-			painter.blit(local_style->m_selection, ePoint(offset.x(), offset.y() + (m_itemsize.height() - local_style->m_selection->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
+		{
+			if (isverticallb)
+				painter.blit(local_style->m_selection, ePoint(offset.x(), offset.y() + (m_itemsize.height() - local_style->m_selection->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
+			else
+				painter.blit(local_style->m_selection, ePoint(offset.x() + (m_itemsize.width() - local_style->m_selection->size().width()) / 2, offset.y()), eRect(), gPainter::BT_ALPHATEST);
+		}
 
 		if (item == Py_None)
 		{
 				/* seperator */
-			int half_height = m_itemsize.height() / 2;
-			painter.fill(eRect(offset.x() + half_height, offset.y() + half_height - 2, m_itemsize.width() - m_itemsize.height(), 4));
+			if (isverticallb) 
+			{
+				int half_height = m_itemsize.height() / 2;
+				painter.fill(eRect(offset.x() + half_height, offset.y() + half_height - 2, m_itemsize.width() - m_itemsize.height(), 4));
+			}
+			else
+			{
+				int half_width = m_itemsize.width() / 2;
+				painter.fill(eRect(offset.x() + half_width, offset.y() + half_width - 2, m_itemsize.width() - m_itemsize.height(), 4));
+			}
 		} else
 		{
 			const char *string = PyUnicode_Check(item) ? PyUnicode_AsUTF8(item) : "<not-a-string>";
@@ -278,8 +301,17 @@ void eListboxPythonStringContent::setList(ePyObject list)
 void eListboxPythonStringContent::setItemHeight(int height)
 {
 	m_itemheight = height;
+	eDebug("[eListboxPythonStringContent] setItemHeight %d", height);
 	if (m_listbox)
 		m_listbox->setItemHeight(height);
+}
+
+void eListboxPythonStringContent::setItemWidth(int width)
+{
+	m_itemwidth = width;
+	eDebug("[eListboxPythonStringContent] setItemWidth %d", width);
+	if (m_listbox)
+		m_listbox->setItemWidth(width);
 }
 
 PyObject *eListboxPythonStringContent::getCurrentSelection()
@@ -367,13 +399,19 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 	{
 		/* blit background picture, if available (otherwise, clear only) */
 		if (local_style && local_style->m_background && cursorValid)
-			painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (m_itemsize.height() - local_style->m_background->size().height()) / 2), eRect(), 0);
+			if (m_listbox && m_listbox->getOrientation() == 1)
+				painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (m_itemsize.height() - local_style->m_background->size().height()) / 2), eRect(), 0);
+			else
+				painter.blit(local_style->m_background, ePoint(offset.x() + (m_itemsize.width() - local_style->m_background->size().width()) / 2, offset.y()), eRect(), 0);
 		else
 			painter.clear();
 	} else
 	{
 		if (local_style->m_background && cursorValid)
-			painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (m_itemsize.height() - local_style->m_background->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
+			if (m_listbox && m_listbox->getOrientation() == 1)
+				painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (m_itemsize.height() - local_style->m_background->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
+			else
+				painter.blit(local_style->m_background, ePoint(offset.x() + (m_itemsize.width() - local_style->m_background->size().width()) / 2, offset.y()), eRect(), gPainter::BT_ALPHATEST);
 		else if (selected && !local_style->m_selection)
 			painter.clear();
 	}
@@ -386,7 +424,10 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 		painter.setFont(fnt);
 
 		if (selected && local_style && local_style->m_selection)
-			painter.blit(local_style->m_selection, ePoint(offset.x(), offset.y() + (m_itemsize.height() - local_style->m_selection->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
+			if (m_listbox && m_listbox->getOrientation() == 1)
+				painter.blit(local_style->m_selection, ePoint(offset.x(), offset.y() + (m_itemsize.height() - local_style->m_selection->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
+			else
+				painter.blit(local_style->m_selection, ePoint(offset.x() + (m_itemsize.width() - local_style->m_selection->size().width()) / 2, offset.y()), eRect(), gPainter::BT_ALPHATEST);
 
 			/* the first tuple element is a string for the left side.
 			   the second one will be called, and the result shall be an tuple.
@@ -511,7 +552,8 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 						if (plist && PyList_Check(plist))
 							entries = PyList_Size(plist);
 
-						int left=0, right=0, last=-1;
+						int left=0, right=0, last=-1, top=0, bottom=0;
+						bool isVertLB = m_listbox && m_listbox->getOrientation() == 1;
 						eRect bbox;
 						eRect pbox = para->getBoundBox();
 						for (int i = 0; i < entries; ++i)
@@ -524,23 +566,38 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 							else
 							{
 								if (last+1 != num && last != -1) {
-									bbox = eRect(left, offset.y(), right-left, (m_itemsize.height() - pbox.height()) / 2);
+									if (isVertLB)
+										bbox = eRect(left, offset.y(), right-left, (m_itemsize.height() - pbox.height()) / 2);
+									else
+										bbox = eRect(offset.x(), top, bottom-top, (m_itemsize.width() - pbox.width()) / 2);
 									painter.fill(bbox);
 								}
 								para->setGlyphFlag(num, GS_INVERT);
 								bbox = para->getGlyphBBox(num);
 								if (last+1 != num || last == -1)
-									left = bbox.left();
-								right = bbox.left() + bbox.width();
+									if (isVertLB)
+										left = bbox.left();
+									else
+										top = bbox.top();
+								if (isVertLB)
+									right = bbox.left() + bbox.width();
+								else
+									bottom = bbox.top() + bbox.height();
 								last = num;
 							}
 							/* entry is borrowed */
 						}
 						if (last != -1) {
-							bbox = eRect(left, offset.y() + (m_itemsize.height() - pbox.height()) / 2, right - left, pbox.height());
+							if (isVertLB)
+								bbox = eRect(left, offset.y() + (m_itemsize.height() - pbox.height()) / 2, right - left, pbox.height());
+							else
+								bbox = eRect(offset.x() + (m_itemsize.width() - pbox.width()) / 2, top , bottom - top, pbox.width());
 							painter.fill(bbox);
 						}
-						painter.renderPara(para, ePoint(0, m_itemsize.height() - pbox.height()) / 2);
+						if (isVertLB)
+							painter.renderPara(para, ePoint(0, m_itemsize.height() - pbox.height()) / 2);
+						else
+							painter.renderPara(para, ePoint(m_itemsize.width() - pbox.width(), 0) / 2);
 						/* pvalue is borrowed */
 						/* plist is 0 or borrowed */
 					}
@@ -621,7 +678,7 @@ void eListboxPythonMultiContent::setSelectionClip(eRect &rect, bool update)
 		m_listbox->entryChanged(m_cursor);
 }
 
-static void clearRegionHelper(gPainter &painter, eListboxStyle *local_style, const ePoint &offset, const eSize &size, ePyObject &pbackColor, bool cursorValid, bool clear=true)
+static void clearRegionHelper(gPainter &painter, eListboxStyle *local_style, const ePoint &offset, const eSize &size, ePyObject &pbackColor, bool cursorValid, bool clear=true, bool isverticallb=true)
 {
 	if (pbackColor)
 	{
@@ -634,10 +691,20 @@ static void clearRegionHelper(gPainter &painter, eListboxStyle *local_style, con
 			painter.setBackgroundColor(local_style->m_background_color);
 		if (local_style->m_background && cursorValid)
 		{
-			if (local_style->m_transparent_background)
-				painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (size.height() - local_style->m_background->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
+			if (isverticallb)
+			{
+				if (local_style->m_transparent_background)
+					painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (size.height() - local_style->m_background->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
+				else
+					painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (size.height() - local_style->m_background->size().height()) / 2), eRect(), 0);
+			}
 			else
-				painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (size.height() - local_style->m_background->size().height()) / 2), eRect(), 0);
+			{
+				if (local_style->m_transparent_background)
+					painter.blit(local_style->m_background, ePoint(offset.x() + (size.width() - local_style->m_background->size().width()) / 2, offset.y()), eRect(), gPainter::BT_ALPHATEST);
+				else
+					painter.blit(local_style->m_background, ePoint(offset.x() + (size.width() - local_style->m_background->size().width()) / 2, offset.y()), eRect(), 0);
+			}
 			return;
 		}
 		else if (local_style->m_transparent_background)
@@ -647,7 +714,7 @@ static void clearRegionHelper(gPainter &painter, eListboxStyle *local_style, con
 		painter.clear();
 }
 
-static void clearRegionSelectedHelper(gPainter &painter, eListboxStyle *local_style, const ePoint &offset, const eSize &size, ePyObject &pbackColorSelected, bool cursorValid, bool clear=true)
+static void clearRegionSelectedHelper(gPainter &painter, eListboxStyle *local_style, const ePoint &offset, const eSize &size, ePyObject &pbackColorSelected, bool cursorValid, bool clear=true, bool isverticallb=true)
 {
 	if (pbackColorSelected)
 	{
@@ -660,10 +727,20 @@ static void clearRegionSelectedHelper(gPainter &painter, eListboxStyle *local_st
 			painter.setBackgroundColor(local_style->m_background_color_selected);
 		if (local_style->m_background && cursorValid)
 		{
-			if (local_style->m_transparent_background)
-				painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (size.height() - local_style->m_background->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
+			if (isverticallb)
+			{
+				if (local_style->m_transparent_background)
+					painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (size.height() - local_style->m_background->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
+				else
+					painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (size.height() - local_style->m_background->size().height()) / 2), eRect(), 0);
+			}
 			else
-				painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (size.height() - local_style->m_background->size().height()) / 2), eRect(), 0);
+			{
+				if (local_style->m_transparent_background)
+					painter.blit(local_style->m_background, ePoint(offset.x() + (size.width() - local_style->m_background->size().width()) / 2, offset.y()), eRect(), gPainter::BT_ALPHATEST);
+				else
+					painter.blit(local_style->m_background, ePoint(offset.x() + (size.width() - local_style->m_background->size().width()) / 2, offset.y()), eRect(), 0);
+			}
 			return;
 		}
 	}
@@ -671,7 +748,7 @@ static void clearRegionSelectedHelper(gPainter &painter, eListboxStyle *local_st
 		painter.clear();
 }
 
-static void clearRegion(gPainter &painter, eWindowStyle &style, eListboxStyle *local_style, ePyObject pforeColor, ePyObject pforeColorSelected, ePyObject pbackColor, ePyObject pbackColorSelected, int selected, gRegion &rc, eRect &sel_clip, const ePoint &offset, const eSize &size, bool cursorValid, bool clear=true)
+static void clearRegion(gPainter &painter, eWindowStyle &style, eListboxStyle *local_style, ePyObject pforeColor, ePyObject pforeColorSelected, ePyObject pbackColor, ePyObject pbackColorSelected, int selected, gRegion &rc, eRect &sel_clip, const ePoint &offset, const eSize &size, bool cursorValid, bool clear=true, bool isverticallb=true)
 {
 	if (selected && sel_clip.valid())
 	{
@@ -680,7 +757,7 @@ static void clearRegion(gPainter &painter, eWindowStyle &style, eListboxStyle *l
 		{
 			painter.clip(part);
 			style.setStyle(painter, eWindowStyle::styleListboxNormal);
-			clearRegionHelper(painter, local_style, offset, size, pbackColor, cursorValid, clear);
+			clearRegionHelper(painter, local_style, offset, size, pbackColor, cursorValid, clear, isverticallb);
 			painter.clippop();
 			selected = 0;
 		}
@@ -689,7 +766,7 @@ static void clearRegion(gPainter &painter, eWindowStyle &style, eListboxStyle *l
 		{
 			painter.clip(part);
 			style.setStyle(painter, eWindowStyle::styleListboxSelected);
-			clearRegionSelectedHelper(painter, local_style, offset, size, pbackColorSelected, cursorValid, clear);
+			clearRegionSelectedHelper(painter, local_style, offset, size, pbackColorSelected, cursorValid, clear, isverticallb);
 			painter.clippop();
 			selected = 1;
 		}
@@ -697,14 +774,17 @@ static void clearRegion(gPainter &painter, eWindowStyle &style, eListboxStyle *l
 	else if (selected)
 	{
 		style.setStyle(painter, eWindowStyle::styleListboxSelected);
-		clearRegionSelectedHelper(painter, local_style, offset, size, pbackColorSelected, cursorValid, clear);
+		clearRegionSelectedHelper(painter, local_style, offset, size, pbackColorSelected, cursorValid, clear, isverticallb);
 		if (local_style && local_style->m_selection)
-			painter.blit(local_style->m_selection, ePoint(offset.x(), offset.y() + (size.height() - local_style->m_selection->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
+			if (isverticallb)
+				painter.blit(local_style->m_selection, ePoint(offset.x(), offset.y() + (size.height() - local_style->m_selection->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
+			else
+				painter.blit(local_style->m_selection, ePoint(offset.x() + (size.width() - local_style->m_selection->size().width()) / 2, offset.y()), eRect(), gPainter::BT_ALPHATEST);
 	}
 	else
 	{
 		style.setStyle(painter, eWindowStyle::styleListboxNormal);
-		clearRegionHelper(painter, local_style, offset, size, pbackColor, cursorValid, clear);
+		clearRegionHelper(painter, local_style, offset, size, pbackColor, cursorValid, clear, isverticallb);
 	}
 
 	if (selected)
@@ -764,6 +844,7 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 	bool cursorValid = this->cursorValid();
 	gRGB border_color;
 	int border_size = 0;
+	bool isverticallb = true;
 
 	if (sel_clip.valid())
 		sel_clip.moveBy(offset);
@@ -774,10 +855,11 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 		local_style = m_listbox->getLocalStyle();
 		border_size = local_style->m_border_size;
 		border_color = local_style->m_border_color;
+		isverticallb = m_listbox->getOrientation() == 1;
 	}
-
+	
 	painter.clip(itemregion);
-	clearRegion(painter, style, local_style, ePyObject(), ePyObject(), ePyObject(), ePyObject(), selected, itemregion, sel_clip, offset, m_itemsize, cursorValid);
+	clearRegion(painter, style, local_style, ePyObject(), ePyObject(), ePyObject(), ePyObject(), selected, itemregion, sel_clip, offset, m_itemsize, cursorValid, true, isverticallb);
 
 	ePyObject items, buildfunc_ret;
 
@@ -937,7 +1019,7 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 				{
 					gRegion rc(rect);
 					bool mustClear = (selected && pbackColorSelected) || (!selected && pbackColor);
-					clearRegion(painter, style, local_style, pforeColor, pforeColorSelected, pbackColor, pbackColorSelected, selected, rc, sel_clip, offset, m_itemsize, cursorValid, mustClear);
+					clearRegion(painter, style, local_style, pforeColor, pforeColorSelected, pbackColor, pbackColorSelected, selected, rc, sel_clip, offset, m_itemsize, cursorValid, mustClear, isverticallb);
 				}
 
 				painter.setFont(m_font[fnt]);
@@ -1059,7 +1141,7 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 				{
 					gRegion rc(rect);
 					bool mustClear = (selected && pbackColorSelected) || (!selected && pbackColor);
-					clearRegion(painter, style, local_style, pforeColor, pforeColorSelected, pbackColor, pbackColorSelected, selected, rc, sel_clip, offset, m_itemsize, cursorValid, mustClear);
+					clearRegion(painter, style, local_style, pforeColor, pforeColorSelected, pbackColor, pbackColorSelected, selected, rc, sel_clip, offset, m_itemsize, cursorValid, mustClear, isverticallb);
 				}
 
 				// border
@@ -1155,7 +1237,7 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 				{
 					gRegion rc(rect);
 					bool mustClear = (selected && pbackColorSelected) || (!selected && pbackColor);
-					clearRegion(painter, style, local_style, ePyObject(), ePyObject(), pbackColor, pbackColorSelected, selected, rc, sel_clip, offset, m_itemsize, cursorValid, mustClear);
+					clearRegion(painter, style, local_style, ePyObject(), ePyObject(), pbackColor, pbackColorSelected, selected, rc, sel_clip, offset, m_itemsize, cursorValid, mustClear, isverticallb);
 				}
 				flags |= (type == TYPE_PIXMAP_ALPHATEST) ? gPainter::BT_ALPHATEST : (type == TYPE_PIXMAP_ALPHABLEND) ? gPainter::BT_ALPHABLEND : 0;
 				painter.blit(pixmap, rect, rect, flags);
@@ -1247,8 +1329,21 @@ void eListboxPythonMultiContent::setFont(int fnt, gFont *font)
 void eListboxPythonMultiContent::setItemHeight(int height)
 {
 	m_itemheight = height;
-	if (m_listbox)
+	eDebug("[eListboxPythonMultiContent] setItemHeight %d", height);
+	if (m_listbox){
+		eDebug("[eListboxPythonMultiContent] Send height to eListBox!!!");
 		m_listbox->setItemHeight(height);
+	}
+}
+
+void eListboxPythonMultiContent::setItemWidth(int width)
+{
+	m_itemwidth = width;
+	eDebug("[eListboxPythonMultiContent] setItemWidth %d", width);
+	if (m_listbox){
+		eDebug("[eListboxPythonMultiContent] Send width to eListBox!!!");
+		m_listbox->setItemWidth(width);
+	}
 }
 
 void eListboxPythonMultiContent::setList(ePyObject list)

--- a/lib/gui/elistboxcontent.h
+++ b/lib/gui/elistboxcontent.h
@@ -12,6 +12,7 @@ public:
 	~eListboxPythonStringContent();
 
 	void setList(SWIG_PYOBJECT(ePyObject) list);
+	void setOrientation(int orientation);
 	void setItemHeight(int height);
 	void setItemWidth(int width);
 	PyObject *getCurrentSelection();
@@ -43,12 +44,14 @@ protected:
 
 	int getItemHeight() { return m_itemheight; }
 	int getItemWidth() { return m_itemwidth; }
+	int getOrientation() { return m_orientation; }
 
 protected:
 	ePyObject m_list;
 	int m_cursor, m_saved_cursor;
 	eSize m_itemsize;
 	ePtr<gFont> m_font;
+	int m_orientation;
 	int m_itemheight;
 	int m_itemwidth;
 #endif
@@ -82,6 +85,7 @@ public:
 	void setFont(int fnt, gFont *font);
 	void setBuildFunc(SWIG_PYOBJECT(ePyObject) func);
 	void setSelectableFunc(SWIG_PYOBJECT(ePyObject) func);
+	void setOrientation(int orientation);
 	void setItemHeight(int height);
 	void setItemWidth(int width);
 	void setSelectionClip(eRect &rect, bool update=false);

--- a/lib/gui/elistboxcontent.h
+++ b/lib/gui/elistboxcontent.h
@@ -13,6 +13,7 @@ public:
 
 	void setList(SWIG_PYOBJECT(ePyObject) list);
 	void setItemHeight(int height);
+	void setItemWidth(int width);
 	PyObject *getCurrentSelection();
 	int getCurrentSelectionIndex() { return m_cursor; }
 	void invalidateEntry(int index);
@@ -41,6 +42,7 @@ protected:
 	virtual void paint(gPainter &painter, eWindowStyle &style, const ePoint &offset, int selected);
 
 	int getItemHeight() { return m_itemheight; }
+	int getItemWidth() { return m_itemwidth; }
 
 protected:
 	ePyObject m_list;
@@ -48,6 +50,7 @@ protected:
 	eSize m_itemsize;
 	ePtr<gFont> m_font;
 	int m_itemheight;
+	int m_itemwidth;
 #endif
 };
 
@@ -80,6 +83,7 @@ public:
 	void setBuildFunc(SWIG_PYOBJECT(ePyObject) func);
 	void setSelectableFunc(SWIG_PYOBJECT(ePyObject) func);
 	void setItemHeight(int height);
+	void setItemWidth(int width);
 	void setSelectionClip(eRect &rect, bool update=false);
 	void updateClip(gRegion &);
 	void resetClip();

--- a/lib/gui/elistboxcontent.h
+++ b/lib/gui/elistboxcontent.h
@@ -51,9 +51,9 @@ protected:
 	int m_cursor, m_saved_cursor;
 	eSize m_itemsize;
 	ePtr<gFont> m_font;
-	int m_orientation;
 	int m_itemheight;
 	int m_itemwidth;
+	int m_orientation;
 #endif
 };
 

--- a/lib/gui/ewindowstyleskinned.cpp
+++ b/lib/gui/ewindowstyleskinned.cpp
@@ -111,21 +111,21 @@ void eWindowStyleSkinned::drawBorder(gPainter &painter, const eRect &pos, struct
 
 	if (tl)
 	{
-		painter.blit(tl, ePoint(x, pos.top()));
+		painter.blit(tl, ePoint(x, pos.top()), eRect(), gPainter::BT_ALPHABLEND);
 		x += tl->size().width();
 	}
 
 	if (tr)
 	{
 		xm -= tr->size().width();
-		painter.blit(tr, ePoint(xm, pos.top()), pos);
+		painter.blit(tr, ePoint(xm, pos.top()), pos, gPainter::BT_ALPHABLEND);
 	}
 
 	if (t)
 	{
 		while (x < xm)
 		{
-			painter.blit(t, ePoint(x, pos.top()), eRect(x, pos.top(), xm - x, pos.height()));
+			painter.blit(t, ePoint(x, pos.top()), eRect(x, pos.top(), xm - x, pos.height()), gPainter::BT_ALPHABLEND);
 			x += t->size().width();
 		}
 	}
@@ -135,21 +135,21 @@ void eWindowStyleSkinned::drawBorder(gPainter &painter, const eRect &pos, struct
 
 	if (bl)
 	{
-		painter.blit(bl, ePoint(pos.left(), pos.bottom()-bl->size().height()));
+		painter.blit(bl, ePoint(pos.left(), pos.bottom()-bl->size().height()), eRect(), gPainter::BT_ALPHABLEND);
 		x += bl->size().width();
 	}
 
 	if (br)
 	{
 		xm -= br->size().width();
-		painter.blit(br, ePoint(xm, pos.bottom()-br->size().height()), eRect(x, pos.bottom()-br->size().height(), pos.width() - x, bl->size().height()));
+		painter.blit(br, ePoint(xm, pos.bottom()-br->size().height()), eRect(x, pos.bottom()-br->size().height(), pos.width() - x, bl->size().height()), gPainter::BT_ALPHABLEND);
 	}
 
 	if (b)
 	{
 		while (x < xm)
 		{
-			painter.blit(b, ePoint(x, pos.bottom()-b->size().height()), eRect(x, pos.bottom()-b->size().height(), xm - x, pos.height()));
+			painter.blit(b, ePoint(x, pos.bottom()-b->size().height()), eRect(x, pos.bottom()-b->size().height(), xm - x, pos.height()), gPainter::BT_ALPHABLEND);
 			x += b->size().width();
 		}
 	}
@@ -168,7 +168,7 @@ void eWindowStyleSkinned::drawBorder(gPainter &painter, const eRect &pos, struct
 	{
 		while (y < ym)
 		{
-			painter.blit(l, ePoint(pos.left(), y), eRect(pos.left(), y, pos.width(), ym - y));
+			painter.blit(l, ePoint(pos.left(), y), eRect(pos.left(), y, pos.width(), ym - y), gPainter::BT_ALPHABLEND);
 			y += l->size().height();
 		}
 	}
@@ -188,7 +188,7 @@ void eWindowStyleSkinned::drawBorder(gPainter &painter, const eRect &pos, struct
 	{
 		while (y < ym)
 		{
-			painter.blit(r, ePoint(pos.right() - r->size().width(), y), eRect(pos.right()-r->size().width(), y, r->size().width(), ym - y));
+			painter.blit(r, ePoint(pos.right() - r->size().width(), y), eRect(pos.right()-r->size().width(), y, r->size().width(), ym - y), gPainter::BT_ALPHABLEND);
 			y += r->size().height();
 		}
 	}

--- a/lib/python/Components/Addons/Pager.py
+++ b/lib/python/Components/Addons/Pager.py
@@ -69,6 +69,8 @@ class Pager(GUIAddon):
 		return self.source.l.getCurrentSelectionIndex()
 
 	def getSourceHeight(self):
+		if self.source.__class__.__name__ == "List": # Components.Sources.List, used by MainMenu
+			return self.source.master.master.instance.size().height()
 		return self.source.instance.size().height()
 
 	def getListCount(self):
@@ -82,6 +84,8 @@ class Pager(GUIAddon):
 	def getListItemHeight(self):
 		if hasattr(self.source, 'content'):
 			return self.source.content.getItemSize().height()
+		if hasattr(self.source, 'item_height'): # Components.Sources.List, used by MainMenu
+			return self.source.item_height
 		return self.source.l.getItemSize().height()
 	
 	def initPager(self):

--- a/lib/python/Components/Addons/Pager.py
+++ b/lib/python/Components/Addons/Pager.py
@@ -100,7 +100,7 @@ class Pager(GUIAddon):
 				items_per_page = listH//itemHeight
 				if items_per_page > 0:
 					currentPageIndex = current_index//items_per_page
-					pagesCount = listCount//items_per_page
+					pagesCount = -(listCount//-items_per_page) - 1
 					self.selChange(currentPageIndex,pagesCount)
 
 	def applySkin(self, desktop, parent):

--- a/lib/python/Components/Addons/Pager.py
+++ b/lib/python/Components/Addons/Pager.py
@@ -39,7 +39,7 @@ class Pager(GUIAddon):
 			pixd_size = self.picDotPage.size()
 			pixd_width = pixd_size.width()
 			pixd_height = pixd_size.height()
-			width_dots = pixd_width + (pixd_width + 5)*pageCount
+			width_dots = pixd_width + (pixd_width + self.spacing)*pageCount
 			xPos = (width - width_dots)/2 - pixd_width/2
 		res = [ None ]
 		if pageCount > 0:

--- a/lib/python/Components/Addons/Pager.py
+++ b/lib/python/Components/Addons/Pager.py
@@ -19,6 +19,7 @@ class Pager(GUIAddon):
 		self.spacing = 5
 		self.picDotPage = LoadPixmap(resolveFilename(SCOPE_GUISKIN, "icons/dot.png"))
 		self.picDotCurPage = LoadPixmap(resolveFilename(SCOPE_GUISKIN, "icons/dotfull.png"))
+		self.showIcons = "showAll" # can be "showAll", "onlyFirst", "onlyLast"
 
 	def onContainerShown(self):
 		# disable listboxes default scrollbars
@@ -40,10 +41,16 @@ class Pager(GUIAddon):
 			pixd_width = pixd_size.width()
 			pixd_height = pixd_size.height()
 			width_dots = pixd_width + (pixd_width + self.spacing)*pageCount
-			xPos = (width - width_dots)/2 - pixd_width/2
+			xPos = (width - width_dots)/2 - pixd_width/2 if self.showIcons == "showAll" else 0
 		res = [ None ]
-		if pageCount > 0:
-			for x in range(pageCount + 1):
+		if pageCount > (0 if self.showIcons == "showAll" else -1):
+			pages = list(range(pageCount + 1))
+			# add option to show just first or last icon
+			if self.showIcons == "onlyFirst":
+				pages = [pages[0]]
+			elif self.showIcons == "onlyLast":
+				pages = [pages[-1]]
+			for x in pages:
 				if self.picDotPage and self.picDotCurPage:
 					res.append(MultiContentEntryPixmapAlphaBlend(
 								pos=(xPos, 0),
@@ -141,6 +148,8 @@ class Pager(GUIAddon):
 				self.l.setItemHeight(parseScale(value))
 			elif attrib == "spacing":
 				self.spacing = parseScale(value)
+			elif attrib == "showIcons":
+				self.showIcons = value
 			else:
 				attribs.append((attrib, value))
 		self.skinAttributes = attribs

--- a/lib/python/Components/Addons/Pager.py
+++ b/lib/python/Components/Addons/Pager.py
@@ -87,8 +87,7 @@ class Pager(GUIAddon):
 			return self.source.listCount
 		elif hasattr(self.source, 'list'):
 			return len(self.source.list)
-		else:
-			return 0
+		return 0
 
 	def getListItemSize(self):
 		if self.source.__class__.__name__ == "List": # Components.Sources.List, used by MainMenu

--- a/lib/python/Components/Converter/TemplatedMultiContent.py
+++ b/lib/python/Components/Converter/TemplatedMultiContent.py
@@ -1,5 +1,7 @@
 from Components.Converter.StringList import StringList
 
+from enigma import eListbox
+
 
 class TemplatedMultiContent(StringList):
 	"""Turns a python tuple list into a multi-content list which can be used in a listbox renderer."""
@@ -15,6 +17,7 @@ class TemplatedMultiContent(StringList):
 		del loc["args"]
 		self.active_style = None
 		self.template = eval(args, {}, loc)
+		self.orientations = {"orHorizontal": eListbox.orHorizontal, "orVertical": eListbox.orVertical}
 		assert "fonts" in self.template
 		assert "itemHeight" in self.template
 		assert "template" in self.template or "templates" in self.template
@@ -67,7 +70,7 @@ class TemplatedMultiContent(StringList):
 				
 			self.content.setTemplate(template)
 			if orientation is not None and itemwidth is not None:
-				self.content.setOrientation(int(orientation))
+				self.content.setOrientation(self.orientations.get(orientation, self.orientations["orVertical"]))
 				self.content.setItemWidth(int(itemwidth))
 			self.content.setItemHeight(int(itemheight))
 			self.selectionEnabled = selectionEnabled

--- a/lib/python/Components/Converter/TemplatedMultiContent.py
+++ b/lib/python/Components/Converter/TemplatedMultiContent.py
@@ -20,8 +20,13 @@ class TemplatedMultiContent(StringList):
 		assert "template" in self.template or "templates" in self.template
 		assert "template" in self.template or "default" in self.template["templates"]  # We need to have a default template.
 		if "template" not in self.template:  # Default template can be ["template"] or ["templates"]["default"].
-			self.template["template"] = self.template["templates"]["default"][1]
-			self.template["itemHeight"] = self.template["template"][0]
+			self.template["template"] = self.template["templates"]["default"][1] # mandatory
+			self.template["itemHeight"] = self.template["template"][0] # mandatory
+			self.template["selectionEnabled"] = self.template["template"][2] if len(self.template["template"]) > 2 and self.template["template"][2] is not None else True  # optional. To skip use None padding.
+			self.template["scrollbarMode"] = self.template["template"][3] if len(self.template["template"]) > 3 and self.template["template"][3] is not None  else "showOnDemand"  # optional. To skip use None padding.
+			# if present self.template["template"][4] is a dict which should have "orientation" and "itemWidth"
+			self.template["itemWidth"] =  self.template["template"][4].get("itemWidth") if len(self.template["template"]) > 4 else None # optional
+			self.template["orientation"] = self.template["template"][4].get("orientation") if len(self.template["template"]) > 4 else None # optional
 
 	def changed(self, what):
 		if not self.content:
@@ -44,16 +49,26 @@ class TemplatedMultiContent(StringList):
 			templates = self.template.get("templates")  # If skin defined "templates", that means that it defines multiple styles in a dict. template should still be a default.
 			template = self.template.get("template")
 			itemheight = self.template["itemHeight"]
+			itemwidth = self.template.get("itemWidth")
+			orientation = self.template.get("orientation")
 			selectionEnabled = self.template.get("selectionEnabled", True)
 			scrollbarMode = self.template.get("scrollbarMode", "showOnDemand")
 			if templates and style and style in templates:  # If we have a custom style defined in the source, and different templates in the skin, look it up
+				# "template" and "itemheight" are mandatory in a template. selectionEnabled, scrollbarMode, itemwidth, and orientation are optional.
 				template = templates[style][1]
 				itemheight = templates[style][0]
-				if len(templates[style]) > 2:
+				if len(templates[style]) > 2 and templates[style][2] is not None:
 					selectionEnabled = templates[style][2]
-				if len(templates[style]) > 3:
+				if len(templates[style]) > 3 and templates[style][3] is not None:
 					scrollbarMode = templates[style][3]
+				if len(templates[style]) > 4 and templates[style][4] is not None and templates[style][4].get("itemWidth") is not None and templates[style][4].get("orientation") is not None:
+					itemwidth = templates[style][4]["itemWidth"]
+					orientation = templates[style][4]["orientation"]
+				
 			self.content.setTemplate(template)
+			if orientation is not None and itemwidth is not None:
+				self.content.setOrientation(int(orientation))
+				self.content.setItemWidth(int(itemwidth))
 			self.content.setItemHeight(int(itemheight))
 			self.selectionEnabled = selectionEnabled
 			self.scrollbarMode = scrollbarMode

--- a/lib/python/Components/Converter/TemplatedMultiContent.py
+++ b/lib/python/Components/Converter/TemplatedMultiContent.py
@@ -23,13 +23,16 @@ class TemplatedMultiContent(StringList):
 		assert "template" in self.template or "templates" in self.template
 		assert "template" in self.template or "default" in self.template["templates"]  # We need to have a default template.
 		if "template" not in self.template:  # Default template can be ["template"] or ["templates"]["default"].
-			self.template["template"] = self.template["templates"]["default"][1] # mandatory
-			self.template["itemHeight"] = self.template["template"][0] # mandatory
-			self.template["selectionEnabled"] = self.template["template"][2] if len(self.template["template"]) > 2 and self.template["template"][2] is not None else True  # optional. To skip use None padding.
-			self.template["scrollbarMode"] = self.template["template"][3] if len(self.template["template"]) > 3 and self.template["template"][3] is not None  else "showOnDemand"  # optional. To skip use None padding.
-			# if present self.template["template"][4] is a dict which should have "orientation" and "itemWidth"
-			self.template["itemWidth"] =  self.template["template"][4].get("itemWidth") if len(self.template["template"]) > 4 else None # optional
-			self.template["orientation"] = self.template["template"][4].get("orientation") if len(self.template["template"]) > 4 else None # optional
+			templateDefault = self.template["templates"]["default"]
+			self.template["template"] = templateDefault[1]  # mandatory
+			self.template["itemHeight"] = templateDefault[0]  # mandatory
+			if len(templateDefault) > 2:  # optional
+				self.template["selectionEnabled"] = templateDefault[2]
+			if len(templateDefault) > 3:  # optional
+				self.template["scrollbarMode"] = templateDefault[3]
+			if len(templateDefault) > 5:  # optional, but, must be present together
+				self.template["itemWidth"] =  templateDefault[4]
+				self.template["orientation"] = templateDefault[5]
 
 	def changed(self, what):
 		if not self.content:
@@ -64,9 +67,9 @@ class TemplatedMultiContent(StringList):
 					selectionEnabled = templates[style][2]
 				if len(templates[style]) > 3 and templates[style][3] is not None:
 					scrollbarMode = templates[style][3]
-				if len(templates[style]) > 4 and templates[style][4] is not None and templates[style][4].get("itemWidth") is not None and templates[style][4].get("orientation") is not None:
-					itemwidth = templates[style][4]["itemWidth"]
-					orientation = templates[style][4]["orientation"]
+				if len(templates[style]) > 5:  # optional, but, must be present together
+					itemwidth = templates[style][4]
+					orientation = templates[style][5]
 				
 			self.content.setTemplate(template)
 			if orientation is not None and itemwidth is not None:

--- a/lib/python/Components/Renderer/Listbox.py
+++ b/lib/python/Components/Renderer/Listbox.py
@@ -38,7 +38,6 @@ class Listbox(Renderer):
 		if self.__content is not None:
 			instance.setContent(self.__content)
 		instance.selectionChanged.get().append(self.selectionChanged)
-		instance.setOrientation(0)
 		self.wrap_around = self.wrap_around # trigger
 		self.selection_enabled = self.selection_enabled # trigger
 		self.scrollbarMode = self.scrollbarMode # trigger

--- a/lib/python/Components/Renderer/Listbox.py
+++ b/lib/python/Components/Renderer/Listbox.py
@@ -38,6 +38,7 @@ class Listbox(Renderer):
 		if self.__content is not None:
 			instance.setContent(self.__content)
 		instance.selectionChanged.get().append(self.selectionChanged)
+		instance.setOrientation(0)
 		self.wrap_around = self.wrap_around # trigger
 		self.selection_enabled = self.selection_enabled # trigger
 		self.scrollbarMode = self.scrollbarMode # trigger
@@ -105,3 +106,14 @@ class Listbox(Renderer):
 	def entry_changed(self, index):
 		if self.instance is not None:
 			self.instance.entryChanged(index)
+			
+	def applySkin(self, desktop, parent):
+		attribs = [ ]
+		for (attrib, value) in self.skinAttributes[:]:
+			if attrib == "selectionFrame":
+				if value == "none":
+					self.instance.setSelectionBorderHidden()
+			else:
+				attribs.append((attrib, value))
+		self.skinAttributes = attribs
+		return Renderer.applySkin(self, desktop, parent)

--- a/lib/python/Components/Renderer/Listbox.py
+++ b/lib/python/Components/Renderer/Listbox.py
@@ -40,6 +40,9 @@ class Listbox(Renderer):
 		instance.selectionChanged.get().append(self.selectionChanged)
 		self.wrap_around = self.wrap_around # trigger
 		self.selection_enabled = self.selection_enabled # trigger
+		for (attrib, value) in self.skinAttributes:
+			if attrib == "scrollbarMode":
+				self.__scrollbarMode = value
 		self.scrollbarMode = self.scrollbarMode # trigger
 
 	def preWidgetRemove(self, instance):
@@ -95,7 +98,9 @@ class Listbox(Renderer):
 		if hasattr(self.source, "selectionEnabled"):
 			self.selection_enabled = self.source.selectionEnabled
 		if hasattr(self.source, "scrollbarMode"):
-			self.scrollbarMode = self.source.scrollbarMode
+			for (attrib, value) in self.skinAttributes:
+				if attrib == "scrollbarMode":
+					self.scrollbarMode = value
 		if len(what) > 1 and isinstance(what[1], str) and what[1] == "style":
 			return
 		if self.content:

--- a/lib/python/Components/Renderer/Listbox.py
+++ b/lib/python/Components/Renderer/Listbox.py
@@ -86,10 +86,9 @@ class Listbox(Renderer):
 		self.__scrollbarMode = mode
 		if self.instance is not None:
 			self.instance.setScrollbarMode(int(
-				{
-					"showOnDemand": 0,
-					"showAlways": 1,
-					"showNever": 2,
+				{"showOnDemand": eListbox.showOnDemand,
+				  "showAlways": eListbox.showAlways,
+				  "showNever": eListbox.showNever,
 				}[mode]))
 
 	scrollbarMode = property(lambda self: self.__scrollbarMode, setScrollbarMode)

--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -1199,14 +1199,11 @@ def readSkin(screen, skin, names, desktop):
 			if not wconnection:
 				raise SkinError("The widget is from addon type: %s , but no connection is specified." % wclass)
 			
-			if not windex:
-				windex = "0"
-			
+			i = 0
 			wclassname_base = name + "_" + wclass + "_" + wconnection + "_"
-			wclassname = wclassname_base + windex
-			while wclassname in usedComponents:
-				next_index = int(wclassname.replace(wclassname_base, "")) + 1
-				wclassname = wclassname_base + str(next_index)
+			while wclassname_base + str(i) in usedComponents:
+				i += 1
+			wclassname = wclassname_base + str(i)
 
 			usedComponents.add(wclassname)
 

--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -1113,6 +1113,7 @@ def readSkin(screen, skin, names, desktop):
 		wsource = widget.attrib.get("source")
 		wconnection = widget.attrib.get("connection")
 		wclass = widget.attrib.get("addon")
+		windex = widget.attrib.get("index")
 		source = None
 		if wname is None and wsource is None and wclass is None:
 			raise SkinError("The widget has no name, no source and no addon type specified")
@@ -1198,7 +1199,10 @@ def readSkin(screen, skin, names, desktop):
 			if not wconnection:
 				raise SkinError("The widget is from addon type: %s , but no connection is specified." % wclass)
 			
-			wclassname = name + "_" + wclass + "_" + wconnection #form a name for the GUI Addon so to be possible to be inited in screen
+			if not windex:
+				windex = "0"
+			
+			wclassname = name + "_" + wclass + "_" + wconnection + "_" + windex
 
 			usedComponents.add(wclassname)
 

--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -1113,7 +1113,6 @@ def readSkin(screen, skin, names, desktop):
 		wsource = widget.attrib.get("source")
 		wconnection = widget.attrib.get("connection")
 		wclass = widget.attrib.get("addon")
-		windex = widget.attrib.get("index")
 		source = None
 		if wname is None and wsource is None and wclass is None:
 			raise SkinError("The widget has no name, no source and no addon type specified")

--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -1202,7 +1202,11 @@ def readSkin(screen, skin, names, desktop):
 			if not windex:
 				windex = "0"
 			
-			wclassname = name + "_" + wclass + "_" + wconnection + "_" + windex
+			wclassname_base = name + "_" + wclass + "_" + wconnection + "_"
+			wclassname = wclassname_base + windex
+			while wclassname in usedComponents:
+				next_index = int(wclassname.replace(wclassname_base, "")) + 1
+				wclassname = wclassname_base + str(next_index)
 
 			usedComponents.add(wclassname)
 

--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -502,6 +502,9 @@ class AttributeParser:
 
 	def itemHeight(self, value):
 		self.guiObject.setItemHeight(parseScale(value))
+	
+	def itemWidth(self, value):
+		self.guiObject.setItemWidth(parseScale(value))
 
 	def pixmap(self, value):
 		if value.endswith(".svg"): # if graphic is svg force alphatest to "blend"
@@ -540,7 +543,7 @@ class AttributeParser:
 		value = 1 if value.lower() in ("1", "enabled", "on", "scale", "true", "yes") else 0
 		self.guiObject.setScale(value)
 
-	def orientation(self, value):  # Used by eSlider.
+	def orientation(self, value):  # Used by eSlider and eListBox.
 		try:
 			self.guiObject.setOrientation(*{
 				"orVertical": (self.guiObject.orVertical, False),


### PR DESCRIPTION
Please do not squash this PR.

The main Author of this project is @DimitarCC

As Littlesat said here: https://forums.openpli.org/topic/71952-horizontal-menus/#entry1440350
"When you do it really right you need to make a listbox horizontal type with size scrollbar number of items etc [...] it is really a feature that universally could be used."

Well these commits allow elistbox to work in horizontal mode.

There are also updates to Pager.py, Listbox.py and TemplatedMulticontent.py for compatibility.

This PR should be fully backwards compatible.

Example:
	<screen name="MenuHorizontal" position="fill" backgroundColor="transparent" flags="wfNoBorder">
		<ePixmap alphatest="blend" pixmap="infobar/hd.png" position="0,e-180" size="e,180" zPosition="-1" scale="1"/>
		<widget source="Title" conditional="Title" render="Label" position="0,e-170" size="e,80" font="Regular;64" halign="center" valign="center" transparent="1" backgroundColor="transpBlack"/>
		<widget source="menu" render="Listbox" enableWrapAround="off" position="60,e-85" size="1800,80" foregroundColorSelected="selectedFG" foregroundColor="foreground" backgroundColorSelected="transpBlack" backgroundColor="transpBlack" scrollbarMode="showNever" selectionFrame="none" >
			<convert type="TemplatedMultiContent">
				{"template": [ MultiContentEntryText(pos = (10,0), size = (340,80), flags = RT_HALIGN_CENTER|RT_VALIGN_CENTER,text = 0) ],
					"fonts": [gFont("Regular",34)],
					"itemHeight": 80,
					"itemWidth": 360,
					"orientation" : "orHorizontal",
				}
			</convert>
		</widget>
		<widget addon="Pager" connection="menu" itemHeight="75" showIcons="onlyFirst" picPage="icons/chevronleft.png" picPageCurrent="icons/chevronlefttrans.png" position="0,e-85" size="50,75" transparent="0" backgroundColor="transpBlack"/>
		<widget addon="Pager" connection="menu" itemHeight="75" showIcons="onlyLast" picPage="icons/chevronright.png" picPageCurrent="icons/chevronrighttrans.png" position="e-50,e-85" size="50,75" transparent="0" backgroundColor="transpBlack"/>
	</screen>

But this is not just for the menu. It should work for other list types that use listbox and will allow creation of horizontal tabs, etc.

New functions regarding horizontal eListBox:

1. eListBox
- setOrientation(int orientation) - allows setting of orientation of the eListbox; takes values orHorizontal, orVertical
- enum { 
	orHorizontal = 0, 
	orVertical  = 1
}
- getOrientation() - gets current eListbox orientation
- setItemWidth(int w) - allow setting of item width of the eListbox. Works only in case of orientation orHorizontal
- setSelectionBorderHidden() - allow to hide eListbox item selection frame (borders) for the specific eListbox instance

2. Listbox.py
- attribute "selectionFrame" - see eListbox::setSelectionBorderHidden()

3. eListboxPythonStringContent
   eListboxPythonMultiContent
   
- setOrientation(int orientation) - allows setting or orientation of the eListbox from the template. Takes values orHorizontal, orVertical
- setItemWidth(int width) - allow setting of item width of the eListbox. Works only in case of orientation orHorizontal
- getItemWidth() - get current item width
- getOrientation() - get current orientation of the eListbox

4. eSlider (skin.py)
- attribute 'height" - handled by eListbox. Used in case of orientation orHorizontal of the listbox

5. TemplatedMultiContent
- attribute "itemWidth" - see eListboxPythonMultiContent::setItemWidth(int width)
- attribute "orientation" - see eListboxPythonMultiContent::setOrientation(int orientation)
