### PR TITLE
About.py: Fix wrong driver date dm8000

### DIFF
--- a/lib/python/Components/About.py
+++ b/lib/python/Components/About.py
@@ -150,7 +150,7 @@ def getDriverInstalledDate():
 	try:
 		from glob import glob
 		try:
-			driver = [x.split("-")[-2:-1][0][-8:] for x in open(glob("/var/lib/opkg/info/*-dvb-modules-*.control")[0], "r") if x.startswith("Version:")][0]
+			driver = [x.split("-")[-2:-1][0][-9 if "a" in x else -8:] for x in open(glob("/var/lib/opkg/info/*-dvb-modules-*.control")[0], "r") if x.startswith("Version:")][0]
 			return "%s-%s-%s" % (driver[:4], driver[4:6], driver[6:])
 		except:
 			try:


### PR DESCRIPTION
Due to an appended 'a' in driver date, driver date is displayed as '014-60-4a'. Increase sliding window to fix this.