### PR TITLE
Optimizes codec replacement in ServiceInfo

### DIFF
--- a/lib/python/Components/Converter/ServiceInfo.py
+++ b/lib/python/Components/Converter/ServiceInfo.py
@@ -3,51 +3,47 @@ from enigma import iServiceInformation, iPlayableService
 from Screens.InfoBarGenerics import hasActiveSubservicesForCurrentChannel
 from Components.Element import cached
 
+
 WIDESCREEN = [3, 4, 7, 8, 0xB, 0xC, 0xF, 0x10]
-
-_acedits = None
-
-def _assignAcedits():
-	return (
-	("A_", ""),
-	("AC-3", "AC3"),
-	("(ATSC A/52)", ""),
-	("(ATSC A/52B)", ""),
-	("MPEG-1 Layer 2 (MP2)", "MP2"),
-	(" Layer 2 (MP2)", ""),
-	(" Layer 3 (MP3)", "MP3"),
-	("-1", ""),
-	("-2", ""),
-	("2-", ""),
-	("MPEG-4 AAC", "AAC"),
-	("-4 AAC", "AAC"),
-	("4-AAC", "HE-AAC"),
-	("audio", ""),
-	("/L3", ""),
-	("/mpeg", "AAC"),
-	("/x-", ""),
-	("raw", "Dolby TrueHD"),
-	("E-AC3", "AC3+"),
-	("EAC3", "AC3+"),
-	("IPCM", "AC3"),
-	("LPCM", "AC3+"),
-	("AAC_PLUS", "AAC+"),
-	("AAC_LATM", "AAC"),
-	("WMA/PRO", "WMA Pro"),
-	("MPEG", "MPEG1 Layer II"),
-	("MPEG1 Layer II AAC", "AAC"),
-	("MPEG1 Layer IIAAC", "AAC"),
-	("MPEG1 Layer IIMP3", "MP3"),
-	)
 
 
 def StdAudioDesc(description):
-	global _acedits
-	if _acedits is None:
-		_acedits = _assignAcedits()
 	if not description:
 		return ""
-	for orig, repl in _acedits:
+
+	REPLACEMENTS = (
+		("A_", ""),
+		("AC-3", "AC3"),
+		("(ATSC A/52)", ""),
+		("(ATSC A/52B)", ""),
+		("MPEG-1 Layer 2 (MP2)", "MP2"),
+		(" Layer 2 (MP2)", ""),
+		(" Layer 3 (MP3)", "MP3"),
+		("-1", ""),
+		("-2", ""),
+		("2-", ""),
+		("MPEG-4 AAC", "AAC"),
+		("-4 AAC", "AAC"),
+		("4-AAC", "HE-AAC"),
+		("audio", ""),
+		("/L3", ""),
+		("/mpeg", "AAC"),
+		("/x-", ""),
+		("raw", "Dolby TrueHD"),
+		("E-AC3", "AC3+"),
+		("EAC3", "AC3+"),
+		("IPCM", "AC3"),
+		("LPCM", "AC3+"),
+		("AAC_PLUS", "AAC+"),
+		("AAC_LATM", "AAC"),
+		("WMA/PRO", "WMA Pro"),
+		("MPEG", "MPEG1 Layer II"),
+		("MPEG1 Layer II AAC", "AAC"),
+		("MPEG1 Layer IIAAC", "AAC"),
+		("MPEG1 Layer IIMP3", "MP3"),
+	)
+
+	for orig, repl in REPLACEMENTS:
 		description = description.replace(orig, repl)
 	return description
 


### PR DESCRIPTION
Moves global constant to local and names it in uppercase according to PEP8.
The constant is used only in the StdAudioDesc function, why define it globally?
Removes the _assignAcedits function and constant assignment using it, which unnecessarily complicates the code.

I think we need to discuss whether all these substitutions are necessary, but no one can give examples how they are used.