### PR TITLE
[Picon.py] Expand snp name trims

### DIFF
--- a/lib/python/Components/Renderer/Picon.py
+++ b/lib/python/Components/Renderer/Picon.py
@@ -98,7 +98,9 @@ def getPiconName(serviceRef):
 		name = re.sub('[^a-z0-9]', '', name.replace('&', 'and').replace('+', 'plus').replace('*', 'star').lower())
 		if name:
 			pngname = findPicon(name)
-			if not pngname and len(name) > 2 and name.endswith('hd'):
+			if not pngname and len(name) > 3 and (name.endswith("fhd") or name.endswith("uhd")):
+				pngname = findPicon(name[:-3])
+			if not pngname and len(name) > 2 and (name.endswith("hd") or name.endswith("sd") or name.endswith("4k")):
 				pngname = findPicon(name[:-2])
 			if not pngname and len(name) > 6:
 				series = re.sub(r's[0-9]*e[0-9]*$', '', name)


### PR DESCRIPTION
Fallback trimming of `sd`, `4k`, `uhd` and `fhd` from SNPicon names

As suggested by @Kiddac
Issue https://github.com/OpenPLi/enigma2/issues/3830