### PR TITLE
Fix scaling factor in EpgList

### DIFF
--- a/lib/python/Components/EpgList.py
+++ b/lib/python/Components/EpgList.py
@@ -437,8 +437,8 @@ class EPGList(GUIComponent):
 		for (attrib, value) in self.skinAttributes[:]:
 			try:
 				locals().get(attrib)(value)
-			except (TypeError, ValueError, NameError):
-				pass
+			except (TypeError, ValueError, NameError) as er:
+				print("[EPGList] error in set skin parameters", er)
 			else:
 				self.skinAttributes.remove((attrib, value))
 

--- a/lib/python/Components/EpgList.py
+++ b/lib/python/Components/EpgList.py
@@ -9,7 +9,7 @@ from time import localtime, time
 from Components.config import config
 from ServiceReference import ServiceReference
 from Tools.Directories import resolveFilename, SCOPE_CURRENT_SKIN
-from skin import applySkinFactor, parseFont, parseScale
+from skin import applySkinFactor, parseFont, parseScale, getSkinFactor
 
 
 EPG_TYPE_SINGLE = 0
@@ -403,6 +403,9 @@ class EPGList(GUIComponent):
 		print(int(time() - t))
 
 	def applySkin(self, desktop, parent):
+		global f
+		f = getSkinFactor()
+
 		def warningWrongSkinParameter(string):
 			print("[EPGList] wrong '%s' skin parameters" % string)
 
@@ -422,7 +425,7 @@ class EPGList(GUIComponent):
 			self.tw = parseScale(value)
 
 		def setColWidths(value):
-			self.col = list(map(int, value.split(',')))
+			self.col = [int(eval(x) if "*f" in x else x) for x in value.split(",")]
 			if len(self.col) == 2:
 				self.skinColumns = True
 			else:
@@ -430,12 +433,15 @@ class EPGList(GUIComponent):
 
 		def setColGap(value):
 			self.colGap = parseScale(value)
+
 		for (attrib, value) in self.skinAttributes[:]:
 			try:
 				locals().get(attrib)(value)
-				self.skinAttributes.remove((attrib, value))
-			except:
+			except (TypeError, ValueError, NameError):
 				pass
+			else:
+				self.skinAttributes.remove((attrib, value))
+
 		self.l.setFont(0, self.eventItemFont)
 		self.l.setFont(1, self.eventTimeFont)
 		return GUIComponent.applySkin(self, desktop, parent)


### PR DESCRIPTION
If scaling factor *f is used in setColWidths it raises ValueError because *f cannot be converted as int.
Therefore create a global f = getSkinFactor() in applySkin for this case and use eval() to calculate the scaling factor.