### PR TITLE
[Standby] show shutdown mesage when use HDMI-CEC

### DIFF
--- a/lib/python/Screens/Standby.py
+++ b/lib/python/Screens/Standby.py
@@ -345,8 +345,11 @@ class TryQuitMainloop(MessageBox):
 						if config.hdmicec.control_tv_standby.value and config.hdmicec.next_boxes_detect.value:
 							import Components.HdmiCec
 							Components.HdmiCec.hdmi_cec.secondBoxActive()
+						if not hasattr(self, "quitScreen"):
+							self.quitScreen = self.session.instantiateDialog(QuitMainloopScreen)
+							self.quitScreen.show()
 						self.delay = eTimer()
-						self.delay.timeout.callback.append(self.quitMainloop)
+						self.delay.timeout.callback.append(self.quitMainloopDelay)
 						self.delay.start(1500, True)
 						return
 			elif not inStandby:
@@ -355,6 +358,10 @@ class TryQuitMainloop(MessageBox):
 			self.quitMainloop()
 		else:
 			MessageBox.close(self, True)
+
+	def quitMainloopDelay(self):
+		self.session.nav.stopService()
+		quitMainloop(self.retval)
 
 	def quitMainloop(self):
 		self.session.nav.stopService()


### PR DESCRIPTION
-before this, the TV turned off before the message appeared on the screen