### PR TITLE
Added possibility to make formatted string in converters

### DIFF
--- a/lib/python/Components/Converter/Converter.py
+++ b/lib/python/Components/Converter/Converter.py
@@ -11,3 +11,10 @@ class Converter(Element):
 
 	def handleCommand(self, cmd):
 		self.source.handleCommand(cmd)
+
+	def appendToStringWithSeparator(self, str, part):
+		if str == "":
+			str = part
+		else:
+			str = str + "  " + self.separator + "  " + part
+		return str

--- a/lib/python/Components/Converter/EventName.py
+++ b/lib/python/Components/Converter/EventName.py
@@ -3,6 +3,7 @@ from Components.Element import cached
 from Components.Converter.genre import getGenreStringSub
 from Components.config import config
 from Components.UsageConfig import dropEPGNewLines, replaceEPGSeparator
+from time import time, localtime
 
 
 class EventName(Converter):
@@ -20,37 +21,43 @@ class EventName(Converter):
 	PDCTIME = 11
 	PDCTIMESHORT = 12
 	ISRUNNINGSTATUS = 13
+	FORMAT_STRING = 14
 
 	def __init__(self, type):
 		Converter.__init__(self, type)
-		if type == "Description":
-			self.type = self.SHORT_DESCRIPTION
-		elif type == "ExtendedDescription":
-			self.type = self.EXTENDED_DESCRIPTION
-		elif type == "FullDescription":
-			self.type = self.FULL_DESCRIPTION
-		elif type == "ID":
-			self.type = self.ID
-		elif type == "NameNow":
-			self.type = self.NAME_NOW
-		elif type == "NameNext":
-			self.type = self.NAME_NEXT
-		elif type == "Genre":
-			self.type = self.GENRE
-		elif type == "Rating":
-			self.type = self.RATING
-		elif type == "SmallRating":
-			self.type = self.SRATING
-		elif type == "Pdc":
-			self.type = self.PDC
-		elif type == "PdcTime":
-			self.type = self.PDCTIME
-		elif type == "PdcTimeShort":
-			self.type = self.PDCTIMESHORT
-		elif type == "IsRunningStatus":
-			self.type = self.ISRUNNINGSTATUS
+		self.parts = type.split(",")
+		if len(self.parts) > 1:
+			self.type = self.FORMAT_STRING
+			self.separator = self.parts[0]
 		else:
-			self.type = self.NAME
+			if type == "Description":
+				self.type = self.SHORT_DESCRIPTION
+			elif type == "ExtendedDescription":
+				self.type = self.EXTENDED_DESCRIPTION
+			elif type == "FullDescription":
+				self.type = self.FULL_DESCRIPTION
+			elif type == "ID":
+				self.type = self.ID
+			elif type == "NameNow":
+				self.type = self.NAME_NOW
+			elif type == "NameNext":
+				self.type = self.NAME_NEXT
+			elif type == "Genre":
+				self.type = self.GENRE
+			elif type == "Rating":
+				self.type = self.RATING
+			elif type == "SmallRating":
+				self.type = self.SRATING
+			elif type == "Pdc":
+				self.type = self.PDC
+			elif type == "PdcTime":
+				self.type = self.PDCTIME
+			elif type == "PdcTimeShort":
+				self.type = self.PDCTIMESHORT
+			elif type == "IsRunningStatus":
+				self.type = self.ISRUNNINGSTATUS
+			else:
+				self.type = self.NAME
 
 	@cached
 	def getBoolean(self):
@@ -152,5 +159,21 @@ class EventName(Converter):
 					return _("reserved for future use")
 				return _("undefined")
 			return ""
