### PR TITLE
[CI] Operator profile

### DIFF
--- a/lib/dvb_ci/dvbci_operatorprofile.cpp
+++ b/lib/dvb_ci/dvbci_operatorprofile.cpp
@@ -20,7 +20,7 @@ int eDVBCIOperatorProfileSession::receivedAPDU(const unsigned char *tag,const vo
 		{
 		case 0x01:
 			eDebug("operator_status");
-			state=stateStarted;
+			state=stateStatus;
 			break;
 		case 0x03:
 			eDebug("operator_nit");
@@ -46,7 +46,7 @@ int eDVBCIOperatorProfileSession::doAction()
 {
 	switch (state)
 	{
-	case stateStarted:
+	case stateStatusRequest:
 	{
 		const unsigned char tag[3]={0x9F, 0x9C, 0x00};
 		sendAPDU(tag);

--- a/lib/dvb_ci/dvbci_operatorprofile.h
+++ b/lib/dvb_ci/dvbci_operatorprofile.h
@@ -6,7 +6,9 @@
 class eDVBCIOperatorProfileSession: public eDVBCISession
 {
 	enum {
-		stateFinal=statePrivate
+		stateStatusRequest=statePrivate,
+		stateStatus,
+		stateFinal
 	};
 
 	int receivedAPDU(const unsigned char *tag, const void *data, int len);


### PR DESCRIPTION
don't send status request message right after session start as some modules
open operator session, but don't seem to be able to handle operator messages
as they just stop working after receiving the message(CANAL+ module).

-thanks @betacentauri