### PR TITLE
[NimManager] remove "internally_connectable" from the first tuner of …

### DIFF
--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -949,6 +949,8 @@ class NimManager:
 							entry["internally_connectable"] = 1
 					elif id:
 						entry["internally_connectable"] = entry["frontend_device"] - 1
+						if HardwareInfo().get_device_model() == "vuduo2" and entry["i2c"] != entries[id - 1]["i2c"]:
+							entry["internally_connectable"] = None
 			else:
 				entry["frontend_device"] = None
 			if "multi_type" not in entry:


### PR DESCRIPTION
…the second slot duo2

it's a dummy value
1 slot

A  --> Vuplus DVB-S NIM(AVL6222)  --> I2C_Device: 2 -->

B  --> Vuplus DVB-S NIM(AVL6222)  --> I2C_Device: 2 --> /proc/stb/frontend/1/rf_switch:external

 

2 slot

C --> Vuplus DVB-S NIM(AVL6222)  --> I2C_Device: 4 --> /proc/stb/frontend/2/rf_switch:external   have internal loopthrough??

D --> Vuplus DVB-S NIM(AVL6222)  --> I2C_Device: 4 --> /proc/stb/frontend/3/rf_switch:external