### PR TITLE
[PluginComponent] add sanity check in remove plugin

### DIFF
--- a/lib/python/Components/PluginComponent.py
+++ b/lib/python/Components/PluginComponent.py
@@ -32,7 +32,8 @@ class PluginComponent:
 			self.restartRequired = True
 
 	def removePlugin(self, plugin):
-		self.pluginList.remove(plugin)
+		if plugin in self.pluginList:
+			self.pluginList.remove(plugin)
 		for x in plugin.where:
 			self.plugins[x].remove(plugin)
 			if x == PluginDescriptor.WHERE_AUTOSTART:


### PR DESCRIPTION
File "/usr/lib/enigma2/python/Screens/PluginBrowser.py", line 316, in requestClose
  File
"/usr/lib/enigma2/python/Components/PluginComponent.py", line 104, in readPluginList
  File
"/usr/lib/enigma2/python/Components/PluginComponent.py", line 37, in removePlugin
ValueError: list.remove(x): x not in list

Remove plugin EPGRefresh