### PR TITLE
[UsageConfig] add "scc" in Serbian language codec

### DIFF
--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -679,7 +679,7 @@ def InitUsageConfig():
 		("por dub Dub DUB ud1", _("Portuguese")),
 		("ron rum", _("Romanian")),
 		("rus", _("Russian")),
-		("srp", _("Serbian")),
+		("srp scc", _("Serbian")),
 		("slk slo", _("Slovak")),
 		("slv", _("Slovenian")),
 		("spa", _("Spanish")),


### PR DESCRIPTION
ISO 639-2/T : srp | ISO 639-2/B : scc; ISO 639-3 : srp