### PR TITLE
FallbackTimer.py: Fix retrieve timer list from fallback with HTTP aut…

### DIFF
--- a/lib/python/Tools/FallbackTimer.py
+++ b/lib/python/Tools/FallbackTimer.py
@@ -20,7 +20,7 @@ class FallbackTimerList():
 			if config.usage.remote_fallback_openwebif_customize.value:
 				self.url = "%s:%s" % (self.url, config.usage.remote_fallback_openwebif_port.value)
 				if config.usage.remote_fallback_openwebif_userid.value and config.usage.remote_fallback_openwebif_password.value:
-					self.headers = {b"Authorization": "Basic %s" % encodebytes(("%s:%s" % (config.usage.remote_fallback_openwebif_userid.value, config.usage.remote_fallback_openwebif_password.value)).encode("UTF-8")).strip()}
+					self.headers = {b"Authorization": b"Basic %s" % encodebytes(("%s:%s" % (config.usage.remote_fallback_openwebif_userid.value, config.usage.remote_fallback_openwebif_password.value)).encode("UTF-8")).strip()}
 			self.getFallbackTimerList()
 		else:
 			self.url = None


### PR DESCRIPTION
…hentication

[Screen] Warning: Skin is missing element 'autoresize' in <class 'Screens.MessageBox.MessageBox'>(Error while retrieving fallback timer information [Failure instance: Traceback (failure with no frames): <class 'twisted.web.error.Error'>: 401 Unauthorized ]).