### PR TITLE
MovieSelection - directly use reload list after item reset (instead u…

### DIFF
--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -1748,7 +1748,7 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 		current = self.getCurrent()
 		if current:
 			resetMoviePlayState(current.getPath() + ".cuts", current)
-			self["list"].invalidateCurrentItem() # trigger repaint
+			self["list"].reload()
 
 	def do_move(self):
 		item = self.getCurrentSelection()


### PR DESCRIPTION
…sed invalidateCurrentItem)

- boxes have no problem quickly refreshing even an extensive list.