### PR TITLE
[skin/menu] patches

### DIFF
--- a/doc/MENU
+++ b/doc/MENU
@@ -1,0 +1,93 @@
+Adding a menu image that identifies the current menu screen based on menuID
+===========================================================================
+
+In skin.xml add the list of images to the "menus" section based on menuID.
+
+	Syntax:
+	
+		<menus>
+			<menu key="default" image="path/myNameForDefault.png" />
+			<menu key="<menuID>" image="path/myNameFor<menuID>.png" />
+		</menus>
+	
+	This element is optional but if defined allows a skin designer to associate 
+	a graphical image with any "Screens/Menu.py" based screen.  The "menus" 
+	tag element has no attributes and contains a list of "menu" tag elements.
+	
+	Each "menu" tag element must contain two attributes:
+	
+		key	This attribute is the value of the "key" attribute from a 
+			menu.xml file.  If the keys match then this entry defines 
+			a graphical image that is to be used when the nominated 
+			Setup screen is displayed.
+	
+		image	This attribute is the pathname of the graphical image that 
+			is to be associated with the Menu screen identified by the 
+			"key" attribute.
+	
+	There is a special "key" attribute with the name "default".  This entry, 
+	if defined, assigns a default graphical image to be used in ALL 
+	"Screens/Menu.py" screens that do not have a specifically assigned 
+	image.
+
+
+In skin.xml add the widget to MainMenu and Menu screens:
+	<screen name="MainMenu" ... >
+		...
+		<widget name="menuimage" position="0,50" size="200,400" alphatest="blend" conditional="menuimage" transparent="1" />
+		...
+	</screen>
+	<screen name="Menu" ... >
+		...
+		<widget name="menuimage" position="0,50" size="200,400" alphatest="blend" conditional="menuimage" transparent="1" />
+		...
+	</screen>
+
+
+Adding icons to the menu list entries
+=====================================
+
+In skin.xml add the icon size parameter (width x height):
+	<parameter name="MenuIconSize" value="48,48" />
+
+
+In skin.xml add the list of icons to the "menuicons" section based on "key" from menu.xml.
+
+	Syntax:
+	
+		<menuicons>
+			<menuicon key="default" image="path/myNameForDefault.png" />
+			<menuicon key="scan" image="path/myNameForScan.png" />
+		</menuicons>
+	
+	This element is optional but if defined allows a skin designer to associate 
+	a graphical icons with menu list items.  The "menuicons" tag element has no 
+	attributes and contains a list of "menuicon" tag elements.
+	
+	Each "menuicon" tag element must contain two attributes:
+	
+		key	This attribute is the value of the "key" attribute from a 
+			menu.xml file. If the keys match then this entry defines 
+			a graphical icon that is to be used in the list item 
+			associated with that key.
+	
+		image	This attribute is the pathname of the graphical image that 
+			is to be associated with the Menu item identified by the 
+			"key" attribute.
+	
+	There is a special "key" attribute with the name "default".  This entry, 
+	if defined, assigns a default graphical icon to be used in any list item
+	that do not have a specifically assigned icon.
+
+
+In skin.xml the skin widget for the Menu screen with icons looks like this:
+
+<widget source="menu" render="Listbox" position="72,274" size="564,545" scrollbarMode="showOnDemand" enableWrapAround="1" transparent="1">
+	<convert type="TemplatedMultiContent">
+		{"template": [ MultiContentEntryText(pos = (97,5), size = (435,45), flags = RT_HALIGN_LEFT|RT_VALIGN_CENTER, text = 0),
+					   MultiContentEntryPixmapAlphaBlend(pos = (32,5), size = (48,48), png = 5)],
+		"fonts": [gFont("Regular",34)],
+		"itemHeight": 60
+		}
+	</convert>
+</widget>

--- a/lib/python/Components/ChoiceList.py
+++ b/lib/python/Components/ChoiceList.py
@@ -10,7 +10,7 @@ def ChoiceEntryComponent(key=None, text=["--"]):
 	res = [text]
 	if text[0] == "--":
 		# Get are we want graphical separator (solid line with color) or dashed line
-		isUseGraphicalSeparator = parameters.get("UseGraphicalSeparator", 0)
+		isUseGraphicalSeparator = parameters.get("ChoicelistUseGraphicalSeparator", 0)
 		x, y, w, h = parameters.get("ChoicelistDash", applySkinFactor(0, 0, 800, 25))
 		if isUseGraphicalSeparator:
 			bk_color = parameters.get("ChoicelistSeparatorColor", "0x00555556")

--- a/lib/python/Screens/Menu.py
+++ b/lib/python/Screens/Menu.py
@@ -374,8 +374,8 @@ class Menu(Screen, ProtectedScreen):
 			if not self.sub_menu_sort.getConfigValue(entry[2], "hidden"):
 				self.list.append(entry)
 		if not self.list:
-			self.list.append(('', None, 'dummy', '10', 10))
-		self.list.sort(key=lambda listweight: int(listweight[4]))
+			self.list.append(('', None, 'dummy', '10', None, None, 10))
+		self.list.sort(key=lambda listweight: int(listweight[-1]))
 
 
 class MenuSort(Menu):
