### PR TITLE
About.py: Simplify extracting date from driver a bit

### DIFF
--- a/lib/python/Components/About.py
+++ b/lib/python/Components/About.py
@@ -150,7 +150,7 @@ def getDriverInstalledDate():
 	try:
 		from glob import glob
 		try:
-			driver = [x.split("-")[-2:-1][0][-8:] for x in open(glob("/var/lib/opkg/info/*-dvb-modules-*.control")[0], "r") if x.startswith("Version:")][0]
+			driver = [x.split("-")[-2] for x in open(glob("/var/lib/opkg/info/*-dvb-modules-*.control")[0], "r") if x.startswith("Version:")][0]
 			return "%s-%s-%s" % (driver[:4], driver[4:6], driver[6:])
 		except:
 			try:


### PR DESCRIPTION
No need to limit string to 8 characters.
Sliding with [-2:-1][0] to a not nested list is equal to list[-2].

This fixes also wrong driver date with dm8000.
Date displayed as '0140-604a' before patch.