### PR TITLE
Restore nimmanager import in Menu

### DIFF
--- a/lib/python/Screens/Menu.py
+++ b/lib/python/Screens/Menu.py
@@ -19,6 +19,8 @@ from enigma import eTimer
 import xml.etree.ElementTree
 
 from Screens.Setup import Setup, getSetupTitle
+from Components.NimManager import nimmanager  # nimmanager is used in eval(conditional), do not remove this import
+
 
 def MenuEntryPixmap(key, png_cache):
 	if not menuicons:


### PR DESCRIPTION
Removed in https://github.com/OpenPLi/enigma2/commit/751df0b550a1412b4de769ae3dab8640a8cfbc94
nimmanager is used in eval(conditional): https://github.com/OpenPLi/enigma2/commit/cc5162f4cd80e2c23a7379785ea0b02ee28d52b3