@@ -415,8 +415,8 @@ class MenuSort(Menu):
 	def hide_show_entries(self):
 		self.list = list(self.full_list)
 		if not self.list:
-			self.list.append(('', None, 'dummy', '10', 10))
-		self.list.sort(key=lambda listweight: int(listweight[4]))
+			self.list.append(('', None, 'dummy', '10', None, None, 10))
+		self.list.sort(key=lambda listweight: int(listweight[-1]))
 
 	def selectionChanged(self):
 		selection = self["menu"].getCurrent() and len(self["menu"].getCurrent()) > 2 and self["menu"].getCurrent()[2] or ""

--- a/lib/python/Screens/Menu.py
+++ b/lib/python/Screens/Menu.py
@@ -3,6 +3,7 @@ from Screens.MessageBox import MessageBox
 from Screens.ParentalControlSetup import ProtectedScreen
 from Components.Sources.List import List
 from Components.ActionMap import NumberActionMap, ActionMap
+from Components.Pixmap import Pixmap
 from Components.Sources.StaticText import StaticText
 from Components.config import configfile
 from Components.PluginComponent import plugins
@@ -219,16 +220,32 @@ class Menu(Screen, ProtectedScreen):
 		title = self.__class__.__name__ == "MenuSort" and _("Menusort (%s)") % title or title
 		self["title"] = StaticText(title)
 		self.setTitle(title)
+		self.loadMenuImage()
 
 		self.number = 0
 		self.nextNumberTimer = eTimer()
 		self.nextNumberTimer.callback.append(self.okbuttonClick)
 		if len(self.list) == 1:
 			self.onExecBegin.append(self.__onExecBegin)
+		if self.layoutFinished not in self.onLayoutFinish:
+			self.onLayoutFinish.append(self.layoutFinished)
 
 	def __onExecBegin(self):
 		self.onExecBegin.remove(self.__onExecBegin)
 		self.okbuttonClick()
+
+	def layoutFinished(self):
+		if self.menuImage:
+			self["menuimage"].instance.setPixmap(self.menuImage)
+
+	def loadMenuImage(self):
+		self.menuImage = None
+		if menus and self.menuID:
+			menuImage = menus.get(self.menuID, menus.get("default", ""))
+			if menuImage:
+				self.menuImage = LoadPixmap(resolveFilename(SCOPE_GUISKIN, menuImage))
+				if self.menuImage:
+					self["menuimage"] = Pixmap()
 
 	def showHelp(self):
 		if config.usage.menu_show_numbers.value not in ("menu&plugins", "menu"):

--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -851,9 +851,9 @@ def loadSingleSkinData(desktop, screenID, domSkin, pathSkin, scope=SCOPE_CURRENT
 			except Exception as err:
 				raise SkinError("Bad parameter: '%s'" % str(err))
 	for tag in domSkin.findall("menus"):
-		for setup in tag.findall("menu"):
-			key = setup.attrib.get("key")
-			image = setup.attrib.get("image")
+		for menu in tag.findall("menu"):
+			key = menu.attrib.get("key")
+			image = menu.attrib.get("image")
 			if key and image:
 				menus[key] = image
 				# print("[Skin] DEBUG: Menu key='%s', image='%s'." % (key, image))

--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -37,6 +37,7 @@ fonts = {  # Dictionary of predefined and skin defined font aliases.
 	"Body": BodyFont
 }
 menus = {}  # Dictionary of images associated with menu entries.
+menuicons = {}  # Dictionary of icons associated with menu items.
 parameters = {}  # Dictionary of skin parameters used to modify code behavior.
 setups = {}  # Dictionary of images associated with setup menus.
 switchPixmap = {}  # Dictionary of switch images.
@@ -193,6 +194,7 @@ def reloadSkins():
 		"Body": BodyFont
 	}
 	menus.clear()
+	menuicons.clear()
 	parameters.clear()
 	setups.clear()
 	switchPixmap.clear()
@@ -859,6 +861,15 @@ def loadSingleSkinData(desktop, screenID, domSkin, pathSkin, scope=SCOPE_CURRENT
 				# print("[Skin] DEBUG: Menu key='%s', image='%s'." % (key, image))
 			else:
 				raise SkinError("Tag menu needs key and image, got key='%s' and image='%s'" % (key, image))
+	for tag in domSkin.findall("menuicons"):
+		for menuicon in tag.findall("menuicon"):
+			key = menuicon.attrib.get("key")
+			image = menuicon.attrib.get("image")
+			if key and image:
+				menuicons[key] = image
+				# print("[Skin] DEBUG: Menu key='%s', image='%s'." % (key, image))
+			else:
+				raise SkinError("Tag 'menuicon' needs key and image, got key='%s' and image='%s'" % (key, image))
 	for tag in domSkin.findall("setups"):
 		for setup in tag.findall("setup"):
 			key = setup.attrib.get("key")


### PR DESCRIPTION
Fix some crash in previous commit.

Fix skin.

Add menuitems to skin.py.

Use latest version of menuitems in Menu.py for compatibility with other images that already use this system.

Menu.py, add missing handling for menu graphic. This has been implemented in skin.py for 5 years but is missing from menu.

Add a doc/MENU to explain how everything works when adding these feature to a skin.