### PR TITLE
ntp time -change logic

### DIFF
--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -772,7 +772,7 @@ def InitUsageConfig():
 	config.ntp = ConfigSubsection()
 
 	def timesyncChanged(configElement):
-		if configElement.value == "dvb" or not GetIPsFromNetworkInterfaces():
+		if configElement.value == "dvb" or (configElement.value == "auto" and not GetIPsFromNetworkInterfaces()):
 			eDVBLocalTimeHandler.getInstance().setUseDVBTime(True)
 			eEPGCache.getInstance().timeUpdated()
 			if os.path.isfile('/var/spool/cron/crontabs/root'):

--- a/lib/python/StartEnigma.py
+++ b/lib/python/StartEnigma.py
@@ -92,7 +92,7 @@ def useTransponderTimeChanged(configElement):
 	enigma.eDVBLocalTimeHandler.getInstance().setUseDVBTime(configElement.value)
 
 
-config.misc.useTransponderTime.addNotifier(useTransponderTimeChanged, initial_call=False)
+config.misc.useTransponderTime.addNotifier(useTransponderTimeChanged)
 
 profile("Twisted")
 try:

--- a/lib/python/StartEnigma.py
+++ b/lib/python/StartEnigma.py
@@ -92,7 +92,7 @@ def useTransponderTimeChanged(configElement):
 	enigma.eDVBLocalTimeHandler.getInstance().setUseDVBTime(configElement.value)
 
 
-config.misc.useTransponderTime.addNotifier(useTransponderTimeChanged)
+config.misc.useTransponderTime.addNotifier(useTransponderTimeChanged, initial_call=False)
 
 profile("Twisted")
 try:


### PR DESCRIPTION
-when config.ntp.timesync.value is 'ntp' always use only ntp time
-config.misc.useTransponderTime. need call when initial( initial_call=False) because
timesyncChanged(when config.ntp.timesync) always set eDVBLocalTimeHandler.getInstance().setUseDVBTime(value)