### PR TITLE
[MessageBox] fix skinName

### DIFF
--- a/lib/python/Screens/MessageBox.py
+++ b/lib/python/Screens/MessageBox.py
@@ -17,8 +17,9 @@ class MessageBox(Screen):
 	def __init__(self, session, text, type=TYPE_YESNO, timeout=-1, close_on_any_key=False, default=True, enable_input=True, msgBoxID=None, picon=None, simple=False, list=[], timeout_default=None, title=None):
 		self.type = type
 		Screen.__init__(self, session)
+		self.skinName = ["MessageBox"]
 		if simple:
-			self.skinName = "MessageBoxSimple"
+			self.skinName = ["MessageBoxSimple"] + self.skinName
 
 		self.msgBoxID = msgBoxID
 


### PR DESCRIPTION
When using "MessageBoxSimple" as the skin name "MessageBox" should be retained as the fallback.

This is the same logic as in other modules, e.g. ChoiceBox.