### PR TITLE
[pmt] audio mpeg priority if default "Auto language selection"

### DIFF
--- a/lib/dvb/pmt.cpp
+++ b/lib/dvb/pmt.cpp
@@ -413,6 +413,7 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 	{
 		unsigned int i;
 		int first_non_mpeg = -1;
+		int first_mpeg = -1;
 		int audio_cached = -1;
 		int autoaudio_mpeg = -1;
 		int autoaudio_ac3 = -1;
@@ -502,6 +503,12 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 			{
 				first_non_mpeg = i;
 			}
+
+			if (autoaudio_languages.empty() && program.audioStreams[i].type == audioStream::atMPEG && first_mpeg == -1)
+			{
+				first_mpeg = i;
+			}
+
 			if (!program.audioStreams[i].language_code.empty())
 			{
 				int x = 1;
@@ -599,6 +606,8 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 				program.defaultAudioStream = autoaudio_aac;
 			else if (first_non_mpeg != -1 && (defaultac3 || defaultddp))
 				program.defaultAudioStream = first_non_mpeg;
+			else if (first_non_mpeg != -1 && first_mpeg != -1 && first_non_mpeg < first_mpeg && (!defaultac3 || !defaultddp))
+				program.defaultAudioStream = first_mpeg;
 		}
 
 		bool allow_hearingimpaired = eConfigManager::getConfigBoolValue("config.autolanguage.subtitle_hearingimpaired");


### PR DESCRIPTION
-example:
"Audio language selection 1" empty
"Prefer AC3 track"/"Prefer AC3+ track"/"Prefer audio track stored by service"  no

play service in audio tracks:
1)AC3  - this used
2)MPEG

This patch selects the MPEG  track.