### PR TITLE
Fix saving the set range in ProgressBar

### DIFF
--- a/lib/python/Components/ProgressBar.py
+++ b/lib/python/Components/ProgressBar.py
@@ -19,9 +19,9 @@ class ProgressBar(VariableValue, GUIComponent):
 		instance.setRange(self.__start, self.__end)
 
 	def setRange(self, range):
-		(__start, __end) = range
 		if self.instance is not None:
-			self.instance.setRange(__start, __end)
+			self.__start, self.__end = range
+			self.instance.setRange(self.__start, self.__end)
 
 	def getRange(self):
 		return (self.__start, self.__end)


### PR DESCRIPTION
When setting the progress bar range, it is set in eSlider but not stored in instance variables.
It does not allow to get the correct range using the ProgressBar method getRange or property range.
Therefore, when setting the range, also stores it in instance variables.