### PR TITLE
[ScanSetup] sanity check empty slot

### DIFF
--- a/lib/python/Screens/ScanSetup.py
+++ b/lib/python/Screens/ScanSetup.py
@@ -1004,9 +1004,9 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 		self.nim_type_dict = {}
 		# collect all nims which are *not* set to "nothing"
 		for n in nimmanager.nim_slots:
-			modes = [x[:5] for x in n.getTunerTypesEnabled()]
-			if n.config_mode == "nothing":
+			if n.empty or n.config_mode == "nothing":
 				continue
+			modes = [x[:5] for x in n.getTunerTypesEnabled()]
 			if "DVB-S" in modes: # Only do the DVB-S tests below when DVB-S is present in modes. This avoids problems with combined tuners such as Availink AVL6862.
 				if n.config_mode in ("simple", "equal", "advanced") and len(nimmanager.getSatListForNim(n.slot)) < 1:
 					continue


### PR DESCRIPTION
root@dm8000:/hdd# cat /proc/bus/nim_sockets
NIM Socket 0:
Type: DVB-S2
Name: BCM4506 (internal)
Has_Outputs: no
Frontend_Device: 0
I2C_Device: 3
NIM Socket 1:
Type: DVB-S2
Name: BCM4506 (internal)
Has_Outputs: no
Frontend_Device: 1
I2C_Device: 3
NIM Socket 2:
empty
NIM Socket 3:
empty

File "/usr/lib/enigma2/python/Screens/ScanSetup.py", line 1007, in <listcomp>
TypeError: 'NoneType' object is not subscriptable