### PR TITLE
Stream Relay fixed to present information like normal DVB service

### DIFF
--- a/lib/dvb/db.cpp
+++ b/lib/dvb/db.cpp
@@ -222,14 +222,14 @@ bool eDVBService::isCrypted()
 
 int eDVBService::isPlayable(const eServiceReference &ref, const eServiceReference &ignore, bool simulate)
 {
-	ServiceReferenceDVB newRef;
+	ServiceReferenceDVB sRelayOrigSref;
 	ePtr<iPlayableService> refCur;
 	eNavigation::getInstance()->getCurrentService(refCur);
 	ePtr<iServiceInformation> tmp_info;
 	refCur->info(tmp_info);
 	std::string ref_s = tmp_info->getInfoString(iServiceInformation::sServiceref);
 	eServiceReferenceDVB currentlyPlaying = eServiceReferenceDVB(ref_s);
-	bool res = currentlyPlaying.getSROriginal(newRef);
+	bool res = currentlyPlaying.getSROriginal(sRelayOrigSref);
 
 	ePtr<eDVBResourceManager> res_mgr;
 	bool remote_fallback_enabled = eConfigManager::getConfigBoolValue("config.usage.remote_fallback_enabled", false);
@@ -245,7 +245,7 @@ int eDVBService::isPlayable(const eServiceReference &ref, const eServiceReferenc
 		((const eServiceReferenceDVB&)ignore).getChannelID(chid_ignore);
 
 		if (res) {
-			newRef.getChannelID(chid_ignore_sr);
+			sRelayOrigSref.getChannelID(chid_ignore_sr);
 		} else {
 			chid_ignore_sr = eDVBChannelID();
 		}

--- a/lib/dvb/db.cpp
+++ b/lib/dvb/db.cpp
@@ -222,7 +222,7 @@ bool eDVBService::isCrypted()
 
 int eDVBService::isPlayable(const eServiceReference &ref, const eServiceReference &ignore, bool simulate)
 {
-	ServiceReferenceDVB sRelayOrigSref;
+	eServiceReferenceDVB sRelayOrigSref;
 	ePtr<iPlayableService> refCur;
 	eNavigation::getInstance()->getCurrentService(refCur);
 	ePtr<iServiceInformation> tmp_info;

--- a/lib/dvb/db.cpp
+++ b/lib/dvb/db.cpp
@@ -222,23 +222,14 @@ bool eDVBService::isCrypted()
 
 int eDVBService::isPlayable(const eServiceReference &ref, const eServiceReference &ignore, bool simulate)
 {
-	std::string sr_url = eConfigManager::getConfigValue("config.misc.softcam_streamrelay_url");
-	sr_url = replace_all(replace_all(replace_all(sr_url, "[", ""), "]", ""), ", ", ".");
-	std::string sr_port = eConfigManager::getConfigValue("config.misc.softcam_streamrelay_port");
-	eServiceReferenceDVB newRef;
+	ServiceReferenceDVB newRef;
 	ePtr<iPlayableService> refCur;
 	eNavigation::getInstance()->getCurrentService(refCur);
 	ePtr<iServiceInformation> tmp_info;
 	refCur->info(tmp_info);
 	std::string ref_s = tmp_info->getInfoString(iServiceInformation::sServiceref);
-	if (ref_s.find(sr_url + "%3a" + sr_port) != std::string::npos) {
-		std::vector<std::string> s_split = split(ref_s, ":");
-		std::string url_sr = s_split[s_split.size() - 2];
-		std::vector<std::string> sr_split = split(url_sr, "/");
-		std::string ref_orig = sr_split.back();
-		ref_orig = replace_all(ref_orig, "%3a", ":");
-		newRef = eServiceReferenceDVB(ref_orig);
-	}
+	eServiceReferenceDVB currentlyPlaying = eServiceReferenceDVB(ref_s);
+	bool res = currentlyPlaying.getSROriginal(newRef);
 
 	ePtr<eDVBResourceManager> res_mgr;
 	bool remote_fallback_enabled = eConfigManager::getConfigBoolValue("config.usage.remote_fallback_enabled", false);
@@ -253,7 +244,7 @@ int eDVBService::isPlayable(const eServiceReference &ref, const eServiceReferenc
 		((const eServiceReferenceDVB&)ref).getChannelID(chid);
 		((const eServiceReferenceDVB&)ignore).getChannelID(chid_ignore);
 
-		if (newRef) {
+		if (res) {
 			newRef.getChannelID(chid_ignore_sr);
 		} else {
 			chid_ignore_sr = eDVBChannelID();

--- a/lib/dvb/dvb.h
+++ b/lib/dvb/dvb.h
@@ -213,7 +213,7 @@ public:
 	};
 
 	RESULT connectChannelAdded(const sigc::slot<void(eDVBChannel*)> &channelAdded, ePtr<eConnection> &connection);
-	int canAllocateChannel(const eDVBChannelID &channelid, const eDVBChannelID &ignore, int &system, bool simulate=false);
+	int canAllocateChannel(const eDVBChannelID &channelid, const eDVBChannelID &ignore, const eDVBChannelID& ignoresr, int &system, bool simulate=false);
 
 		/* allocate channel... */
 	RESULT allocateChannel(const eDVBChannelID &channelid, eUsePtr<iDVBChannel> &channel, bool simulate=false);

--- a/lib/dvb/pmt.cpp
+++ b/lib/dvb/pmt.cpp
@@ -969,22 +969,14 @@ int eDVBServicePMTHandler::tuneExt(eServiceReferenceDVB &ref, ePtr<iTsSource> &s
 	if (!simulate)
 	{
 		// If is stream relay service then allocate the real channel so to provide correct frontend info
-		std::string s_ref = ref.toString();
 		eDVBChannelID chid;
-		std::string sr_url = eConfigManager::getConfigValue("config.misc.softcam_streamrelay_url");
-		sr_url = replace_all(replace_all(replace_all(sr_url, "[", ""), "]", ""), ", ", ".");
-		std::string sr_port = eConfigManager::getConfigValue("config.misc.softcam_streamrelay_port");
-		if (s_ref.find(sr_url + "%3a" + sr_port) != std::string::npos) {
-			std::vector<std::string> s_split = split(s_ref, ":");
-			std::string url_sr = s_split[s_split.size() - 2];
-			std::vector<std::string> sr_split = split(url_sr, "/");
-			std::string ref_orig = sr_split.back();
-			ref_orig = replace_all(ref_orig, "%3a", ":");
-			eServiceReferenceDVB newRef = eServiceReferenceDVB(ref_orig);
-			newRef.getChannelID(chid);
-			// Allocate the channel in different ptr so to not mess up original pvr channel info
+		eServiceReferenceDVB sRelayOrigSref;
+		bool res = ref.getSROriginal(sRelayOrigSref);
+
+		if (res) {
+			sRelayOrigSref.getChannelID(chid);
 			res = m_resourceManager->allocateChannel(chid, m_sr_channel, simulate);
-		} 
+		}
 
 
 		if (m_sr_channel) {

--- a/lib/dvb/pmt.cpp
+++ b/lib/dvb/pmt.cpp
@@ -971,9 +971,9 @@ int eDVBServicePMTHandler::tuneExt(eServiceReferenceDVB &ref, ePtr<iTsSource> &s
 		// If is stream relay service then allocate the real channel so to provide correct frontend info
 		eDVBChannelID chid;
 		eServiceReferenceDVB sRelayOrigSref;
-		bool res = ref.getSROriginal(sRelayOrigSref);
+		bool isStreamRelay = ref.getSROriginal(sRelayOrigSref);
 
-		if (res) {
+		if (isStreamRelay) {
 			sRelayOrigSref.getChannelID(chid);
 			res = m_resourceManager->allocateChannel(chid, m_sr_channel, simulate);
 		}

--- a/lib/dvb/pmt.cpp
+++ b/lib/dvb/pmt.cpp
@@ -964,6 +964,23 @@ int eDVBServicePMTHandler::tuneExt(eServiceReferenceDVB &ref, ePtr<iTsSource> &s
 
 	if (!simulate)
 	{
+		// If is stream relay service then allocate the real channel so to provide correct frontend info
+		std::string s_ref = ref.toString();
+		eDVBChannelID chid;
+		std::string sr_url = eConfigManager::getConfigValue("config.misc.softcam_streamrelay_url");
+		sr_url = replace_all(replace_all(replace_all(sr_url, "[", ""), "]", ""), ", ", ".");
+		std::string sr_port = eConfigManager::getConfigValue("config.misc.softcam_streamrelay_port");
+		if (s_ref.find(sr_url + "%3a" + sr_port) != std::string::npos) {
+			std::vector<std::string> s_split = split(s_ref, ":");
+			std::string url_sr = s_split[s_split.size() - 2];
+			std::vector<std::string> sr_split = split(url_sr, "/");
+			std::string ref_orig = sr_split.back();
+			ref_orig = replace_all(ref_orig, "%3a", ":");
+			eServiceReferenceDVB newRef = eServiceReferenceDVB(ref_orig);
+			newRef.getChannelID(chid);
+			res = m_resourceManager->allocateChannel(chid, m_channel, simulate);
+		}
+
 		if (m_channel)
 		{
 			m_channel->connectStateChange(

--- a/lib/dvb/pmt.h
+++ b/lib/dvb/pmt.h
@@ -57,6 +57,7 @@ class eDVBServicePMTHandler: public eDVBPMTParser
 	eAUTable<eTable<OCSection> > m_OC;
 
 	eUsePtr<iDVBChannel> m_channel;
+	eUsePtr<iDVBChannel> m_sr_channel;
 	eUsePtr<iDVBPVRChannel> m_pvr_channel;
 	ePtr<eDVBResourceManager> m_resourceManager;
 	ePtr<iDVBDemux> m_demux, m_pvr_demux_tmp;

--- a/lib/python/Components/Converter/ServiceName.py
+++ b/lib/python/Components/Converter/ServiceName.py
@@ -81,7 +81,7 @@ class ServiceName(Converter):
 	text = property(getText)
 
 	def changed(self, what):
-		if what[0] != self.CHANGED_SPECIFIC or what[1] in (iPlayableService.evStart,):
+		if what[0] != self.CHANGED_SPECIFIC or what[1] in (iPlayableService.evStart, iPlayableService.evNewProgramInfo):
 			Converter.changed(self, what)
 
 	def getName(self, ref, info):

--- a/lib/python/Components/Converter/ServiceName.py
+++ b/lib/python/Components/Converter/ServiceName.py
@@ -102,8 +102,8 @@ class ServiceName(Converter):
 
 	def getProvider(self, ref, info, tp_data=None):
 		if ref:
-			return info.getInfoString(ref, iServiceInformation.sProvider) or tp_data and {282: "BSkyB", 192: "SKY", 130: "SkyItalia"}.get(tp_data["orbital_position"], "")
-		return info.getInfoString(iServiceInformation.sProvider) or tp_data and {282: "BSkyB", 192: "SKY", 130: "SkyItalia"}.get(tp_data["orbital_position"], "")
+			return info.getInfoString(ref, iServiceInformation.sProvider)
+		return info.getInfoString(iServiceInformation.sProvider)
 
 	def getOrbitalPos(self, ref, info):
 		orbitalpos = ""

--- a/lib/python/Components/Converter/ServiceName.py
+++ b/lib/python/Components/Converter/ServiceName.py
@@ -61,8 +61,8 @@ class ServiceName(Converter):
 			name = self.getName(ref, info)
 			numservice = self.source.serviceref
 			num = self.getNumber(numservice, info)
-			provider = self.getProvider(ref, info)
-			orbpos = self.getOrbitalPos(ref, info)
+			orbpos, tp_data = self.getOrbitalPos(service, info)
+			provider = self.getProvider(service, info, tp_data)
 			res_str = ""
 			for x in self.parts[1:]:
 				x = x.upper()
@@ -99,18 +99,25 @@ class ServiceName(Converter):
 		else:
 			num = str(num)
 		return num
-	
-	def getProvider(self, ref, info):
+
+	def getProvider(self, ref, info, tp_data=None):
 		if ref:
-			return info.getInfoString(ref, iServiceInformation.sProvider)
-		return info.getInfoString(iServiceInformation.sProvider)
-	
+			return info.getInfoString(ref, iServiceInformation.sProvider) or tp_data and {282: "BSkyB", 192: "SKY", 130: "SkyItalia"}.get(tp_data["orbital_position"], "")
+		return info.getInfoString(iServiceInformation.sProvider) or tp_data and {282: "BSkyB", 192: "SKY", 130: "SkyItalia"}.get(tp_data["orbital_position"], "")
+
 	def getOrbitalPos(self, ref, info):
 		orbitalpos = ""
 		if ref:
 			tp_data = info.getInfoObject(ref, iServiceInformation.sTransponderData)
 		else:
 			tp_data = info.getInfoObject(iServiceInformation.sTransponderData)
+
+		if not tp_data and not ref:
+			service = self.source.service
+			if service:
+				feraw = service.frontendInfo()
+				tp_data = feraw and feraw.getAll(config.usage.infobar_frontend_source.value == "settings")
+
 		if tp_data is not None:
 			try:
 				position = tp_data["orbital_position"]
@@ -120,4 +127,4 @@ class ServiceName(Converter):
 					orbitalpos = "%.1f " %(float(position)/10) + _("E")
 			except:
 				pass
-		return orbitalpos
+		return orbitalpos, tp_data

--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -53,6 +53,18 @@ FLAG_SERVICE_NEW_FOUND = 64
 FLAG_IS_DEDICATED_3D = 128
 FLAG_CENTER_DVB_SUBS = 2048 #define in lib/dvb/idvb.h as dxNewFound = 64 and dxIsDedicated3D = 128
 
+def getStreamRelayRef(sref):
+	try:
+		if "http" in sref:
+			sr_port = config.misc.softcam_streamrelay_port.value
+			sr_ip = ".".join("%d" % d for d in config.misc.softcam_streamrelay_url.value)
+			sr_url = f"http%3a//{sr_ip}%3a{sr_port}/"
+			if sr_url in sref:
+				return sref.split(sr_url)[1].split(":")[0].replace("%3a", ":")
+	except Exception:
+		pass
+	return sref
+
 
 class BouquetSelector(Screen):
 	def __init__(self, session, bouquets, selectedFunc, enableWrapAround=True):
@@ -1999,6 +2011,7 @@ class ChannelSelection(ChannelSelectionBase, ChannelSelectionEdit, ChannelSelect
 				info = service.info()
 				if info:
 					refstr = info.getInfoString(iServiceInformation.sServiceref)
+					refstr = getStreamRelayRef(refstr)
 					self.servicelist.setPlayableIgnoreService(eServiceReference(refstr))
 
 	def __evServiceEnd(self):

--- a/lib/service/listboxservice.cpp
+++ b/lib/service/listboxservice.cpp
@@ -811,7 +811,6 @@ void eListboxServiceContent::paint(gPainter &painter, eWindowStyle &style, const
 		if (!marked && isPlayable && service_info && m_is_playable_ignore.valid())
 		{
 			isplayable_value = service_info->isPlayable(*m_cursor, m_is_playable_ignore);
-
 			if (isplayable_value == 0) // service unavailable
 			{
 				if (m_color_set[serviceNotAvail])

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -102,7 +102,7 @@ int eStaticServiceDVBInformation::isPlayable(const eServiceReference &ref, const
 		int system;
 		((const eServiceReferenceDVB&)ref).getChannelID(chid);
 		((const eServiceReferenceDVB&)ignore).getChannelID(chid_ignore);
-		return res_mgr->canAllocateChannel(chid, chid_ignore, system);
+		return res_mgr->canAllocateChannel(chid, chid_ignore, eDVBChannelID(), system);
 	}
 	return 0;
 }
@@ -247,7 +247,7 @@ int eStaticServiceDVBBouquetInformation::isPlayable(const eServiceReference &ref
 			};
 			int system;
 			((const eServiceReferenceDVB&)*it).getChannelID(chid);
-			int tmp = res->canAllocateChannel(chid, chid_ignore, system, simulate);
+			int tmp = res->canAllocateChannel(chid, chid_ignore, eDVBChannelID(), system, simulate);
 			if (prio_order == 127) // ignore dvb-type priority, try all alternatives one-by-one
 			{
 				if (((tmp > 0) || (!it->path.empty())))
@@ -2376,7 +2376,8 @@ bool eDVBServiceBase::tryFallbackTuner(eServiceReferenceDVB &service, bool &is_s
 		return false;
 	service.getChannelID(chid); 						// this sets chid
 	eServiceReferenceDVB().getChannelID(chid_ignore);	// this sets chid_ignore
-	if(res_mgr->canAllocateChannel(chid, chid_ignore, system))	// this sets system
+
+	if(res_mgr->canAllocateChannel(chid, chid_ignore, eDVBChannelID(), system))	// this sets system
 		return false;
 
 	if (eConfigManager::getConfigBoolValue("config.usage.remote_fallback_alternative", false) && !(system == iDVBFrontend::feSatellite))

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -2034,8 +2034,20 @@ std::string eDVBServicePlay::getInfoString(int w)
 	switch (w)
 	{
 	case sProvider:
+	{
 		if (!m_dvb_service) return "";
-		return m_dvb_service->m_provider_name;
+		std::string prov = m_dvb_service->m_provider_name;
+		if (prov.empty()) {
+			eServiceReferenceDVB orig;
+			bool res = ((const eServiceReferenceDVB&)m_reference).getSROriginal(orig);
+			if (res) {
+				ePtr<eDVBService> serviceOrig;
+				eDVBDB::getInstance()->getService(orig, serviceOrig);
+				return serviceOrig->m_provider_name;
+			}
+		}
+		return prov;
+	}
 	case sServiceref:
 		return m_reference.toString();
 	case sHBBTVUrl:

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -2072,6 +2072,11 @@ std::string eDVBServicePlay::getInfoString(int w)
 
 ePtr<iDVBTransponderData> eDVBServicePlay::getTransponderData()
 {
+	eServiceReferenceDVB orig;
+	bool res = ((const eServiceReferenceDVB&)m_reference).getSROriginal(orig);
+	if (res) {
+		return eStaticServiceDVBInformation().getTransponderData(orig);
+	}
 	return eStaticServiceDVBInformation().getTransponderData(m_reference);
 }
 

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -2038,12 +2038,12 @@ std::string eDVBServicePlay::getInfoString(int w)
 		if (!m_dvb_service) return "";
 		std::string prov = m_dvb_service->m_provider_name;
 		if (prov.empty()) {
-			eServiceReferenceDVB orig;
-			bool res = ((const eServiceReferenceDVB&)m_reference).getSROriginal(orig);
+			eServiceReferenceDVB sRelayOrigSref;
+			bool res = ((const eServiceReferenceDVB&)m_reference).getSROriginal(sRelayOrigSref);
 			if (res) {
-				ePtr<eDVBService> serviceOrig;
-				eDVBDB::getInstance()->getService(orig, serviceOrig);
-				return serviceOrig->m_provider_name;
+				ePtr<eDVBService> sRelayServiceOrigSref;
+				eDVBDB::getInstance()->getService(sRelayOrigSref, sRelayServiceOrigSref);
+				return sRelayServiceOrigSref->m_provider_name;
 			}
 		}
 		return prov;


### PR DESCRIPTION
This makes all stream relay channels to report all the info like it was on the normal DVB channel.
So Provider, Transponder info, DVB namespace, SNR, AGC, BER is all there.
Also it fixes grayed out channels in Channel list.

This is test so keep in mind that have to be tested how it behaves on PLi more deeply.