### PR TITLE
[Added] scale to fit functionality for SVG images

### DIFF
--- a/lib/gdi/epng.h
+++ b/lib/gdi/epng.h
@@ -6,7 +6,7 @@
 SWIG_VOID(int) loadPNG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, int accel = 0, int cached = 1);
 SWIG_VOID(int) loadJPG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, int cached = 0);
 SWIG_VOID(int) loadJPG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, ePtr<gPixmap> alpha, int cached = 0);
-SWIG_VOID(int) loadSVG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, int cached = 1, int width = 0, int height = 0, float scale = 0);
+SWIG_VOID(int) loadSVG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, int cached = 1, int width = 0, int height = 0, float scale = 0, int keepAspect = 0);
 
 int loadImage(ePtr<gPixmap> &result, const char *filename, int accel = 0, int width = 0, int height = 0);
 int savePNG(const char *filename, gPixmap *pixmap);

--- a/lib/python/Tools/LoadPixmap.py
+++ b/lib/python/Tools/LoadPixmap.py
@@ -4,7 +4,7 @@ from enigma import loadPNG, loadJPG, loadSVG
 # If cached is not supplied, LoadPixmap defaults to caching PNGs and not caching JPGs
 # Split alpha channel JPGs are never cached as the C++ layer's caching is based on
 # a single file per image in the cache
-def LoadPixmap(path, desktop=None, cached=None, width=0, height=0):
+def LoadPixmap(path, desktop=None, cached=None, width=0, height=0, scaletoFit=0):
 	if path[-4:] == ".png":
 		# cache unless caller explicity requests to not cache
 		ptr = loadPNG(path, 0, 0 if not cached else 1)
@@ -15,7 +15,7 @@ def LoadPixmap(path, desktop=None, cached=None, width=0, height=0):
 		from skin import parameters, getSkinFactor # imported here to avoid circular import
 		autoscale = int(parameters.get("AutoscaleSVG", -1)) # skin_default only == -1, disabled == 0 or enabled == 1
 		scale = height == 0 and (autoscale == -1 and "/skin_default/" in path or autoscale == 1) and getSkinFactor() or 0
-		ptr = loadSVG(path, 0 if not cached else 1, width, height, scale)
+		ptr = loadSVG(path, 0 if cached is False else 1, width, height, scale, scaletoFit)
 	elif path[-1:] == ".":
 		# caching mechanism isn't suitable for multi file images, so it's explicitly disabled
 		alpha = loadPNG(path + "a.png", 0, 0)


### PR DESCRIPTION
This is to allow automatically fit SVG to a specified container.

It works with LoadPixmap by specifying desired width and height of the container and a new  scaleToFit parameter set to True.