+		elif self.type == self.FORMAT_STRING:
+			begin = event.getBeginTime()
+			end = begin + event.getDuration()
+			now = int(time())
+			t_start = localtime(begin)
+			t_end = localtime(end)
+			if begin <= now <= end:
+				duration = end - now
+				duration_str = "+%d min" % (duration / 60)
+			else:
+				duration = event.getDuration()
+				duration_str = "%d min" % (duration / 60)
+			start_time_str = "%2d:%02d" % (t_start.tm_hour, t_start.tm_min)
+			end_time_str = "%2d:%02d" % (t_end.tm_hour, t_end.tm_min) 
+			res_str = "%s - %s  %s  %s" % (start_time_str, end_time_str, self.separator, duration_str)
+			return res_str
 
 	text = property(getText)

--- a/lib/python/Components/Converter/ServiceName.py
+++ b/lib/python/Components/Converter/ServiceName.py
@@ -3,7 +3,6 @@ from Components.Converter.Converter import Converter
 from enigma import iServiceInformation, iPlayableService, iPlayableServicePtr, eServiceReference
 from ServiceReference import resolveAlternate
 from Components.Element import cached
-from Tools.General import getServiceNum
 
 
 class ServiceName(Converter):
@@ -89,14 +88,14 @@ class ServiceName(Converter):
 		return name.replace('\xc2\x86', '').replace('\xc2\x87', '').replace('_', ' ')
 	
 	def getNumber(self, ref, info):
-		from Screens.InfoBar import InfoBar
-		channelSelectionServicelist = InfoBar.instance and InfoBar.instance.servicelist
-		channelnum = ''
-		ref = ref or eServiceReference(info.getInfoString(iServiceInformation.sServiceref))
-		if channelSelectionServicelist and channelSelectionServicelist.inBouquet():
-			myRoot = channelSelectionServicelist.getRoot()
-			channelnum = getServiceNum(ref, myRoot)
-		return channelnum
+		if not ref:
+			ref = eServiceReference(info.getInfoString(iServiceInformation.sServiceref))
+		num = ref and ref.getChannelNum() or None
+		if num is None:
+			num = '---'
+		else:
+			num = str(num)
+		return num
 	
 	def getProvider(self, ref, info):
 		if ref:

--- a/lib/python/Components/Converter/ServiceName.py
+++ b/lib/python/Components/Converter/ServiceName.py
@@ -3,6 +3,7 @@ from Components.Converter.Converter import Converter
 from enigma import iServiceInformation, iPlayableService, iPlayableServicePtr, eServiceReference
 from ServiceReference import resolveAlternate
 from Components.Element import cached
+from Tools.General import getServiceNum
 
 
 class ServiceName(Converter):
@@ -11,20 +12,26 @@ class ServiceName(Converter):
 	REFERENCE = 2
 	EDITREFERENCE = 3
 	NUMBER = 4
+	FORMAT_STRING = 5
 
 	def __init__(self, type):
 		Converter.__init__(self, type)
 
-		if type == "Provider":
-			self.type = self.PROVIDER
-		elif type == "Reference":
-			self.type = self.REFERENCE
-		elif type == "EditReference":
-			self.type = self.EDITREFERENCE
-		elif type == "Number":
-			self.type = self.NUMBER
+		self.parts = type.split(",")
+		if len(self.parts) > 1:
+			self.type = self.FORMAT_STRING
+			self.separator = self.parts[0]
 		else:
-			self.type = self.NAME
+			if type == "Provider":
+				self.type = self.PROVIDER
+			elif type == "Reference":
+				self.type = self.REFERENCE
+			elif type == "EditReference":
+				self.type = self.EDITREFERENCE
+			elif type == "Number":
+				self.type = self.NUMBER
+			else:
+				self.type = self.NAME
 
 	@cached
 	def getText(self):
@@ -38,12 +45,9 @@ class ServiceName(Converter):
 		if not info:
 			return ""
 		if self.type == self.NAME:
-			name = ref and info.getName(ref)
-			if name is None:
-				name = info.getName()
-			return name.replace('\xc2\x86', '').replace('\xc2\x87', '').replace('_', ' ')
+			return self.getName(ref, info)
 		elif self.type == self.PROVIDER:
-			return info.getInfoString(iServiceInformation.sProvider)
+			return self.getProvider(ref, info)
 		elif self.type == self.REFERENCE or self.type == self.EDITREFERENCE and hasattr(self.source, "editmode") and self.source.editmode:
 			if not ref:
 				return info.getInfoString(iServiceInformation.sServiceref)
@@ -52,17 +56,66 @@ class ServiceName(Converter):
 				ref = nref
 			return ref.toString()
 		elif self.type == self.NUMBER:
-			if not ref:
-				ref = eServiceReference(info.getInfoString(iServiceInformation.sServiceref))
-			num = ref and ref.getChannelNum() or None
-			if num is None:
-				num = '---'
-			else:
-				num = str(num)
-			return num
+			return self.getNumber(ref, info)
+		elif self.type == self.FORMAT_STRING:
+			name = self.getName(ref, info)
+			num = self.getNumber(ref, info)
+			provider = self.getProvider(ref, info)
+			orbpos = self.getOrbitalPos(ref, info)
+			res_str = ""
+			for x in self.parts[1:]:
+				if x == "NUMBER" and num:
+					res_str = self.appendToStringWithSeparator(res_str, num)
+				if x == "NAME" and name:
+					res_str = self.appendToStringWithSeparator(res_str, name)
+				if x == "ORBPOS" and orbpos:
+					res_str = self.appendToStringWithSeparator(res_str, orbpos)
+				if x == "PROVIDER" and provider is not None and provider:
+					res_str = self.appendToStringWithSeparator(res_str, provider)
+			return res_str
+
+
 
 	text = property(getText)
 
 	def changed(self, what):
 		if what[0] != self.CHANGED_SPECIFIC or what[1] in (iPlayableService.evStart,):
 			Converter.changed(self, what)
+
+	def getName(self, ref, info):
+		name = ref and info.getName(ref)
+		if name is None:
+			name = info.getName()
+		return name.replace('\xc2\x86', '').replace('\xc2\x87', '').replace('_', ' ')
+	
+	def getNumber(self, ref, info):
+		from Screens.InfoBar import InfoBar
+		channelSelectionServicelist = InfoBar.instance and InfoBar.instance.servicelist
+		channelnum = ''
+		ref = ref or eServiceReference(info.getInfoString(iServiceInformation.sServiceref))
+		if channelSelectionServicelist and channelSelectionServicelist.inBouquet():
+			myRoot = channelSelectionServicelist.getRoot()
+			channelnum = getServiceNum(ref, myRoot)
+		return channelnum
+	
+	def getProvider(self, ref, info):
+		if ref:
+			return info.getInfoString(ref, iServiceInformation.sProvider)
+		return info.getInfoString(iServiceInformation.sProvider)
+	
+	def getOrbitalPos(self, ref, info):
+		orbitalpos = ""
+		if ref:
+			tp_data = info.getInfoObject(ref, iServiceInformation.sTransponderData)
+		else:
+			tp_data = info.getInfoObject(iServiceInformation.sTransponderData)
+		if tp_data is not None:
+			try:
+				position = tp_data["orbital_position"]
+				if position > 1800: # west
+					orbitalpos = "%.1f " %(float(3600 - position)/10) + _("W")
+				else:
+					orbitalpos = "%.1f " %(float(position)/10) + _("E")
+			except:
+				pass
+		return orbitalpos


### PR DESCRIPTION
Added possibility to make formatted string in converters.

For example for ServiceName we can define that:

`<convert type="ServiceName">•,NUMBER,NAME,ORBPOS,PROVIDER</convert>`

which will produce the service name like that

1 • Channel One • 13E • Provider

So the first parameter of the definition is separator character and the rest is what we want to include in result string.

For now the possible parameters are limited, but that can be extended.