### PR TITLE
[Added] Native rounded corners rendering and border support for widgets

### DIFF
--- a/lib/gdi/Makefile.inc
+++ b/lib/gdi/Makefile.inc
@@ -6,6 +6,7 @@ gdi_libenigma_gdi_a_SOURCES = \
 	gdi/accel.cpp \
 	gdi/bcm.cpp \
 	gdi/compositing.cpp \
+	gdi/drawing.cpp \
 	gdi/epng.cpp \
 	gdi/erect.cpp \
 	gdi/fb.cpp \
@@ -27,6 +28,7 @@ gdiincludedir = $(pkgincludedir)/lib/gdi
 gdiinclude_HEADERS = \
 	gdi/accel.h \
 	gdi/compositing.h \
+	gdi/drawing.h \
 	gdi/epng.h \
 	gdi/epoint.h \
 	gdi/erect.h \

--- a/lib/gdi/drawing.cpp
+++ b/lib/gdi/drawing.cpp
@@ -1,0 +1,2043 @@
+/*
+Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License
+
+Copyright (c) 2023-2024 openATV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+1. Non-Commercial Use: You may not use the Software or any derivative works
+   for commercial purposes without obtaining explicit permission from the
+   copyright holder.
+2. Share Alike: If you distribute or publicly perform the Software or any
+   derivative works, you must do so under the same license terms, and you
+   must make the source code of any derivative works available to the
+   public.
+3. Attribution: You must give appropriate credit to the original author(s)
+   of the Software by including a prominent notice in your derivative works.
+THE SOFTWARE IS PROVIDED "AS IS," WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE,
+ARISING FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more details about the CC BY-NC-SA 4.0 License, please visit:
+https://creativecommons.org/licenses/by-nc-sa/4.0/
+*/
+
+#include <lib/gdi/drawing.h>
+#include <lib/gdi/region.h>
+
+uint32_t *createGradientBuffer3(int graSize, const std::vector<gRGB> &colors)
+{
+	uint32_t *gradientBuf = (uint32_t *)malloc(graSize * sizeof(uint32_t));
+
+	uint32_t start_col = colors.at(0).argb();
+	uint32_t mid_col = colors.at(1).argb();
+	uint32_t end_col = colors.at(2).argb();
+
+	start_col ^= 0xFF000000;
+	mid_col ^= 0xFF000000;
+	end_col ^= 0xFF000000;
+
+	uint8_t start_a = (uint8_t)((start_col & 0xFF000000) >> 24);
+	uint8_t start_r = (uint8_t)((start_col & 0x00FF0000) >> 16);
+	uint8_t start_g = (uint8_t)((start_col & 0x0000FF00) >> 8);
+	uint8_t start_b = (uint8_t)(start_col & 0x000000FF);
+
+	uint8_t mid_a = (uint8_t)((mid_col & 0xFF000000) >> 24);
+	uint8_t mid_r = (uint8_t)((mid_col & 0x00FF0000) >> 16);
+	uint8_t mid_g = (uint8_t)((mid_col & 0x0000FF00) >> 8);
+	uint8_t mid_b = (uint8_t)(mid_col & 0x000000FF);
+
+	uint8_t end_a = (uint8_t)((end_col & 0xFF000000) >> 24);
+	uint8_t end_r = (uint8_t)((end_col & 0x00FF0000) >> 16);
+	uint8_t end_g = (uint8_t)((end_col & 0x0000FF00) >> 8);
+	uint8_t end_b = (uint8_t)(end_col & 0x000000FF);
+
+	float steps = (float)graSize;
+	float aStep1 = (float)(mid_a - start_a) / (steps / 2);
+	float rStep1 = (float)(mid_r - start_r) / (steps / 2);
+	float gStep1 = (float)(mid_g - start_g) / (steps / 2);
+	float bStep1 = (float)(mid_b - start_b) / (steps / 2);
+
+	float aStep2 = (float)(end_a - mid_a) / (steps / 2);
+	float rStep2 = (float)(end_r - mid_r) / (steps / 2);
+	float gStep2 = (float)(end_g - mid_g) / (steps / 2);
+	float bStep2 = (float)(end_b - mid_b) / (steps / 2);
+
+	if (gradientBuf != NULL)
+	{
+		for (int x = 0; x < graSize; x++)
+		{
+			uint8_t a, r, g, b;
+			if (x < graSize / 2)
+			{
+				a = (uint8_t)(start_a + aStep1 * x);
+				r = (uint8_t)(start_r + rStep1 * x);
+				g = (uint8_t)(start_g + gStep1 * x);
+				b = (uint8_t)(start_b + bStep1 * x);
+			}
+			else
+			{
+				a = (uint8_t)(mid_a + aStep2 * (x - graSize / 2));
+				r = (uint8_t)(mid_r + rStep2 * (x - graSize / 2));
+				g = (uint8_t)(mid_g + gStep2 * (x - graSize / 2));
+				b = (uint8_t)(mid_b + bStep2 * (x - graSize / 2));
+			}
+			gradientBuf[x] = (((uint32_t)a << 24) | ((uint32_t)r << 16) | ((uint32_t)g << 8) | (uint32_t)b);
+		}
+	}
+	return gradientBuf;
+}
+
+uint32_t *createGradientBuffer2(int graSize, const gRGB &startColor, const gRGB &endColor)
+{
+	uint32_t *gradientBuf = (uint32_t *)malloc(graSize * sizeof(uint32_t));
+
+	uint32_t start_col = startColor.argb();
+	start_col ^= 0xFF000000;
+
+	uint32_t end_col = endColor.argb();
+	end_col ^= 0xFF000000;
+
+	uint8_t start_a = (uint8_t)((start_col & 0xFF000000) >> 24);
+	uint8_t start_r = (uint8_t)((start_col & 0x00FF0000) >> 16);
+	uint8_t start_g = (uint8_t)((start_col & 0x0000FF00) >> 8);
+	uint8_t start_b = (uint8_t)(start_col & 0x000000FF);
+
+	uint8_t end_a = (uint8_t)((end_col & 0xFF000000) >> 24);
+	uint8_t end_r = (uint8_t)((end_col & 0x00FF0000) >> 16);
+	uint8_t end_g = (uint8_t)((end_col & 0x0000FF00) >> 8);
+	uint8_t end_b = (uint8_t)(end_col & 0x000000FF);
+
+	float steps = (float)graSize;
+	float aStep = (float)(end_a - start_a) / steps;
+	float rStep = (float)(end_r - start_r) / steps;
+	float gStep = (float)(end_g - start_g) / steps;
+	float bStep = (float)(end_b - start_b) / steps;
+
+	if (gradientBuf != nullptr)
+	{
+		for (int x = 0; x < graSize; x++)
+		{
+			uint8_t a = (uint8_t)(start_a + aStep * x);
+			uint8_t r = (uint8_t)(start_r + rStep * x);
+			uint8_t g = (uint8_t)(start_g + gStep * x);
+			uint8_t b = (uint8_t)(start_b + bStep * x);
+			gradientBuf[x] = ((uint32_t)a << 24) | ((uint32_t)r << 16) | ((uint32_t)g << 8) | (uint32_t)b;
+		}
+	}
+	return gradientBuf;
+}
+
+static void blendPixelRounded(uint32_t *dst, const uint32_t *src, const double alpha)
+{
+	if (!((*src) & 0xFF000000))
+		return;
+
+	uint8_t r = (*src >> 24) & 0xFF;
+	uint8_t g = (*src >> 16) & 0xFF;
+	uint8_t b = (*src >> 8) & 0xFF;
+	uint8_t a = (*src >> 0) & 0xFF;
+
+	// Apply alpha blending
+	uint8_t newR = r * alpha;
+	uint8_t newG = g * alpha;
+	uint8_t newB = b * alpha;
+	uint8_t newA = a * alpha;
+
+	// Combine the new color with the existing pixel color using alpha blending
+	uint8_t oldR = (*dst >> 24) & 0xFF;
+	uint8_t oldG = (*dst >> 16) & 0xFF;
+	uint8_t oldB = (*dst >> 8) & 0xFF;
+	uint8_t oldA = (*dst >> 0) & 0xFF;
+
+	uint8_t finalR = newR + oldR * (1 - alpha);
+	uint8_t finalG = newG + oldG * (1 - alpha);
+	uint8_t finalB = newB + oldB * (1 - alpha);
+	uint8_t finalA = newA + oldA * (1 - alpha);
+
+	*dst = (finalR << 24) | (finalG << 16) | (finalB << 8) | finalA;
+}
+
+void drawAngleTl(gUnmanagedSurface *surface, const uint32_t *src, const eRect &area, uint8_t direction, const eRect &cornerRect, const CornerData &cornerData)
+{
+	double alpha = 1.0;
+	int dx = 0, dy = 0, squared_dst = 0;
+	const std::unordered_map<int, double> &radiusData = cornerData.RadiusData;
+	const int aLeft = area.left();
+	const int aTop = area.top();
+	const int rLeft = cornerRect.left();
+	const int rRight = cornerRect.right();
+	const int rTop = cornerRect.top();
+	const int rBottom = cornerRect.bottom();
+	for (int y = rTop; y < rBottom; y++)
+	{
+		int yInOriginalArea = y - aTop;
+		uint32_t *dst = (uint32_t *)(((uint8_t *)surface->data) + y * surface->stride + rLeft * surface->bypp);
+
+		for (int x = rLeft; x < rRight; x++)
+		{
+			int xInOriginalArea = x - aLeft;
+			dx = cornerData.topLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+			dy = cornerData.topLeftCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+			squared_dst = dx * dx + dy * dy;
+			if (squared_dst <= cornerData.topLeftCornerDRadius)
+			{
+				const uint32_t *s = src + (direction == 1 ? yInOriginalArea : xInOriginalArea);
+				*dst = *s;
+				++dst;
+				continue;
+			}
+			else if (squared_dst < cornerData.topLeftCornerSRadius)
+			{
+				const uint32_t *s = src + (direction == 1 ? yInOriginalArea : xInOriginalArea);
+				alpha = radiusData.at(squared_dst);
+				blendPixelRounded(dst, s, alpha);
+			}
+			++dst;
+		}
+	}
+}
+
+void drawAngleTr(gUnmanagedSurface *surface, const uint32_t *src, const eRect &area, uint8_t direction, const eRect &cornerRect, const CornerData &cornerData)
+{
+	double alpha = 1.0;
+	int dx = 0, dy = 0, squared_dst = 0;
+	const std::unordered_map<int, double> &radiusData = cornerData.RadiusData;
+	const int aLeft = area.left();
+	const int aTop = area.top();
+	const int rLeft = cornerRect.left();
+	const int rRight = cornerRect.right();
+	const int rTop = cornerRect.top();
+	const int rBottom = cornerRect.bottom();
+	for (int y = rTop; y < rBottom; y++)
+	{
+		int yInOriginalArea = y - aTop;
+		uint32_t *dst = (uint32_t *)(((uint8_t *)surface->data) + y * surface->stride + rLeft * surface->bypp);
+
+		for (int x = rLeft; x < rRight; x++)
+		{
+			int xInOriginalArea = x - aLeft;
+			dx = xInOriginalArea - cornerData.w_topRightCornerRadius;
+			dy = cornerData.topRightCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+			squared_dst = dx * dx + dy * dy;
+			if (squared_dst <= cornerData.topRightCornerDRadius)
+			{
+				const uint32_t *s = src + (direction == 1 ? yInOriginalArea : xInOriginalArea);
+				*dst = *s;
+				++dst;
+				continue;
+			}
+			else if (squared_dst < cornerData.topRightCornerSRadius)
+			{
+				const uint32_t *s = src + (direction == 1 ? yInOriginalArea : xInOriginalArea);
+				alpha = radiusData.at(squared_dst);
+				blendPixelRounded(dst, s, alpha);
+			}
+			++dst;
+		}
+	}
+}
+
+void drawAngleBl(gUnmanagedSurface *surface, const uint32_t *src, const eRect &area, uint8_t direction, const eRect &cornerRect, const CornerData &cornerData)
+{
+	double alpha = 1.0;
+	int dx = 0, dy = 0, squared_dst = 0;
+	const std::unordered_map<int, double> &radiusData = cornerData.RadiusData;
+	const int aLeft = area.left();
+	const int aTop = area.top();
+	const int rLeft = cornerRect.left();
+	const int rRight = cornerRect.right();
+	const int rTop = cornerRect.top();
+	const int rBottom = cornerRect.bottom();
+	for (int y = rTop; y < rBottom; y++)
+	{
+		int yInOriginalArea = y - aTop;
+		uint32_t *dst = (uint32_t *)(((uint8_t *)surface->data) + y * surface->stride + rLeft * surface->bypp);
+
+		for (int x = rLeft; x < rRight; x++)
+		{
+			int xInOriginalArea = x - aLeft;
+			dx = cornerData.bottomLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+			dy = yInOriginalArea - cornerData.h_bottomLeftCornerRadius;
+			squared_dst = dx * dx + dy * dy;
+			if (squared_dst <= cornerData.bottomLeftCornerDRadius)
+			{
+				const uint32_t *s = src + (direction == 1 ? yInOriginalArea : xInOriginalArea);
+				*dst = *s;
+				++dst;
+				continue;
+			}
+			else if (squared_dst < cornerData.bottomLeftCornerSRadius)
+			{
+				const uint32_t *s = src + (direction == 1 ? yInOriginalArea : xInOriginalArea);
+				alpha = radiusData.at(squared_dst);
+				blendPixelRounded(dst, s, alpha);
+			}
+			++dst;
+		}
+	}
+}
+
+void drawAngleBr(gUnmanagedSurface *surface, const uint32_t *src, const eRect &area, uint8_t direction, const eRect &cornerRect, const CornerData &cornerData)
+{
+	double alpha = 1.0;
+	int dx = 0, dy = 0, squared_dst = 0;
+	const std::unordered_map<int, double> &radiusData = cornerData.RadiusData;
+	const int aLeft = area.left();
+	const int aTop = area.top();
+	const int rLeft = cornerRect.left();
+	const int rRight = cornerRect.right();
+	const int rTop = cornerRect.top();
+	const int rBottom = cornerRect.bottom();
+	for (int y = rTop; y < rBottom; y++)
+	{
+		int yInOriginalArea = y - aTop;
+		uint32_t *dst = (uint32_t *)(((uint8_t *)surface->data) + y * surface->stride + rLeft * surface->bypp);
+
+		for (int x = rLeft; x < rRight; x++)
+		{
+			int xInOriginalArea = x - aLeft;
+			dx = xInOriginalArea - cornerData.w_bottomRightCornerRadius;
+			dy = yInOriginalArea - cornerData.h_bottomRightCornerRadius;
+			squared_dst = dx * dx + dy * dy;
+			if (squared_dst <= cornerData.bottomRightCornerDRadius)
+			{
+				const uint32_t *s = src + (direction == 1 ? yInOriginalArea : xInOriginalArea);
+				*dst = *s;
+				++dst;
+				continue;
+			}
+			else if (squared_dst < cornerData.bottomRightCornerSRadius)
+			{
+				const uint32_t *s = src + (direction == 1 ? yInOriginalArea : xInOriginalArea);
+				alpha = radiusData.at(squared_dst);
+				blendPixelRounded(dst, s, alpha);
+			}
+			++dst;
+		}
+	}
+}
+
+void drawAngle32Tl(gUnmanagedSurface *surface, const gPixmap &pixmap, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag)
+{
+	double alpha = 1.0;
+	int dx = 0, dy = 0, squared_dst = 0;
+	const std::unordered_map<int, double> &radiusData = cornerData.RadiusData;
+	const int aLeft = area.left();
+	const int aTop = area.top();
+	const int rLeft = cornerRect.left();
+	const int rRight = cornerRect.right();
+	const int rTop = cornerRect.top();
+	const int rBottom = cornerRect.bottom();
+	uint32_t *srcptr = (uint32_t *)pixmap.surface->data;
+	uint32_t *dstptr = (uint32_t *)surface->data;
+
+	srcptr += (rLeft - aLeft) + (rTop - aTop) * pixmap.surface->stride / 4;
+	dstptr += rLeft + rTop * surface->stride / 4;
+	if (flag & gPixmap::blitAlphaTest)
+	{
+		for (int y = rTop; y < rBottom; y++)
+		{
+			int yInOriginalArea = y - aTop;
+			uint32_t *src = srcptr;
+			uint32_t *dst = dstptr;
+
+			for (int x = rLeft; x < rRight; x++)
+			{
+				int xInOriginalArea = x - aLeft;
+				dx = cornerData.topLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+				dy = cornerData.topLeftCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.topLeftCornerDRadius)
+				{
+					if (!((*src) & 0xFF000000))
+					{
+						src++;
+						dst++;
+					}
+					else
+						*dst++ = *src++;
+					continue;
+				}
+				else if (squared_dst < cornerData.topLeftCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				++dst;
+				++src;
+			}
+			srcptr = (uint32_t *)((uint8_t *)srcptr + pixmap.surface->stride);
+			dstptr = (uint32_t *)((uint8_t *)dstptr + surface->stride);
+		}
+	}
+	else if (flag & gPixmap::blitAlphaBlend)
+	{
+		for (int y = rTop; y < rBottom; y++)
+		{
+			int yInOriginalArea = y - aTop;
+			uint32_t *src = srcptr;
+			uint32_t *dst = dstptr;
+
+			for (int x = rLeft; x < rRight; x++)
+			{
+				int xInOriginalArea = x - aLeft;
+				dx = cornerData.topLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+				dy = cornerData.topLeftCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.topLeftCornerDRadius)
+				{
+					gRGB *gSrc = (gRGB *)src;
+					gRGB *gDst = (gRGB *)dst;
+					gDst->b += (((gSrc->b - gDst->b) * gSrc->a) >> 8);
+					gDst->g += (((gSrc->g - gDst->g) * gSrc->a) >> 8);
+					gDst->r += (((gSrc->r - gDst->r) * gSrc->a) >> 8);
+					gDst->a += (((0xFF - gDst->a) * gSrc->a) >> 8);
+					src++;
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.topLeftCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				++dst;
+				++src;
+			}
+			srcptr = (uint32_t *)((uint8_t *)srcptr + pixmap.surface->stride);
+			dstptr = (uint32_t *)((uint8_t *)dstptr + surface->stride);
+		}
+	}
+	else
+	{
+		for (int y = rTop; y < rBottom; y++)
+		{
+			int yInOriginalArea = y - aTop;
+			uint32_t *src = srcptr;
+			uint32_t *dst = dstptr;
+
+			for (int x = rLeft; x < rRight; x++)
+			{
+				int xInOriginalArea = x - aLeft;
+				dx = cornerData.topLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+				dy = cornerData.topLeftCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.topLeftCornerDRadius)
+				{
+					*dst++ = *src++;
+					continue;
+				}
+				else if (squared_dst < cornerData.topLeftCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				++dst;
+				++src;
+			}
+			srcptr = (uint32_t *)((uint8_t *)srcptr + pixmap.surface->stride);
+			dstptr = (uint32_t *)((uint8_t *)dstptr + surface->stride);
+		}
+	}
+}
+
+void drawAngle32Tr(gUnmanagedSurface *surface, const gPixmap &pixmap, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag)
+{
+	double alpha = 1.0;
+	int dx = 0, dy = 0, squared_dst = 0;
+	const std::unordered_map<int, double> &radiusData = cornerData.RadiusData;
+	const int aLeft = area.left();
+	const int aTop = area.top();
+	const int rLeft = cornerRect.left();
+	const int rRight = cornerRect.right();
+	const int rTop = cornerRect.top();
+	const int rBottom = cornerRect.bottom();
+	uint32_t *srcptr = (uint32_t *)pixmap.surface->data;
+	uint32_t *dstptr = (uint32_t *)surface->data;
+
+	srcptr += (rLeft - aLeft) + (rTop - aTop) * pixmap.surface->stride / 4;
+	dstptr += rLeft + rTop * surface->stride / 4;
+	if (flag & gPixmap::blitAlphaTest)
+	{
+		for (int y = rTop; y < rBottom; y++)
+		{
+			int yInOriginalArea = y - aTop;
+			uint32_t *src = srcptr;
+			uint32_t *dst = dstptr;
+
+			for (int x = rLeft; x < rRight; x++)
+			{
+				int xInOriginalArea = x - aLeft;
+				dx = xInOriginalArea - cornerData.w_topRightCornerRadius;
+				dy = cornerData.topRightCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.topRightCornerDRadius)
+				{
+					if (!((*src) & 0xFF000000))
+					{
+						src++;
+						dst++;
+					}
+					else
+						*dst++ = *src++;
+					continue;
+				}
+				else if (squared_dst < cornerData.topRightCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				++dst;
+				++src;
+			}
+			srcptr = (uint32_t *)((uint8_t *)srcptr + pixmap.surface->stride);
+			dstptr = (uint32_t *)((uint8_t *)dstptr + surface->stride);
+		}
+	}
+	else if (flag & gPixmap::blitAlphaBlend)
+	{
+		for (int y = rTop; y < rBottom; y++)
+		{
+			int yInOriginalArea = y - aTop;
+			uint32_t *src = srcptr;
+			uint32_t *dst = dstptr;
+
+			for (int x = rLeft; x < rRight; x++)
+			{
+				int xInOriginalArea = x - aLeft;
+				dx = xInOriginalArea - cornerData.w_topRightCornerRadius;
+				dy = cornerData.topRightCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.topRightCornerDRadius)
+				{
+					gRGB *gSrc = (gRGB *)src;
+					gRGB *gDst = (gRGB *)dst;
+					gDst->b += (((gSrc->b - gDst->b) * gSrc->a) >> 8);
+					gDst->g += (((gSrc->g - gDst->g) * gSrc->a) >> 8);
+					gDst->r += (((gSrc->r - gDst->r) * gSrc->a) >> 8);
+					gDst->a += (((0xFF - gDst->a) * gSrc->a) >> 8);
+					src++;
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.topRightCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				++dst;
+				++src;
+			}
+			srcptr = (uint32_t *)((uint8_t *)srcptr + pixmap.surface->stride);
+			dstptr = (uint32_t *)((uint8_t *)dstptr + surface->stride);
+		}
+	}
+	else
+	{
+		for (int y = rTop; y < rBottom; y++)
+		{
+			int yInOriginalArea = y - aTop;
+			uint32_t *src = srcptr;
+			uint32_t *dst = dstptr;
+
+			for (int x = rLeft; x < rRight; x++)
+			{
+				int xInOriginalArea = x - aLeft;
+				dx = xInOriginalArea - cornerData.w_topRightCornerRadius;
+				dy = cornerData.topRightCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.topRightCornerDRadius)
+				{
+					*dst++ = *src++;
+					continue;
+				}
+				else if (squared_dst < cornerData.topRightCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				++dst;
+				++src;
+			}
+			srcptr = (uint32_t *)((uint8_t *)srcptr + pixmap.surface->stride);
+			dstptr = (uint32_t *)((uint8_t *)dstptr + surface->stride);
+		}
+	}
+}
+
+void drawAngle32Bl(gUnmanagedSurface *surface, const gPixmap &pixmap, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag)
+{
+	double alpha = 1.0;
+	int dx = 0, dy = 0, squared_dst = 0;
+	const std::unordered_map<int, double> &radiusData = cornerData.RadiusData;
+	const int aLeft = area.left();
+	const int aTop = area.top();
+	const int rLeft = cornerRect.left();
+	const int rRight = cornerRect.right();
+	const int rTop = cornerRect.top();
+	const int rBottom = cornerRect.bottom();
+	uint32_t *srcptr = (uint32_t *)pixmap.surface->data;
+	uint32_t *dstptr = (uint32_t *)surface->data;
+
+	srcptr += (rLeft - aLeft) + (rTop - aTop) * pixmap.surface->stride / 4;
+	dstptr += rLeft + rTop * surface->stride / 4;
+	if (flag & gPixmap::blitAlphaTest)
+	{
+		for (int y = rTop; y < rBottom; y++)
+		{
+			int yInOriginalArea = y - aTop;
+			uint32_t *src = srcptr;
+			uint32_t *dst = dstptr;
+
+			for (int x = rLeft; x < rRight; x++)
+			{
+				int xInOriginalArea = x - aLeft;
+				dx = cornerData.bottomLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+				dy = yInOriginalArea - cornerData.h_bottomLeftCornerRadius;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.bottomLeftCornerDRadius)
+				{
+					if (!((*src) & 0xFF000000))
+					{
+						src++;
+						dst++;
+					}
+					else
+						*dst++ = *src++;
+					continue;
+				}
+				else if (squared_dst < cornerData.bottomLeftCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				++dst;
+				++src;
+			}
+			srcptr = (uint32_t *)((uint8_t *)srcptr + pixmap.surface->stride);
+			dstptr = (uint32_t *)((uint8_t *)dstptr + surface->stride);
+		}
+	}
+	else if (flag & gPixmap::blitAlphaBlend)
+	{
+		for (int y = rTop; y < rBottom; y++)
+		{
+			int yInOriginalArea = y - aTop;
+			uint32_t *src = srcptr;
+			uint32_t *dst = dstptr;
+
+			for (int x = rLeft; x < rRight; x++)
+			{
+				int xInOriginalArea = x - aLeft;
+				dx = cornerData.bottomLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+				dy = yInOriginalArea - cornerData.h_bottomLeftCornerRadius;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.bottomLeftCornerDRadius)
+				{
+					gRGB *gSrc = (gRGB *)src;
+					gRGB *gDst = (gRGB *)dst;
+					gDst->b += (((gSrc->b - gDst->b) * gSrc->a) >> 8);
+					gDst->g += (((gSrc->g - gDst->g) * gSrc->a) >> 8);
+					gDst->r += (((gSrc->r - gDst->r) * gSrc->a) >> 8);
+					gDst->a += (((0xFF - gDst->a) * gSrc->a) >> 8);
+					src++;
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.bottomLeftCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				++dst;
+				++src;
+			}
+			srcptr = (uint32_t *)((uint8_t *)srcptr + pixmap.surface->stride);
+			dstptr = (uint32_t *)((uint8_t *)dstptr + surface->stride);
+		}
+	}
+	else
+	{
+		for (int y = rTop; y < rBottom; y++)
+		{
+			int yInOriginalArea = y - aTop;
+			uint32_t *src = srcptr;
+			uint32_t *dst = dstptr;
+
+			for (int x = rLeft; x < rRight; x++)
+			{
+				int xInOriginalArea = x - aLeft;
+				dx = cornerData.bottomLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+				dy = yInOriginalArea - cornerData.h_bottomLeftCornerRadius;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.bottomLeftCornerDRadius)
+				{
+					*dst++ = *src++;
+					continue;
+				}
+				else if (squared_dst < cornerData.bottomLeftCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				++dst;
+				++src;
+			}
+			srcptr = (uint32_t *)((uint8_t *)srcptr + pixmap.surface->stride);
+			dstptr = (uint32_t *)((uint8_t *)dstptr + surface->stride);
+		}
+	}
+}
+
+void drawAngle32Br(gUnmanagedSurface *surface, const gPixmap &pixmap, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag)
+{
+	double alpha = 1.0;
+	int dx = 0, dy = 0, squared_dst = 0;
+	const std::unordered_map<int, double> &radiusData = cornerData.RadiusData;
+	const int aLeft = area.left();
+	const int aTop = area.top();
+	const int rLeft = cornerRect.left();
+	const int rRight = cornerRect.right();
+	const int rTop = cornerRect.top();
+	const int rBottom = cornerRect.bottom();
+	uint32_t *srcptr = (uint32_t *)pixmap.surface->data;
+	uint32_t *dstptr = (uint32_t *)surface->data;
+
+	srcptr += (rLeft - aLeft) + (rTop - aTop) * pixmap.surface->stride / 4;
+	dstptr += rLeft + rTop * surface->stride / 4;
+	if (flag & gPixmap::blitAlphaTest)
+	{
+		for (int y = rTop; y < rBottom; y++)
+		{
+			int yInOriginalArea = y - aTop;
+			uint32_t *src = srcptr;
+			uint32_t *dst = dstptr;
+
+			for (int x = rLeft; x < rRight; x++)
+			{
+				int xInOriginalArea = x - aLeft;
+				dx = xInOriginalArea - cornerData.w_bottomRightCornerRadius;
+				dy = yInOriginalArea - cornerData.h_bottomRightCornerRadius;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.bottomRightCornerDRadius)
+				{
+					if (!((*src) & 0xFF000000))
+					{
+						src++;
+						dst++;
+					}
+					else
+						*dst++ = *src++;
+					continue;
+				}
+				else if (squared_dst < cornerData.bottomRightCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				++dst;
+				++src;
+			}
+			srcptr = (uint32_t *)((uint8_t *)srcptr + pixmap.surface->stride);
+			dstptr = (uint32_t *)((uint8_t *)dstptr + surface->stride);
+		}
+	}
+	else if (flag & gPixmap::blitAlphaBlend)
+	{
+		for (int y = rTop; y < rBottom; y++)
+		{
+			int yInOriginalArea = y - aTop;
+			uint32_t *src = srcptr;
+			uint32_t *dst = dstptr;
+
+			for (int x = rLeft; x < rRight; x++)
+			{
+				int xInOriginalArea = x - aLeft;
+				dx = xInOriginalArea - cornerData.w_bottomRightCornerRadius;
+				dy = yInOriginalArea - cornerData.h_bottomRightCornerRadius;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.bottomRightCornerDRadius)
+				{
+					gRGB *gSrc = (gRGB *)src;
+					gRGB *gDst = (gRGB *)dst;
+					gDst->b += (((gSrc->b - gDst->b) * gSrc->a) >> 8);
+					gDst->g += (((gSrc->g - gDst->g) * gSrc->a) >> 8);
+					gDst->r += (((gSrc->r - gDst->r) * gSrc->a) >> 8);
+					gDst->a += (((0xFF - gDst->a) * gSrc->a) >> 8);
+					src++;
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.bottomRightCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				++dst;
+				++src;
+			}
+			srcptr = (uint32_t *)((uint8_t *)srcptr + pixmap.surface->stride);
+			dstptr = (uint32_t *)((uint8_t *)dstptr + surface->stride);
+		}
+	}
+	else
+	{
+		for (int y = rTop; y < rBottom; y++)
+		{
+			int yInOriginalArea = y - aTop;
+			uint32_t *src = srcptr;
+			uint32_t *dst = dstptr;
+
+			for (int x = rLeft; x < rRight; x++)
+			{
+				int xInOriginalArea = x - aLeft;
+				dx = xInOriginalArea - cornerData.w_bottomRightCornerRadius;
+				dy = yInOriginalArea - cornerData.h_bottomRightCornerRadius;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.bottomRightCornerDRadius)
+				{
+					*dst++ = *src++;
+					continue;
+				}
+				else if (squared_dst < cornerData.bottomRightCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				++dst;
+				++src;
+			}
+			srcptr = (uint32_t *)((uint8_t *)srcptr + pixmap.surface->stride);
+			dstptr = (uint32_t *)((uint8_t *)dstptr + surface->stride);
+		}
+	}
+}
+
+void drawAngle32ScaledTl(gUnmanagedSurface *surface, const gPixmap &pixmap, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag)
+{
+	double alpha = 1.0;
+	int dx = 0, dy = 0, squared_dst = 0;
+	const std::unordered_map<int, double> &radiusData = cornerData.RadiusData;
+	const int src_bypp = pixmap.surface->bypp;
+	const int dst_bypp = surface->bypp;
+	const int src_stride = pixmap.surface->stride;
+	const int dst_stride = surface->stride;
+	const float scaleX = (float)pixmap.size().width() / (float)area.width();
+	const float scaleY = (float)pixmap.size().height() / (float)area.height();
+	const int aLeft = area.left();
+	const int aTop = area.top();
+	const int rLeft = cornerRect.left();
+	const int rRight = cornerRect.right();
+	const int rTop = cornerRect.top();
+	const int rBottom = cornerRect.bottom();
+	uint8_t *dst_row = (uint8_t *)surface->data + rLeft * dst_bypp + rTop * dst_stride;
+
+	if (flag & gPixmap::blitAlphaTest)
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint32_t *src = (const uint32_t *)(src_row + src_x * src_bypp);
+				dx = cornerData.topLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+				dy = cornerData.topLeftCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.topLeftCornerDRadius)
+				{
+					if (*src & 0x80000000)
+						*dst = *src;
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.topLeftCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+	else if (flag & gPixmap::blitAlphaBlend)
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint32_t *src = (const uint32_t *)(src_row + src_x * src_bypp);
+				dx = cornerData.topLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+				dy = cornerData.topLeftCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.topLeftCornerDRadius)
+				{
+					const gRGB *src = (gRGB *)(src_row + src_x * src_bypp);
+					gRGB *gDst = (gRGB *)dst;
+					gDst->b += (((src->b - gDst->b) * src->a) >> 8);
+					gDst->g += (((src->g - gDst->g) * src->a) >> 8);
+					gDst->r += (((src->r - gDst->r) * src->a) >> 8);
+					gDst->a += (((0xFF - gDst->a) * src->a) >> 8);
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.topLeftCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+	else
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint32_t *src = (const uint32_t *)(src_row + src_x * src_bypp);
+				dx = cornerData.topLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+				dy = cornerData.topLeftCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.topLeftCornerDRadius)
+				{
+					*dst = *src;
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.topLeftCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+}
+
+void drawAngle32ScaledTr(gUnmanagedSurface *surface, const gPixmap &pixmap, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag)
+{
+	double alpha = 1.0;
+	int dx = 0, dy = 0, squared_dst = 0;
+	const std::unordered_map<int, double> &radiusData = cornerData.RadiusData;
+	const int src_bypp = pixmap.surface->bypp;
+	const int dst_bypp = surface->bypp;
+	const int src_stride = pixmap.surface->stride;
+	const int dst_stride = surface->stride;
+	const float scaleX = (float)pixmap.size().width() / (float)area.width();
+	const float scaleY = (float)pixmap.size().height() / (float)area.height();
+	const int aLeft = area.left();
+	const int aTop = area.top();
+	const int rLeft = cornerRect.left();
+	const int rRight = cornerRect.right();
+	const int rTop = cornerRect.top();
+	const int rBottom = cornerRect.bottom();
+	uint8_t *dst_row = (uint8_t *)surface->data + rLeft * dst_bypp + rTop * dst_stride;
+
+	if (flag & gPixmap::blitAlphaTest)
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint32_t *src = (const uint32_t *)(src_row + src_x * src_bypp);
+				dx = xInOriginalArea - cornerData.w_topRightCornerRadius;
+				dy = cornerData.topRightCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.topRightCornerDRadius)
+				{
+					if (*src & 0x80000000)
+						*dst = *src;
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.topRightCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+	else if (flag & gPixmap::blitAlphaBlend)
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint32_t *src = (const uint32_t *)(src_row + src_x * src_bypp);
+				dx = xInOriginalArea - cornerData.w_topRightCornerRadius;
+				dy = cornerData.topRightCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.topRightCornerDRadius)
+				{
+					const gRGB *src = (gRGB *)(src_row + src_x * src_bypp);
+					gRGB *gDst = (gRGB *)dst;
+					gDst->b += (((src->b - gDst->b) * src->a) >> 8);
+					gDst->g += (((src->g - gDst->g) * src->a) >> 8);
+					gDst->r += (((src->r - gDst->r) * src->a) >> 8);
+					gDst->a += (((0xFF - gDst->a) * src->a) >> 8);
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.topRightCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+	else
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint32_t *src = (const uint32_t *)(src_row + src_x * src_bypp);
+				dx = xInOriginalArea - cornerData.w_topRightCornerRadius;
+				dy = cornerData.topRightCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.topRightCornerDRadius)
+				{
+					*dst = *src;
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.topRightCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+}
+
+void drawAngle32ScaledBl(gUnmanagedSurface *surface, const gPixmap &pixmap, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag)
+{
+	double alpha = 1.0;
+	int dx = 0, dy = 0, squared_dst = 0;
+	const std::unordered_map<int, double> &radiusData = cornerData.RadiusData;
+	const int src_bypp = pixmap.surface->bypp;
+	const int dst_bypp = surface->bypp;
+	const int src_stride = pixmap.surface->stride;
+	const int dst_stride = surface->stride;
+	const float scaleX = (float)pixmap.size().width() / (float)area.width();
+	const float scaleY = (float)pixmap.size().height() / (float)area.height();
+	const int aLeft = area.left();
+	const int aTop = area.top();
+	const int rLeft = cornerRect.left();
+	const int rRight = cornerRect.right();
+	const int rTop = cornerRect.top();
+	const int rBottom = cornerRect.bottom();
+	uint8_t *dst_row = (uint8_t *)surface->data + rLeft * dst_bypp + rTop * dst_stride;
+
+	if (flag & gPixmap::blitAlphaTest)
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint32_t *src = (const uint32_t *)(src_row + src_x * src_bypp);
+				dx = cornerData.bottomLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+				dy = yInOriginalArea - cornerData.h_bottomLeftCornerRadius;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.bottomLeftCornerDRadius)
+				{
+					if (*src & 0x80000000)
+						*dst = *src;
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.bottomLeftCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+	else if (flag & gPixmap::blitAlphaBlend)
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint32_t *src = (const uint32_t *)(src_row + src_x * src_bypp);
+				dx = cornerData.bottomLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+				dy = yInOriginalArea - cornerData.h_bottomLeftCornerRadius;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.bottomLeftCornerDRadius)
+				{
+					const gRGB *src = (gRGB *)(src_row + src_x * src_bypp);
+					gRGB *gDst = (gRGB *)dst;
+					gDst->b += (((src->b - gDst->b) * src->a) >> 8);
+					gDst->g += (((src->g - gDst->g) * src->a) >> 8);
+					gDst->r += (((src->r - gDst->r) * src->a) >> 8);
+					gDst->a += (((0xFF - gDst->a) * src->a) >> 8);
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.bottomLeftCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+	else
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint32_t *src = (const uint32_t *)(src_row + src_x * src_bypp);
+				dx = cornerData.bottomLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+				dy = yInOriginalArea - cornerData.h_bottomLeftCornerRadius;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.bottomLeftCornerDRadius)
+				{
+					*dst = *src;
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.bottomLeftCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+}
+
+void drawAngle32ScaledBr(gUnmanagedSurface *surface, const gPixmap &pixmap, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag)
+{
+	double alpha = 1.0;
+	int dx = 0, dy = 0, squared_dst = 0;
+	const std::unordered_map<int, double> &radiusData = cornerData.RadiusData;
+	const int src_bypp = pixmap.surface->bypp;
+	const int dst_bypp = surface->bypp;
+	const int src_stride = pixmap.surface->stride;
+	const int dst_stride = surface->stride;
+	const float scaleX = (float)pixmap.size().width() / (float)area.width();
+	const float scaleY = (float)pixmap.size().height() / (float)area.height();
+	const int aLeft = area.left();
+	const int aTop = area.top();
+	const int rLeft = cornerRect.left();
+	const int rRight = cornerRect.right();
+	const int rTop = cornerRect.top();
+	const int rBottom = cornerRect.bottom();
+	uint8_t *dst_row = (uint8_t *)surface->data + rLeft * dst_bypp + rTop * dst_stride;
+
+	if (flag & gPixmap::blitAlphaTest)
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint32_t *src = (const uint32_t *)(src_row + src_x * src_bypp);
+				dx = xInOriginalArea - cornerData.w_bottomRightCornerRadius;
+				dy = yInOriginalArea - cornerData.h_bottomRightCornerRadius;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.bottomRightCornerDRadius)
+				{
+					if (*src & 0x80000000)
+						*dst = *src;
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.bottomRightCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+	else if (flag & gPixmap::blitAlphaBlend)
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint32_t *src = (const uint32_t *)(src_row + src_x * src_bypp);
+				dx = xInOriginalArea - cornerData.w_bottomRightCornerRadius;
+				dy = yInOriginalArea - cornerData.h_bottomRightCornerRadius;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.bottomRightCornerDRadius)
+				{
+					const gRGB *src = (gRGB *)(src_row + src_x * src_bypp);
+					gRGB *gDst = (gRGB *)dst;
+					gDst->b += (((src->b - gDst->b) * src->a) >> 8);
+					gDst->g += (((src->g - gDst->g) * src->a) >> 8);
+					gDst->r += (((src->r - gDst->r) * src->a) >> 8);
+					gDst->a += (((0xFF - gDst->a) * src->a) >> 8);
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.bottomRightCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+	else
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint32_t *src = (const uint32_t *)(src_row + src_x * src_bypp);
+				dx = xInOriginalArea - cornerData.w_bottomRightCornerRadius;
+				dy = yInOriginalArea - cornerData.h_bottomRightCornerRadius;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.bottomRightCornerDRadius)
+				{
+					*dst = *src;
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.bottomRightCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, src, alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+}
+
+void drawAngle8Tl(gUnmanagedSurface *surface, const gPixmap &pixmap, const uint32_t *pal, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag)
+{
+	double alpha = 1.0;
+	int dx = 0, dy = 0, squared_dst = 0;
+	const std::unordered_map<int, double> &radiusData = cornerData.RadiusData;
+	const uint8_t *srcptr = (uint8_t *)pixmap.surface->data;
+	uint32_t *dstptr = (uint32_t *)surface->data;
+
+	srcptr += (cornerRect.left() - area.left()) + (cornerRect.top() - area.top()) * pixmap.surface->stride;
+	dstptr += cornerRect.left() + cornerRect.top() * surface->stride / 4;
+	for (int y = cornerRect.top(); y < cornerRect.bottom(); y++)
+	{
+		int yInOriginalArea = y - area.top();
+		const uint8_t *src = srcptr;
+		uint32_t *dst = dstptr;
+
+		for (int x = cornerRect.left(); x < cornerRect.right(); x++)
+		{
+			int xInOriginalArea = x - area.left();
+			dx = cornerData.topLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+			dy = cornerData.topLeftCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+			squared_dst = dx * dx + dy * dy;
+			if (squared_dst <= cornerData.topLeftCornerDRadius)
+			{
+				if (flag & gPixmap::blitAlphaTest)
+				{
+					if (!(pal[*src] & 0xFF000000))
+					{
+						src++;
+						dst++;
+					}
+					else
+						*dst++ = pal[*src++];
+				}
+				else if (flag & gPixmap::blitAlphaBlend)
+				{
+					gRGB *gDst = (gRGB *)dst;
+					gDst->alpha_blend(pal[*src++]);
+					dst++;
+				}
+				else
+					*dst++ = pal[*src++];
+				continue;
+			}
+			else if (squared_dst < cornerData.topLeftCornerSRadius)
+			{
+				alpha = radiusData.at(squared_dst);
+				blendPixelRounded(dst, &pal[*src], alpha);
+			}
+			++dst;
+			++src;
+		}
+		srcptr += pixmap.surface->stride;
+		dstptr = (uint32_t *)((uint8_t *)dstptr + surface->stride);
+	}
+}
+
+void drawAngle8Tr(gUnmanagedSurface *surface, const gPixmap &pixmap, const uint32_t *pal, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag)
+{
+	double alpha = 1.0;
+	int dx = 0, dy = 0, squared_dst = 0;
+	const std::unordered_map<int, double> &radiusData = cornerData.RadiusData;
+	const uint8_t *srcptr = (uint8_t *)pixmap.surface->data;
+	uint32_t *dstptr = (uint32_t *)surface->data;
+
+	srcptr += (cornerRect.left() - area.left()) + (cornerRect.top() - area.top()) * pixmap.surface->stride;
+	dstptr += cornerRect.left() + cornerRect.top() * surface->stride / 4;
+	for (int y = cornerRect.top(); y < cornerRect.bottom(); y++)
+	{
+		int yInOriginalArea = y - area.top();
+		const uint8_t *src = srcptr;
+		uint32_t *dst = dstptr;
+
+		for (int x = cornerRect.left(); x < cornerRect.right(); x++)
+		{
+			int xInOriginalArea = x - area.left();
+			dx = xInOriginalArea - cornerData.w_topRightCornerRadius;
+			dy = cornerData.topRightCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+			squared_dst = dx * dx + dy * dy;
+			if (squared_dst <= cornerData.topRightCornerDRadius)
+			{
+				if (flag & gPixmap::blitAlphaTest)
+				{
+					if (!(pal[*src] & 0xFF000000))
+					{
+						src++;
+						dst++;
+					}
+					else
+						*dst++ = pal[*src++];
+				}
+				else if (flag & gPixmap::blitAlphaBlend)
+				{
+					gRGB *gDst = (gRGB *)dst;
+					gDst->alpha_blend(pal[*src++]);
+					dst++;
+				}
+				else
+					*dst++ = pal[*src++];
+				continue;
+			}
+			else if (squared_dst < cornerData.topRightCornerSRadius)
+			{
+				alpha = radiusData.at(squared_dst);
+				blendPixelRounded(dst, &pal[*src], alpha);
+			}
+			++dst;
+			++src;
+		}
+		srcptr += pixmap.surface->stride;
+		dstptr = (uint32_t *)((uint8_t *)dstptr + surface->stride);
+	}
+}
+
+void drawAngle8Bl(gUnmanagedSurface *surface, const gPixmap &pixmap, const uint32_t *pal, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag)
+{
+	double alpha = 1.0;
+	int dx = 0, dy = 0, squared_dst = 0;
+	const std::unordered_map<int, double> &radiusData = cornerData.RadiusData;
+	const uint8_t *srcptr = (uint8_t *)pixmap.surface->data;
+	uint32_t *dstptr = (uint32_t *)surface->data;
+
+	srcptr += (cornerRect.left() - area.left()) + (cornerRect.top() - area.top()) * pixmap.surface->stride;
+	dstptr += cornerRect.left() + cornerRect.top() * surface->stride / 4;
+	for (int y = cornerRect.top(); y < cornerRect.bottom(); y++)
+	{
+		int yInOriginalArea = y - area.top();
+		const uint8_t *src = srcptr;
+		uint32_t *dst = dstptr;
+
+		for (int x = cornerRect.left(); x < cornerRect.right(); x++)
+		{
+			int xInOriginalArea = x - area.left();
+			dx = cornerData.bottomLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+			dy = yInOriginalArea - cornerData.h_bottomLeftCornerRadius;
+			squared_dst = dx * dx + dy * dy;
+			if (squared_dst <= cornerData.bottomLeftCornerDRadius)
+			{
+				if (flag & gPixmap::blitAlphaTest)
+				{
+					if (!(pal[*src] & 0xFF000000))
+					{
+						src++;
+						dst++;
+					}
+					else
+						*dst++ = pal[*src++];
+				}
+				else if (flag & gPixmap::blitAlphaBlend)
+				{
+					gRGB *gDst = (gRGB *)dst;
+					gDst->alpha_blend(pal[*src++]);
+					dst++;
+				}
+				else
+					*dst++ = pal[*src++];
+				continue;
+			}
+			else if (squared_dst < cornerData.bottomLeftCornerSRadius)
+			{
+				alpha = radiusData.at(squared_dst);
+				blendPixelRounded(dst, &pal[*src], alpha);
+			}
+			++dst;
+			++src;
+		}
+		srcptr += pixmap.surface->stride;
+		dstptr = (uint32_t *)((uint8_t *)dstptr + surface->stride);
+	}
+}
+
+void drawAngle8Br(gUnmanagedSurface *surface, const gPixmap &pixmap, const uint32_t *pal, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag)
+{
+	double alpha = 1.0;
+	int dx = 0, dy = 0, squared_dst = 0;
+	const std::unordered_map<int, double> &radiusData = cornerData.RadiusData;
+	const uint8_t *srcptr = (uint8_t *)pixmap.surface->data;
+	uint32_t *dstptr = (uint32_t *)surface->data;
+
+	srcptr += (cornerRect.left() - area.left()) + (cornerRect.top() - area.top()) * pixmap.surface->stride;
+	dstptr += cornerRect.left() + cornerRect.top() * surface->stride / 4;
+	for (int y = cornerRect.top(); y < cornerRect.bottom(); y++)
+	{
+		int yInOriginalArea = y - area.top();
+		const uint8_t *src = srcptr;
+		uint32_t *dst = dstptr;
+
+		for (int x = cornerRect.left(); x < cornerRect.right(); x++)
+		{
+			int xInOriginalArea = x - area.left();
+			dx = xInOriginalArea - cornerData.w_bottomRightCornerRadius;
+			dy = yInOriginalArea - cornerData.h_bottomRightCornerRadius;
+			squared_dst = dx * dx + dy * dy;
+			if (squared_dst <= cornerData.bottomRightCornerDRadius)
+			{
+				if (flag & gPixmap::blitAlphaTest)
+				{
+					if (!(pal[*src] & 0xFF000000))
+					{
+						src++;
+						dst++;
+					}
+					else
+						*dst++ = pal[*src++];
+				}
+				else if (flag & gPixmap::blitAlphaBlend)
+				{
+					gRGB *gDst = (gRGB *)dst;
+					gDst->alpha_blend(pal[*src++]);
+					dst++;
+				}
+				else
+					*dst++ = pal[*src++];
+				continue;
+			}
+			else if (squared_dst < cornerData.bottomRightCornerSRadius)
+			{
+				alpha = radiusData.at(squared_dst);
+				blendPixelRounded(dst, &pal[*src], alpha);
+			}
+			++dst;
+			++src;
+		}
+		srcptr += pixmap.surface->stride;
+		dstptr = (uint32_t *)((uint8_t *)dstptr + surface->stride);
+	}
+}
+
+void drawAngle8ScaledTl(gUnmanagedSurface *surface, const gPixmap &pixmap, const uint32_t *pal, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag)
+{
+	double alpha = 1.0;
+	int dx = 0, dy = 0, squared_dst = 0;
+	const std::unordered_map<int, double> &radiusData = cornerData.RadiusData;
+	const int src_bypp = pixmap.surface->bypp;
+	const int dst_bypp = surface->bypp;
+	const int src_stride = pixmap.surface->stride;
+	const int dst_stride = surface->stride;
+	const float scaleX = (float)pixmap.size().width() / (float)area.width();
+	const float scaleY = (float)pixmap.size().height() / (float)area.height();
+	const int aLeft = area.left();
+	const int aTop = area.top();
+	const int rLeft = cornerRect.left();
+	const int rRight = cornerRect.right();
+	const int rTop = cornerRect.top();
+	const int rBottom = cornerRect.bottom();
+	uint8_t *dst_row = (uint8_t *)surface->data + rLeft * dst_bypp + rTop * dst_stride;
+
+	if (flag & gPixmap::blitAlphaTest)
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint8_t *src = src_row + src_x * src_bypp;
+				dx = cornerData.topLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+				dy = cornerData.topLeftCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.topLeftCornerDRadius)
+				{
+					if (pal[*src] & 0x80000000)
+						*dst = pal[*src];
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.topLeftCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, &pal[*src], alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+	else if (flag & gPixmap::blitAlphaBlend)
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint8_t *src = src_row + src_x * src_bypp;
+				dx = cornerData.topLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+				dy = cornerData.topLeftCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.topLeftCornerDRadius)
+				{
+					gRGB *gDst = (gRGB *)dst;
+					gDst->alpha_blend(pal[*src]);
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.topLeftCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, &pal[*src], alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+	else
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint8_t *src = src_row + src_x * src_bypp;
+				dx = cornerData.topLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+				dy = cornerData.topLeftCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.topLeftCornerDRadius)
+				{
+					*dst = pal[*src];
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.topLeftCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, &pal[*src], alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+}
+
+void drawAngle8ScaledTr(gUnmanagedSurface *surface, const gPixmap &pixmap, const uint32_t *pal, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag)
+{
+	double alpha = 1.0;
+	int dx = 0, dy = 0, squared_dst = 0;
+	const std::unordered_map<int, double> &radiusData = cornerData.RadiusData;
+	const int src_bypp = pixmap.surface->bypp;
+	const int dst_bypp = surface->bypp;
+	const int src_stride = pixmap.surface->stride;
+	const int dst_stride = surface->stride;
+	const float scaleX = (float)pixmap.size().width() / (float)area.width();
+	const float scaleY = (float)pixmap.size().height() / (float)area.height();
+	const int aLeft = area.left();
+	const int aTop = area.top();
+	const int rLeft = cornerRect.left();
+	const int rRight = cornerRect.right();
+	const int rTop = cornerRect.top();
+	const int rBottom = cornerRect.bottom();
+	uint8_t *dst_row = (uint8_t *)surface->data + rLeft * dst_bypp + rTop * dst_stride;
+
+	if (flag & gPixmap::blitAlphaTest)
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint8_t *src = src_row + src_x * src_bypp;
+				dx = xInOriginalArea - cornerData.w_topRightCornerRadius;
+				dy = cornerData.topRightCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.topRightCornerDRadius)
+				{
+					if (pal[*src] & 0x80000000)
+						*dst = pal[*src];
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.topRightCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, &pal[*src], alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+	else if (flag & gPixmap::blitAlphaBlend)
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint8_t *src = src_row + src_x * src_bypp;
+				dx = xInOriginalArea - cornerData.w_topRightCornerRadius;
+				dy = cornerData.topRightCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.topRightCornerDRadius)
+				{
+					gRGB *gDst = (gRGB *)dst;
+					gDst->alpha_blend(pal[*src]);
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.topRightCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, &pal[*src], alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+	else
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint8_t *src = src_row + src_x * src_bypp;
+				dx = xInOriginalArea - cornerData.w_topRightCornerRadius;
+				dy = cornerData.topRightCornerRadius - yInOriginalArea - 1 + cornerData.borderWidth;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.topRightCornerDRadius)
+				{
+					*dst = pal[*src];
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.topRightCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, &pal[*src], alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+}
+
+void drawAngle8ScaledBl(gUnmanagedSurface *surface, const gPixmap &pixmap, const uint32_t *pal, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag)
+{
+	double alpha = 1.0;
+	int dx = 0, dy = 0, squared_dst = 0;
+	const std::unordered_map<int, double> &radiusData = cornerData.RadiusData;
+	const int src_bypp = pixmap.surface->bypp;
+	const int dst_bypp = surface->bypp;
+	const int src_stride = pixmap.surface->stride;
+	const int dst_stride = surface->stride;
+	const float scaleX = (float)pixmap.size().width() / (float)area.width();
+	const float scaleY = (float)pixmap.size().height() / (float)area.height();
+	const int aLeft = area.left();
+	const int aTop = area.top();
+	const int rLeft = cornerRect.left();
+	const int rRight = cornerRect.right();
+	const int rTop = cornerRect.top();
+	const int rBottom = cornerRect.bottom();
+	uint8_t *dst_row = (uint8_t *)surface->data + rLeft * dst_bypp + rTop * dst_stride;
+
+	if (flag & gPixmap::blitAlphaTest)
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint8_t *src = src_row + src_x * src_bypp;
+				dx = cornerData.bottomLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+				dy = yInOriginalArea - cornerData.h_bottomLeftCornerRadius;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.bottomLeftCornerDRadius)
+				{
+					if (pal[*src] & 0x80000000)
+						*dst = pal[*src];
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.bottomLeftCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, &pal[*src], alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+	else if (flag & gPixmap::blitAlphaBlend)
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint8_t *src = src_row + src_x * src_bypp;
+				dx = cornerData.bottomLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+				dy = yInOriginalArea - cornerData.h_bottomLeftCornerRadius;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.bottomLeftCornerDRadius)
+				{
+					gRGB *gDst = (gRGB *)dst;
+					gDst->alpha_blend(pal[*src]);
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.bottomLeftCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, &pal[*src], alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+	else
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint8_t *src = src_row + src_x * src_bypp;
+				dx = cornerData.bottomLeftCornerRadius - xInOriginalArea - 1 + cornerData.borderWidth;
+				dy = yInOriginalArea - cornerData.h_bottomLeftCornerRadius;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.bottomLeftCornerDRadius)
+				{
+					*dst = pal[*src];
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.bottomLeftCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, &pal[*src], alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+}
+
+void drawAngle8ScaledBr(gUnmanagedSurface *surface, const gPixmap &pixmap, const uint32_t *pal, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag)
+{
+	double alpha = 1.0;
+	int dx = 0, dy = 0, squared_dst = 0;
+	const std::unordered_map<int, double> &radiusData = cornerData.RadiusData;
+	const int src_bypp = pixmap.surface->bypp;
+	const int dst_bypp = surface->bypp;
+	const int src_stride = pixmap.surface->stride;
+	const int dst_stride = surface->stride;
+	const float scaleX = (float)pixmap.size().width() / (float)area.width();
+	const float scaleY = (float)pixmap.size().height() / (float)area.height();
+	const int aLeft = area.left();
+	const int aTop = area.top();
+	const int rLeft = cornerRect.left();
+	const int rRight = cornerRect.right();
+	const int rTop = cornerRect.top();
+	const int rBottom = cornerRect.bottom();
+	uint8_t *dst_row = (uint8_t *)surface->data + rLeft * dst_bypp + rTop * dst_stride;
+
+	if (flag & gPixmap::blitAlphaTest)
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint8_t *src = src_row + src_x * src_bypp;
+				dx = xInOriginalArea - cornerData.w_bottomRightCornerRadius;
+				dy = yInOriginalArea - cornerData.h_bottomRightCornerRadius;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.bottomRightCornerDRadius)
+				{
+					if (pal[*src] & 0x80000000)
+						*dst = pal[*src];
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.bottomRightCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, &pal[*src], alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+	else if (flag & gPixmap::blitAlphaBlend)
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint8_t *src = src_row + src_x * src_bypp;
+				dx = xInOriginalArea - cornerData.w_bottomRightCornerRadius;
+				dy = yInOriginalArea - cornerData.h_bottomRightCornerRadius;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.bottomRightCornerDRadius)
+				{
+					gRGB *gDst = (gRGB *)dst;
+					gDst->alpha_blend(pal[*src]);
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.bottomRightCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, &pal[*src], alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+	else
+	{
+		for (int y = rTop; y < rBottom; ++y)
+		{
+			int src_y = (int)((y - aTop) * scaleY);
+			const uint8_t *src_row = (const uint8_t *)pixmap.surface->data + src_y * src_stride;
+			uint32_t *dst = (uint32_t *)dst_row;
+			int yInOriginalArea = y - aTop;
+
+			for (int x = rLeft; x < rRight; ++x)
+			{
+				int xInOriginalArea = x - aLeft;
+				int src_x = (int)((x - aLeft) * scaleX);
+				const uint8_t *src = src_row + src_x * src_bypp;
+				dx = xInOriginalArea - cornerData.w_bottomRightCornerRadius;
+				dy = yInOriginalArea - cornerData.h_bottomRightCornerRadius;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= cornerData.bottomRightCornerDRadius)
+				{
+					*dst = pal[*src];
+					dst++;
+					continue;
+				}
+				else if (squared_dst < cornerData.bottomRightCornerSRadius)
+				{
+					alpha = radiusData.at(squared_dst);
+					blendPixelRounded(dst, &pal[*src], alpha);
+				}
+				dst++;
+			}
+			dst_row += dst_stride;
+		}
+	}
+}

--- a/lib/gdi/drawing.h
+++ b/lib/gdi/drawing.h
@@ -1,0 +1,67 @@
+/*
+Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License
+
+Copyright (c) 2023-2024 openATV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+1. Non-Commercial Use: You may not use the Software or any derivative works
+   for commercial purposes without obtaining explicit permission from the
+   copyright holder.
+2. Share Alike: If you distribute or publicly perform the Software or any
+   derivative works, you must do so under the same license terms, and you
+   must make the source code of any derivative works available to the
+   public.
+3. Attribution: You must give appropriate credit to the original author(s)
+   of the Software by including a prominent notice in your derivative works.
+THE SOFTWARE IS PROVIDED "AS IS," WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE,
+ARISING FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more details about the CC BY-NC-SA 4.0 License, please visit:
+https://creativecommons.org/licenses/by-nc-sa/4.0/
+*/
+
+#ifndef __drawing__
+#define __drawing__
+
+#include "gpixmap.h"
+#include <vector>
+
+void duplicate_32fc(uint32_t *out, const uint32_t in, size_t size);
+uint32_t *createGradientBuffer2(int graSize, const gRGB &startColor, const gRGB &endColor);
+uint32_t *createGradientBuffer3(int graSize, const std::vector<gRGB> &colors);
+void drawAngleTl(gUnmanagedSurface *surface, const uint32_t *src, const eRect &area, uint8_t direction, const eRect &cornerRect, const CornerData &cornerData);
+void drawAngleTr(gUnmanagedSurface *surface, const uint32_t *src, const eRect &area, uint8_t direction, const eRect &cornerRect, const CornerData &cornerData);
+void drawAngleBl(gUnmanagedSurface *surface, const uint32_t *src, const eRect &area, uint8_t direction, const eRect &cornerRect, const CornerData &cornerData);
+void drawAngleBr(gUnmanagedSurface *surface, const uint32_t *src, const eRect &area, uint8_t direction, const eRect &cornerRect, const CornerData &cornerData);
+
+void drawAngle32Tl(gUnmanagedSurface *surface, const gPixmap &pixmap, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag);
+void drawAngle32Tr(gUnmanagedSurface *surface, const gPixmap &pixmap, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag);
+void drawAngle32Bl(gUnmanagedSurface *surface, const gPixmap &pixmap, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag);
+void drawAngle32Br(gUnmanagedSurface *surface, const gPixmap &pixmap, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag);
+
+void drawAngle32ScaledTl(gUnmanagedSurface *surface, const gPixmap &pixmap, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag);
+void drawAngle32ScaledTr(gUnmanagedSurface *surface, const gPixmap &pixmap, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag);
+void drawAngle32ScaledBl(gUnmanagedSurface *surface, const gPixmap &pixmap, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag);
+void drawAngle32ScaledBr(gUnmanagedSurface *surface, const gPixmap &pixmap, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag);
+
+void drawAngle8Tl(gUnmanagedSurface *surface, const gPixmap &pixmap, const uint32_t *pal, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag);
+void drawAngle8Tr(gUnmanagedSurface *surface, const gPixmap &pixmap, const uint32_t *pal, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag);
+void drawAngle8Bl(gUnmanagedSurface *surface, const gPixmap &pixmap, const uint32_t *pal, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag);
+void drawAngle8Br(gUnmanagedSurface *surface, const gPixmap &pixmap, const uint32_t *pal, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag);
+
+void drawAngle8ScaledTl(gUnmanagedSurface *surface, const gPixmap &pixmap, const uint32_t *pal, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag);
+void drawAngle8ScaledTr(gUnmanagedSurface *surface, const gPixmap &pixmap, const uint32_t *pal, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag);
+void drawAngle8ScaledBl(gUnmanagedSurface *surface, const gPixmap &pixmap, const uint32_t *pal, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag);
+void drawAngle8ScaledBr(gUnmanagedSurface *surface, const gPixmap &pixmap, const uint32_t *pal, const eRect &area, const eRect &cornerRect, const CornerData &cornerData, int flag);
+
+#endif

--- a/lib/gdi/gpixmap.h
+++ b/lib/gdi/gpixmap.h
@@ -9,6 +9,7 @@
 #include <lib/gdi/erect.h>
 #include <lib/gdi/fb.h>
 #include <byteswap.h>
+#include <unordered_map>
 
 struct gRGB
 {
@@ -164,6 +165,7 @@ struct gUnmanagedSurface
 	gPalette clut;
 	void *data;
 	int data_phys;
+	bool transparent = true;
 
 	gUnmanagedSurface();
 	gUnmanagedSurface(int width, int height, int bpp);
@@ -202,6 +204,14 @@ public:
 		blitVAlignBottom = 128
 	};
 
+	enum
+	{
+		RADIUS_TOP_LEFT = 1,
+		RADIUS_TOP_RIGHT = 2,
+		RADIUS_BOTTOM_LEFT = 4,
+		RADIUS_BOTTOM_RIGHT = 8,
+	};
+
 	enum {
 		accelNever = -1,
 		accelAuto = 0,
@@ -228,13 +238,140 @@ private:
 	void fill(const gRegion &clip, const gColor &color);
 	void fill(const gRegion &clip, const gRGB &color);
 
-	void blit(const gPixmap &src, const eRect &pos, const gRegion &clip, int flags=0);
+	void blit(const gPixmap &src, const eRect &pos, const gRegion &clip, int cornerRadius, int edges, int flags=0);
+
+    void blitRounded32Bit(const gPixmap &src, const eRect &pos, const eRect &clip, int cornerRadius, int edges, int flag);
+    void blitRounded32BitScaled(const gPixmap &src, const eRect &pos, const eRect &clip, int cornerRadius, int edges, int flag);
+    void blitRounded8Bit(const gPixmap &src, const eRect &pos, const eRect &clip, int cornerRadius, int edges, int flag);
+    void blitRounded8BitScaled(const gPixmap &src, const eRect &pos, const eRect &clip, int cornerRadius, int edges, int flag);
 
 	void mergePalette(const gPixmap &target);
 	void line(const gRegion &clip, ePoint start, ePoint end, gColor color);
 	void line(const gRegion &clip, ePoint start, ePoint end, gRGB color);
 	void line(const gRegion &clip, ePoint start, ePoint end, unsigned int color);
+
+	void drawRectangle(const gRegion &region, const eRect &area, const gRGB &backgroundColor, const gRGB &borderColor, int borderWidth, const std::vector<gRGB> &gradientColors, uint8_t direction, int radius, uint8_t edges, bool alphablend, int gradientFullSize = 0);
 };
 SWIG_TEMPLATE_TYPEDEF(ePtr<gPixmap>, gPixmapPtr);
+
+
+#ifndef SWIG
+struct CornerData
+{
+	int width;
+	int height;
+	int topLeftCornerRadius;
+	int topLeftCornerSRadius;
+	int topLeftCornerDRadius;
+	int topRightCornerRadius;
+	int topRightCornerSRadius;
+	int topRightCornerDRadius;
+	int bottomLeftCornerRadius;
+	int bottomLeftCornerSRadius;
+	int bottomLeftCornerDRadius;
+	int bottomRightCornerRadius;
+	int bottomRightCornerSRadius;
+	int bottomRightCornerDRadius;
+	int borderWidth;
+	int cornerRadius;
+	int w_topRightCornerRadius;
+	int h_bottomLeftCornerRadius;
+	int w_bottomRightCornerRadius;
+	int h_bottomRightCornerRadius;
+	uint32_t borderCol;
+
+	bool radiusSet = false;
+	bool isCircle = false;
+
+	std::unordered_map<int, double> RadiusData;
+
+	CornerData(int radius, uint8_t edges, int h, int w, int bw, uint32_t borderColor)
+	{
+		cornerRadius = checkRadiusValue(radius, h, w);
+		radiusSet = cornerRadius > 0;
+		topLeftCornerRadius = (gPixmap::RADIUS_TOP_LEFT & edges) ? cornerRadius: 0;
+		topRightCornerRadius = (gPixmap::RADIUS_TOP_RIGHT & edges) ? cornerRadius: 0;
+		bottomLeftCornerRadius = (gPixmap::RADIUS_BOTTOM_LEFT & edges) ? cornerRadius: 0;
+		bottomRightCornerRadius = (gPixmap::RADIUS_BOTTOM_RIGHT & edges) ? cornerRadius: 0;
+		topLeftCornerSRadius = topLeftCornerRadius * topLeftCornerRadius;
+		topLeftCornerDRadius = (topLeftCornerRadius - 1) * (topLeftCornerRadius - 1);
+		topRightCornerSRadius = topRightCornerRadius * topRightCornerRadius;
+		topRightCornerDRadius = (topRightCornerRadius - 1) * (topRightCornerRadius - 1);
+		bottomLeftCornerSRadius = bottomLeftCornerRadius * bottomLeftCornerRadius;
+		bottomLeftCornerDRadius = (bottomLeftCornerRadius - 1) * (bottomLeftCornerRadius - 1);
+		bottomRightCornerSRadius = bottomRightCornerRadius * bottomRightCornerRadius;
+		bottomRightCornerDRadius = (bottomRightCornerRadius - 1) * (bottomRightCornerRadius - 1);
+		width = h;
+		height = w;
+		borderWidth = bw;
+		borderCol = borderColor;
+
+		w_topRightCornerRadius = w - topRightCornerRadius;
+		if(width > height)
+			w_topRightCornerRadius += (width - height);
+		else if (height > width)
+			w_topRightCornerRadius -= (height - width);
+
+		h_bottomLeftCornerRadius = h - bottomLeftCornerRadius;
+		if(width > height)
+			h_bottomLeftCornerRadius -= (width - height);
+		else if (height > width)
+			h_bottomLeftCornerRadius += (height - width);
+
+		w_bottomRightCornerRadius = w - bottomRightCornerRadius;
+		if(width > height)
+			w_bottomRightCornerRadius += (width - height);
+		else if (height > width)
+			w_bottomRightCornerRadius -= (height - width);
+
+		h_bottomRightCornerRadius = h - bottomRightCornerRadius;
+		if(width > height)
+			h_bottomRightCornerRadius -= (width - height);
+		else if (height > width)
+			h_bottomRightCornerRadius += (height - width);
+
+		isCircle = ((edges == 15) && (width == height) && (cornerRadius == width / 2));
+		caclCornerAlpha();
+	}
+
+	int checkRadiusValue(int r, const int w, const int h)
+	{
+		int minDimension = (w < h) ? w : h;
+		if (r > minDimension / 2) {
+			r = minDimension / 2;
+		}
+		return r;
+	}
+
+	void caclCornerAlpha()
+	{
+		int dx = 0, dy = 0, squared_dst = 0;
+		double alpha = 0.0, distance = 0.0;
+		int r = cornerRadius;
+		for (int y = 0; y < r; y++)
+		{
+			for (int x = 0; x < r; x++)
+			{
+				dx = r - x - 1;
+				dy = r - y - 1;
+				squared_dst = dx * dx + dy * dy;
+				if (squared_dst <= (r - 1) * (r - 1))
+					continue;
+				else if (squared_dst >= r * r)
+					continue;
+				else
+				{
+					if (RadiusData.find(squared_dst) == RadiusData.end())
+					{
+						distance = sqrt(squared_dst);
+						alpha = (r - distance);
+						RadiusData[squared_dst] = alpha;
+					}
+				}
+			}
+		}
+	}
+};
+#endif
 
 #endif

--- a/lib/gdi/grc.cpp
+++ b/lib/gdi/grc.cpp
@@ -419,10 +419,6 @@ void gPainter::renderText(const eRect &pos, const std::string &string, int flags
 	o.parm.renderText->flags = flags;
 	o.parm.renderText->border = border;
 	o.parm.renderText->bordercolor = bordercolor;
-	o.parm.renderText->markedpos = markedpos;
-	o.parm.renderText->offset = offset;
-	if (markedpos >= 0)
-		o.parm.renderText->scrollpos = eConfigManager::getConfigIntValue("config.usage.cursorscroll");
 	m_rc->submit(o);
 }
 

--- a/lib/gdi/grc.cpp
+++ b/lib/gdi/grc.cpp
@@ -1,24 +1,31 @@
 #include <unistd.h>
+#include <fstream>
 #include <lib/gdi/grc.h>
 #include <lib/gdi/font.h>
 #include <lib/base/init.h>
 #include <lib/base/init_num.h>
+#ifdef USE_LIBVUGLES2
+#include <vuplus_gles.h>
+#endif
+
 
 #ifndef SYNC_PAINT
 void *gRC::thread_wrapper(void *ptr)
 {
-	return ((gRC*)ptr)->thread();
+	return ((gRC *)ptr)->thread();
 }
 #endif
 
-gRC *gRC::instance=0;
+gRC *gRC::instance = 0;
 
-gRC::gRC(): rp(0), wp(0)
+gRC::gRC() : rp(0), wp(0)
 #ifdef SYNC_PAINT
 ,m_notify_pump(eApp, 0)
 #else
 ,m_notify_pump(eApp, 1)
 #endif
+			 ,
+			 m_spinner_enabled(0), m_spinneronoff(1), m_prev_idle_count(0) // NOSONAR
 {
 	ASSERT(!instance);
 	instance=this;
@@ -31,67 +38,80 @@ gRC::gRC(): rp(0), wp(0)
 	pthread_cond_init(&cond, 0);
 	pthread_attr_t attr;
 	pthread_attr_init(&attr);
-	if (pthread_attr_setstacksize(&attr, 2048*1024) != 0)
-		eDebug("[gRC] pthread_attr_setstacksize failed");
+	if (pthread_attr_setstacksize(&attr, 2048 * 1024) != 0)
+		eDebug("[gRC] Error: pthread_attr_setstacksize failed!");
 	int res = pthread_create(&the_thread, &attr, thread_wrapper, this);
 	pthread_attr_destroy(&attr);
 	if (res)
-		eFatal("[gRC] thread couldn't be created");
+		eFatal("[gRC] Error: Thread couldn't be created!");
 	else
-		eDebug("[gRC] thread created successfully");
+		eDebug("[gRC] Thread created successfully.");
 #endif
-	m_spinner_enabled = 0;
-	m_spinneronoff = 1;
 }
+
+#ifdef CONFIG_ION
+void gRC::lock()
+{
+#ifndef SYNC_PAINT
+	pthread_mutex_lock(&mutex);
+#endif
+}
+
+void gRC::unlock()
+{
+#ifndef SYNC_PAINT
+	pthread_mutex_unlock(&mutex);
+#endif
+}
+#endif
 
 DEFINE_REF(gRC);
 
 gRC::~gRC()
 {
-	instance=0;
-
+	instance = 0;
 	gOpcode o;
-	o.opcode=gOpcode::shutdown;
+	o.opcode = gOpcode::shutdown;
 	submit(o);
 #ifndef SYNC_PAINT
-	eDebug("[gRC] waiting for gRC thread shutdown");
+	eDebug("[gRC] Waiting for gRC thread shutdown.");
 	pthread_join(the_thread, 0);
-	eDebug("[gRC] thread has finished");
+	eDebug("[gRC] Thread has finished.");
 #endif
 }
 
 void gRC::submit(const gOpcode &o)
 {
-	while(1)
+	while (1)
 	{
 #ifndef SYNC_PAINT
 		pthread_mutex_lock(&mutex);
 #endif
-		int tmp=wp+1;
-		if ( tmp == MAXSIZE )
-			tmp=0;
-		if ( tmp == rp )
+		int tmp = wp + 1;
+		if (tmp == MAXSIZE)
+			tmp = 0;
+		if (tmp == rp)
 		{
 #ifndef SYNC_PAINT
-			pthread_cond_signal(&cond);  // wakeup gdi thread
+			pthread_cond_signal(&cond); // wakeup gdi thread
 			pthread_mutex_unlock(&mutex);
 #else
 			thread();
 #endif
-			//eDebug("[gRC] render buffer full...");
-			//fflush(stdout);
-			usleep(1000);  // wait 1 msec
+			// eDebug("[gRC] Render buffer full.");
+			// fflush(stdout);
+			usleep(1000); // wait 1 msec
 			continue;
 		}
-		int free=rp-wp;
-		if ( free <= 0 )
-			free+=MAXSIZE;
-		queue[wp++]=o;
-		if ( wp == MAXSIZE )
+		int free = rp - wp;
+		if (free <= 0)
+			free += MAXSIZE;
+		queue[wp++] = o;
+		if (wp == MAXSIZE)
 			wp = 0;
-		if (o.opcode==gOpcode::flush||o.opcode==gOpcode::shutdown||o.opcode==gOpcode::notify)
+		if (o.opcode == gOpcode::flush || o.opcode == gOpcode::shutdown || o.opcode == gOpcode::notify)
 #ifndef SYNC_PAINT
-			pthread_cond_signal(&cond);  // wakeup gdi thread
+			pthread_cond_signal(&cond); // wakeup gdi thread
 		pthread_mutex_unlock(&mutex);
 #else
 			thread(); // paint
@@ -103,6 +123,13 @@ void gRC::submit(const gOpcode &o)
 void *gRC::thread()
 {
 	int need_notify = 0;
+#ifdef USE_LIBVUGLES2
+	if (gles_open())
+	{
+		gles_state_open();
+		gles_viewport(720, 576, 720 * 4);
+	}
+#endif
 #ifndef SYNC_PAINT
 	while (1)
 	{
@@ -113,26 +140,27 @@ void *gRC::thread()
 #ifndef SYNC_PAINT
 		pthread_mutex_lock(&mutex);
 #endif
-		if ( rp != wp )
+		if (rp != wp)
 		{
-				/* make sure the spinner is not displayed when something is painted */
+			/* make sure the spinner is not displayed when something is painted */
 			disableSpinner();
 
 			gOpcode o(queue[rp++]);
-			if ( rp == MAXSIZE )
-				rp=0;
+			if (rp == MAXSIZE)
+				rp = 0;
 #ifndef SYNC_PAINT
 			pthread_mutex_unlock(&mutex);
 #endif
-			if (o.opcode==gOpcode::shutdown)
+			if (o.opcode == gOpcode::shutdown)
 				break;
-			else if (o.opcode==gOpcode::notify)
+			else if (o.opcode == gOpcode::notify)
 				need_notify = 1;
-			else if (o.opcode==gOpcode::setCompositing)
+			else if (o.opcode == gOpcode::setCompositing)
 			{
 				m_compositing = o.parm.setCompositing;
 				m_compositing->Release();
-			} else if(o.dc)
+			}
+			else if (o.dc)
 			{
 				o.dc->exec(&o);
 				// o.dc is a gDC* filled with grabref... so we must release it here
@@ -147,21 +175,21 @@ void *gRC::thread()
 				m_notify_pump.send(1);
 			}
 #ifndef SYNC_PAINT
-			while(rp == wp)
+			while (rp == wp)
 			{
 
-					/* when the main thread is non-idle for a too long time without any display output,
-					   we want to display a spinner. */
-				struct timespec timeout = {};
+				/* when the main thread is non-idle for a too long time without any display output,
+				   we want to display a spinner. */
+				struct timespec timeout;
 				clock_gettime(CLOCK_REALTIME, &timeout);
 
 				if (m_spinner_enabled)
 				{
-					timeout.tv_nsec += 100*1000*1000;
+					timeout.tv_nsec += 100 * 1000 * 1000;
 					/* yes, this is required. */
-					if (timeout.tv_nsec > 1000*1000*1000)
+					if (timeout.tv_nsec > 1000 * 1000 * 1000)
 					{
-						timeout.tv_nsec -= 1000*1000*1000;
+						timeout.tv_nsec -= 1000 * 1000 * 1000;
 						timeout.tv_sec++;
 					}
 				}
@@ -185,9 +213,14 @@ void *gRC::thread()
 				if (!idle)
 				{
 					if (!m_spinner_enabled)
-						eDebug("[gRC] main thread is non-idle! display spinner!");
+					{
+						eDebug("[gRC] Warning: Main thread is busy, displaying spinner!");
+						std::ofstream dummy("/tmp/doPythonStackTrace");
+						dummy.close();
+					}
 					enableSpinner();
-				} else
+				}
+				else
 					disableSpinner();
 			}
 			pthread_mutex_unlock(&mutex);
@@ -214,7 +247,7 @@ void gRC::enableSpinner()
 {
 	if (!m_spinner_dc)
 	{
-		eDebug("[gRC] enabelSpinner: no spinner DC!");
+		eDebug("[gRC] enableSpinner Error: No spinner DC!");
 		return;
 	}
 
@@ -236,7 +269,7 @@ void gRC::disableSpinner()
 
 	if (!m_spinner_dc)
 	{
-		eDebug("[gRC] disableSpinner: no spinner DC!");
+		eDebug("[gRC] disableSpinner Error: No spinner DC!");
 		return;
 	}
 
@@ -251,11 +284,11 @@ void gRC::disableSpinner()
 
 static int gPainter_instances;
 
-gPainter::gPainter(gDC *dc, eRect rect): m_dc(dc), m_rc(gRC::getInstance())
+gPainter::gPainter(gDC *dc, eRect rect) : m_dc(dc), m_rc(gRC::getInstance())
 {
-//	ASSERT(!gPainter_instances);
+	//	ASSERT(!gPainter_instances);
 	gPainter_instances++;
-//	begin(rect);
+	//	begin(rect);
 }
 
 gPainter::~gPainter()
@@ -266,7 +299,7 @@ gPainter::~gPainter()
 
 void gPainter::setBackgroundColor(const gColor &color)
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
 	o.opcode = gOpcode::setBackgroundColor;
@@ -279,7 +312,7 @@ void gPainter::setBackgroundColor(const gColor &color)
 
 void gPainter::setForegroundColor(const gColor &color)
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
 	o.opcode = gOpcode::setForegroundColor;
@@ -292,7 +325,7 @@ void gPainter::setForegroundColor(const gColor &color)
 
 void gPainter::setBackgroundColor(const gRGB &color)
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
 	o.opcode = gOpcode::setBackgroundColorRGB;
@@ -305,7 +338,7 @@ void gPainter::setBackgroundColor(const gRGB &color)
 
 void gPainter::setForegroundColor(const gRGB &color)
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
 	o.opcode = gOpcode::setForegroundColorRGB;
@@ -316,9 +349,50 @@ void gPainter::setForegroundColor(const gRGB &color)
 	m_rc->submit(o);
 }
 
+void gPainter::setGradient(const std::vector<gRGB> &colors, uint8_t orientation, bool alphablend, int fullSize)
+{
+	if (m_dc->islocked())
+		return;
+	gOpcode o;
+	o.opcode = gOpcode::setGradient;
+	o.dc = m_dc.grabRef();
+	o.parm.gradient = new gOpcode::para::pgradient;
+	o.parm.gradient->colors = colors;
+	o.parm.gradient->orientation = orientation;
+	o.parm.gradient->alphablend = alphablend;
+	o.parm.gradient->fullSize = fullSize;
+	m_rc->submit(o);
+}
+
+void gPainter::setRadius(int radius, uint8_t edges)
+{
+	if (m_dc->islocked())
+		return;
+	gOpcode o;
+	o.opcode = gOpcode::setRadius;
+	o.dc = m_dc.grabRef();
+	o.parm.radius = new gOpcode::para::pradius;
+	o.parm.radius->radius = radius;
+	o.parm.radius->edges = edges;
+	m_rc->submit(o);
+}
+
+void gPainter::setBorder(const gRGB &borderColor, int width)
+{
+	if (m_dc->islocked())
+		return;
+	gOpcode o;
+	o.opcode = gOpcode::setBorder;
+	o.dc = m_dc.grabRef();
+	o.parm.border = new gOpcode::para::pborder;
+	o.parm.border->color = borderColor;
+	o.parm.border->width = width;
+	m_rc->submit(o);
+}
+
 void gPainter::setFont(gFont *font)
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
 	o.opcode = gOpcode::setFont;
@@ -330,13 +404,14 @@ void gPainter::setFont(gFont *font)
 	m_rc->submit(o);
 }
 
-void gPainter::renderText(const eRect &pos, const std::string &string, int flags, gRGB bordercolor, int border)
+void gPainter::renderText(const eRect &pos, const std::string &string, int flags, gRGB bordercolor, int border, int markedpos, int *offset)
 {
-	if (string.empty()) return;
-	if ( m_dc->islocked() )
+	if (string.empty())
+		return;
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
-	o.opcode=gOpcode::renderText;
+	o.opcode = gOpcode::renderText;
 	o.dc = m_dc.grabRef();
 	o.parm.renderText = new gOpcode::para::prenderText;
 	o.parm.renderText->area = pos;
@@ -344,31 +419,35 @@ void gPainter::renderText(const eRect &pos, const std::string &string, int flags
 	o.parm.renderText->flags = flags;
 	o.parm.renderText->border = border;
 	o.parm.renderText->bordercolor = bordercolor;
+	o.parm.renderText->markedpos = markedpos;
+	o.parm.renderText->offset = offset;
+	if (markedpos >= 0)
+		o.parm.renderText->scrollpos = eConfigManager::getConfigIntValue("config.usage.cursorscroll");
 	m_rc->submit(o);
 }
 
 void gPainter::renderPara(eTextPara *para, ePoint offset)
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	ASSERT(para);
 	gOpcode o;
-	o.opcode=gOpcode::renderPara;
+	o.opcode = gOpcode::renderPara;
 	o.dc = m_dc.grabRef();
 	o.parm.renderPara = new gOpcode::para::prenderPara;
 	o.parm.renderPara->offset = offset;
 
- 	para->AddRef();
+	para->AddRef();
 	o.parm.renderPara->textpara = para;
 	m_rc->submit(o);
 }
 
 void gPainter::fill(const eRect &area)
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
-	o.opcode=gOpcode::fill;
+	o.opcode = gOpcode::fill;
 
 	o.dc = m_dc.grabRef();
 	o.parm.fill = new gOpcode::para::pfillRect;
@@ -378,10 +457,10 @@ void gPainter::fill(const eRect &area)
 
 void gPainter::fill(const gRegion &region)
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
-	o.opcode=gOpcode::fillRegion;
+	o.opcode = gOpcode::fillRegion;
 
 	o.dc = m_dc.grabRef();
 	o.parm.fillRegion = new gOpcode::para::pfillRegion;
@@ -391,10 +470,10 @@ void gPainter::fill(const gRegion &region)
 
 void gPainter::clear()
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
-	o.opcode=gOpcode::clear;
+	o.opcode = gOpcode::clear;
 	o.dc = m_dc.grabRef();
 	o.parm.fill = new gOpcode::para::pfillRect;
 	o.parm.fill->area = eRect();
@@ -413,16 +492,16 @@ void gPainter::blit(gPixmap *pixmap, ePoint pos, const eRect &clip, int flags)
 
 void gPainter::blit(gPixmap *pixmap, const eRect &pos, const eRect &clip, int flags)
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
 
 	ASSERT(pixmap);
 
-	o.opcode=gOpcode::blit;
+	o.opcode = gOpcode::blit;
 	o.dc = m_dc.grabRef();
 	pixmap->AddRef();
-	o.parm.blit  = new gOpcode::para::pblit;
+	o.parm.blit = new gOpcode::para::pblit;
 	o.parm.blit->pixmap = pixmap;
 	o.parm.blit->clip = clip;
 	o.parm.blit->flags = flags;
@@ -430,24 +509,35 @@ void gPainter::blit(gPixmap *pixmap, const eRect &pos, const eRect &clip, int fl
 	m_rc->submit(o);
 }
 
+void gPainter::drawRectangle(const eRect &area) {
+	if ( m_dc->islocked() )
+		return;
+	gOpcode o;
+	o.opcode=gOpcode::rectangle;
+	o.dc = m_dc.grabRef();
+	o.parm.rectangle = new gOpcode::para::prectangle;
+	o.parm.rectangle->area = area;
+	m_rc->submit(o);
+}
+
 void gPainter::setPalette(gRGB *colors, int start, int len)
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	if (len <= 0)
 		return;
 	ASSERT(colors);
 	gOpcode o;
-	o.opcode=gOpcode::setPalette;
+	o.opcode = gOpcode::setPalette;
 	o.dc = m_dc.grabRef();
-	gPalette *p=new gPalette;
+	gPalette *p = new gPalette;
 
 	o.parm.setPalette = new gOpcode::para::psetPalette;
-	p->data=new gRGB[static_cast<size_t>(len)];
+	p->data = new gRGB[static_cast<size_t>(len)];
 
-	memcpy(static_cast<void*>(p->data), colors, len*sizeof(gRGB));
-	p->start=start;
-	p->colors=len;
+	memcpy(static_cast<void *>(p->data), colors, len * sizeof(gRGB));
+	p->start = start;
+	p->colors = len;
 	o.parm.setPalette->palette = p;
 	m_rc->submit(o);
 }
@@ -460,7 +550,7 @@ void gPainter::setPalette(gPixmap *source)
 
 void gPainter::mergePalette(gPixmap *target)
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	ASSERT(target);
 	gOpcode o;
@@ -474,10 +564,10 @@ void gPainter::mergePalette(gPixmap *target)
 
 void gPainter::line(ePoint start, ePoint end)
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
-	o.opcode=gOpcode::line;
+	o.opcode = gOpcode::line;
 	o.dc = m_dc.grabRef();
 	o.parm.line = new gOpcode::para::pline;
 	o.parm.line->start = start;
@@ -487,10 +577,10 @@ void gPainter::line(ePoint start, ePoint end)
 
 void gPainter::setOffset(ePoint val)
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
-	o.opcode=gOpcode::setOffset;
+	o.opcode = gOpcode::setOffset;
 	o.dc = m_dc.grabRef();
 	o.parm.setOffset = new gOpcode::para::psetOffset;
 	o.parm.setOffset->rel = 0;
@@ -500,10 +590,10 @@ void gPainter::setOffset(ePoint val)
 
 void gPainter::moveOffset(ePoint rel)
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
-	o.opcode=gOpcode::setOffset;
+	o.opcode = gOpcode::setOffset;
 	o.dc = m_dc.grabRef();
 	o.parm.setOffset = new gOpcode::para::psetOffset;
 	o.parm.setOffset->rel = 1;
@@ -513,10 +603,10 @@ void gPainter::moveOffset(ePoint rel)
 
 void gPainter::resetOffset()
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
-	o.opcode=gOpcode::setOffset;
+	o.opcode = gOpcode::setOffset;
 	o.dc = m_dc.grabRef();
 	o.parm.setOffset = new gOpcode::para::psetOffset;
 	o.parm.setOffset->rel = 0;
@@ -526,7 +616,7 @@ void gPainter::resetOffset()
 
 void gPainter::resetClip(const gRegion &region)
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
 	o.opcode = gOpcode::setClip;
@@ -538,7 +628,7 @@ void gPainter::resetClip(const gRegion &region)
 
 void gPainter::clip(const gRegion &region)
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
 	o.opcode = gOpcode::addClip;
@@ -550,7 +640,7 @@ void gPainter::clip(const gRegion &region)
 
 void gPainter::clippop()
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
 	o.opcode = gOpcode::popClip;
@@ -560,7 +650,7 @@ void gPainter::clippop()
 
 void gPainter::waitVSync()
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
 	o.opcode = gOpcode::waitVSync;
@@ -570,7 +660,7 @@ void gPainter::waitVSync()
 
 void gPainter::flip()
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
 	o.opcode = gOpcode::flip;
@@ -580,7 +670,7 @@ void gPainter::flip()
 
 void gPainter::notify()
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
 	o.opcode = gOpcode::notify;
@@ -600,7 +690,7 @@ void gPainter::setCompositing(gCompositingData *comp)
 
 void gPainter::flush()
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 	gOpcode o;
 	o.opcode = gOpcode::flush;
@@ -610,16 +700,85 @@ void gPainter::flush()
 
 void gPainter::end()
 {
-	if ( m_dc->islocked() )
+	if (m_dc->islocked())
 		return;
 }
+
+void gPainter::sendShow(ePoint point, eSize size)
+{
+	if (m_dc->islocked())
+		return;
+	gOpcode o;
+	o.opcode = gOpcode::sendShow;
+	o.dc = m_dc.grabRef();
+	o.parm.setShowHideInfo = new gOpcode::para::psetShowHideInfo;
+	o.parm.setShowHideInfo->point = point;
+	o.parm.setShowHideInfo->size = size;
+	m_rc->submit(o);
+}
+
+void gPainter::sendHide(ePoint point, eSize size)
+{
+	if (m_dc->islocked())
+		return;
+	gOpcode o;
+	o.opcode = gOpcode::sendHide;
+	o.dc = m_dc.grabRef();
+	o.parm.setShowHideInfo = new gOpcode::para::psetShowHideInfo;
+	o.parm.setShowHideInfo->point = point;
+	o.parm.setShowHideInfo->size = size;
+	m_rc->submit(o);
+}
+#ifdef USE_LIBVUGLES2
+void gPainter::sendShowItem(long dir, ePoint point, eSize size)
+{
+	if (m_dc->islocked())
+		return;
+	gOpcode o;
+	o.opcode = gOpcode::sendShowItem;
+	o.dc = m_dc.grabRef();
+	o.parm.setShowItemInfo = new gOpcode::para::psetShowItemInfo;
+	o.parm.setShowItemInfo->dir = dir;
+	o.parm.setShowItemInfo->point = point;
+	o.parm.setShowItemInfo->size = size;
+	m_rc->submit(o);
+}
+void gPainter::setFlush(bool val)
+{
+	if (m_dc->islocked())
+		return;
+	gOpcode o;
+	o.opcode = gOpcode::setFlush;
+	o.dc = m_dc.grabRef();
+	o.parm.setFlush = new gOpcode::para::psetFlush;
+	o.parm.setFlush->enable = val;
+	m_rc->submit(o);
+}
+void gPainter::setView(eSize size)
+{
+	if (m_dc->islocked())
+		return;
+	gOpcode o;
+	o.opcode = gOpcode::setView;
+	o.dc = m_dc.grabRef();
+	o.parm.setViewInfo = new gOpcode::para::psetViewInfo;
+	o.parm.setViewInfo->size = size;
+	m_rc->submit(o);
+}
+#endif
 
 gDC::gDC()
 {
 	m_spinner_pic = 0;
+	m_border_width = 0;
+	m_radius = 0;
+	m_radius_edges = 0;
+	m_gradient_orientation = 0;
+	m_gradient_alphablend = false;
+	m_gradient_fullSize = 0;
 }
 
-gDC::gDC(gPixmap *pixmap): m_pixmap(pixmap)
+gDC::gDC(gPixmap *pixmap) : m_pixmap(pixmap)
 {
 	m_spinner_pic = 0;
 }
@@ -660,13 +819,64 @@ void gDC::exec(const gOpcode *o)
 		o->parm.setFont->font->Release();
 		delete o->parm.setFont;
 		break;
+	case gOpcode::setGradient:
+		m_gradient_colors = o->parm.gradient->colors;
+		m_gradient_orientation = o->parm.gradient->orientation;
+		m_gradient_alphablend = o->parm.gradient->alphablend;
+		m_gradient_fullSize = o->parm.gradient->fullSize;
+		delete o->parm.gradient;
+		break;
+	case gOpcode::setRadius:
+		m_radius = o->parm.radius->radius;
+		m_radius_edges = o->parm.radius->edges;
+		delete o->parm.radius;
+		break;
+	case gOpcode::setBorder:
+		m_border_color = o->parm.border->color;
+		m_border_width = o->parm.border->width;
+		delete o->parm.border;
+		break;
 	case gOpcode::renderText:
 	{
 		ePtr<eTextPara> para = new eTextPara(o->parm.renderText->area);
 		int flags = o->parm.renderText->flags;
+		int border = o->parm.renderText->border;
+		int markedpos = o->parm.renderText->markedpos;
+		int scrollpos = o->parm.renderText->scrollpos;
+		if (markedpos != -1)
+			border = 0;
 		ASSERT(m_current_font);
 		para->setFont(m_current_font);
+
+		if (flags & gPainter::RT_ELLIPSIS)
+		{
+			if (flags & gPainter::RT_WRAP) // Remove wrap
+				flags -= gPainter::RT_WRAP;
+			std::string text = o->parm.renderText->text;
+			text += u8"…";
+
+			eTextPara testpara(o->parm.renderText->area);
+			testpara.setFont(m_current_font);
+			testpara.renderString(text.c_str(), 0);
+			int bw = testpara.getBoundBox().width();
+			int w = o->parm.renderText->area.width();
+			if (bw > w) // Available space not fit
+			{
+				float pers = (float)w / (float)bw;
+				text = o->parm.renderText->text;
+				int ns = text.size() * pers;
+				if ((int)text.size() > ns)
+				{
+					text.resize(ns);
+					text += u8"…";
+				}
+				if (o->parm.renderText->text)
+					free(o->parm.renderText->text);
+				o->parm.renderText->text = strdup(text.c_str());
+			}
+		}
 		para->renderString(o->parm.renderText->text, (flags & gPainter::RT_WRAP) ? RS_WRAP : 0, o->parm.renderText->border);
+
 		if (o->parm.renderText->text)
 			free(o->parm.renderText->text);
 		if (flags & gPainter::RT_HALIGN_LEFT)
@@ -751,7 +961,7 @@ void gDC::exec(const gOpcode *o)
 	case gOpcode::blit:
 	{
 		gRegion clip;
-				// this code should be checked again but i'm too tired now
+		// this code should be checked again but i'm too tired now
 
 		o->parm.blit->position.moveBy(m_current_offset);
 
@@ -759,21 +969,39 @@ void gDC::exec(const gOpcode *o)
 		{
 			o->parm.blit->clip.moveBy(m_current_offset);
 			clip.intersect(gRegion(o->parm.blit->clip), m_current_clip);
-		} else
+		}
+		else
 			clip = m_current_clip;
-
-		m_pixmap->blit(*o->parm.blit->pixmap, o->parm.blit->position, clip, o->parm.blit->flags);
+		 if (!o->parm.blit->pixmap->surface->transparent)
+		 	o->parm.blit->flags &=~(gPixmap::blitAlphaTest|gPixmap::blitAlphaBlend);
+		m_pixmap->blit(*o->parm.blit->pixmap, o->parm.blit->position, clip, m_radius, m_radius_edges, o->parm.blit->flags);
+		m_radius = 0;
+		m_radius_edges = 0;
 		o->parm.blit->pixmap->Release();
 		delete o->parm.blit;
+		break;
+	}
+	case gOpcode::rectangle:
+	{
+		o->parm.rectangle->area.moveBy(m_current_offset);
+		gRegion clip = m_current_clip & o->parm.rectangle->area;
+		m_pixmap->drawRectangle(clip, o->parm.rectangle->area, m_background_color_rgb, m_border_color, m_border_width, m_gradient_colors, m_gradient_orientation, m_radius, m_radius_edges, m_gradient_alphablend, m_gradient_fullSize);
+		m_border_width = 0;
+		m_radius = 0;
+		m_radius_edges = 0;
+		m_gradient_orientation = 0;
+		m_gradient_fullSize = 0;
+		m_gradient_alphablend = false;
+		delete o->parm.rectangle;
 		break;
 	}
 	case gOpcode::setPalette:
 		if (o->parm.setPalette->palette->start > m_pixmap->surface->clut.colors)
 			o->parm.setPalette->palette->start = m_pixmap->surface->clut.colors;
-		if (o->parm.setPalette->palette->colors > (m_pixmap->surface->clut.colors-o->parm.setPalette->palette->start))
-			o->parm.setPalette->palette->colors = m_pixmap->surface->clut.colors-o->parm.setPalette->palette->start;
+		if (o->parm.setPalette->palette->colors > (m_pixmap->surface->clut.colors - o->parm.setPalette->palette->start))
+			o->parm.setPalette->palette->colors = m_pixmap->surface->clut.colors - o->parm.setPalette->palette->start;
 		if (o->parm.setPalette->palette->colors)
-			memcpy(static_cast<void*>(m_pixmap->surface->clut.data+o->parm.setPalette->palette->start), o->parm.setPalette->palette->data, o->parm.setPalette->palette->colors*sizeof(gRGB));
+			memcpy(static_cast<void *>(m_pixmap->surface->clut.data + o->parm.setPalette->palette->start), o->parm.setPalette->palette->data, o->parm.setPalette->palette->colors * sizeof(gRGB));
 
 		delete[] o->parm.setPalette->palette->data;
 		delete o->parm.setPalette->palette;
@@ -816,7 +1044,7 @@ void gDC::exec(const gOpcode *o)
 		if (o->parm.setOffset->rel)
 			m_current_offset += o->parm.setOffset->value;
 		else
-			m_current_offset  = o->parm.setOffset->value;
+			m_current_offset = o->parm.setOffset->value;
 		delete o->parm.setOffset;
 		break;
 	case gOpcode::waitVSync:
@@ -825,6 +1053,18 @@ void gDC::exec(const gOpcode *o)
 		break;
 	case gOpcode::flush:
 		break;
+	case gOpcode::sendShow:
+		break;
+	case gOpcode::sendHide:
+		break;
+#ifdef USE_LIBVUGLES2
+	case gOpcode::sendShowItem:
+		break;
+	case gOpcode::setFlush:
+		break;
+	case gOpcode::setView:
+		break;
+#endif
 	case gOpcode::enableSpinner:
 		enableSpinner();
 		break;
@@ -835,7 +1075,7 @@ void gDC::exec(const gOpcode *o)
 		incrementSpinner();
 		break;
 	default:
-		eFatal("[gDC] illegal opcode %d. expect memory leak!", o->opcode);
+		eFatal("[gRC] gDC Error: Illegal opcode %d, expect memory leak!", o->opcode);
 	}
 }
 
@@ -843,9 +1083,9 @@ gRGB gDC::getRGB(gColor col)
 {
 	if ((!m_pixmap) || (!m_pixmap->surface->clut.data))
 		return gRGB(col, col, col);
-	if (col<0)
+	if (col < 0)
 	{
-		eFatal("[gDC] getRGB transp");
+		eFatal("[gRC] gDC Error: getRGB transp!");
 		return gRGB(0, 0, 0, 0xFF);
 	}
 	return m_pixmap->surface->clut.data[col];
@@ -855,8 +1095,8 @@ void gDC::enableSpinner()
 {
 	ASSERT(m_spinner_saved);
 
-		/* save the background to restore it later. We need to negative position because we want to blit from the middle of the screen. */
-	m_spinner_saved->blit(*m_pixmap, eRect(-m_spinner_pos.topLeft(), eSize()), gRegion(eRect(ePoint(0, 0), m_spinner_saved->size())), 0);
+	/* save the background to restore it later. We need to negative position because we want to blit from the middle of the screen. */
+	m_spinner_saved->blit(*m_pixmap, eRect(-m_spinner_pos.topLeft(), eSize()), gRegion(eRect(ePoint(0, 0), m_spinner_saved->size())), 0, 0 ,0);
 
 	incrementSpinner();
 }
@@ -865,8 +1105,8 @@ void gDC::disableSpinner()
 {
 	ASSERT(m_spinner_saved);
 
-		/* restore background */
-	m_pixmap->blit(*m_spinner_saved, eRect(m_spinner_pos.topLeft(), eSize()), gRegion(m_spinner_pos), 0);
+	/* restore background */
+	m_pixmap->blit(*m_spinner_saved, eRect(m_spinner_pos.topLeft(), eSize()), gRegion(m_spinner_pos), 0, 0, 0);
 }
 
 void gDC::incrementSpinner()
@@ -890,12 +1130,12 @@ void gDC::incrementSpinner()
 	}
 #endif
 
-	m_spinner_temp->blit(*m_spinner_saved, eRect(0, 0, 0, 0), eRect(ePoint(0, 0), m_spinner_pos.size()));
+	m_spinner_temp->blit(*m_spinner_saved, eRect(0, 0, 0, 0), eRect(ePoint(0, 0), m_spinner_pos.size()), 0, 0, 0);
 
 	if (m_spinner_pic[m_spinner_i])
-		m_spinner_temp->blit(*m_spinner_pic[m_spinner_i], eRect(0, 0, 0, 0), eRect(ePoint(0, 0), m_spinner_pos.size()), gPixmap::blitAlphaTest);
+		m_spinner_temp->blit(*m_spinner_pic[m_spinner_i], eRect(0, 0, 0, 0), eRect(ePoint(0, 0), m_spinner_pos.size()), 0, 0, gPixmap::blitAlphaBlend);
 
-	m_pixmap->blit(*m_spinner_temp, eRect(m_spinner_pos.topLeft(), eSize()), gRegion(m_spinner_pos), 0);
+	m_pixmap->blit(*m_spinner_temp, eRect(m_spinner_pos.topLeft(), eSize()), gRegion(m_spinner_pos), 0, 0, 0);
 	m_spinner_i++;
 	m_spinner_i %= m_spinner_num;
 }

--- a/lib/gui/ewidget.h
+++ b/lib/gui/ewidget.h
@@ -48,6 +48,12 @@ public:
 	void setBackgroundColor(const gRGB &col);
 	void clearBackgroundColor();
 
+	void setBorderWidth(int pixel);
+	void setBorderColor(const gRGB &color);
+
+	void setWidgetBorderWidth(int pixel) { setBorderWidth(pixel); }
+	void setWidgetBorderColor(const gRGB &color) { setBorderColor(color); }
+
 	void setZPosition(int z);
 	void setTransparent(int transp);
 
@@ -97,6 +103,19 @@ private:
 	int m_z_position;
 	int m_lowered;
 	int m_notify_child_on_position_change;
+
+	bool m_gradient_set;
+	bool m_gradient_alphablend;
+	int m_gradient_direction;
+	gRGB m_gradient_startcolor, m_gradient_endcolor;
+
+	bool m_have_border_color;
+	int m_border_width;
+	gRGB m_border_color;
+
+	int m_cornerRadius;
+	int m_cornerRadiusEdges;
+
 protected:
 	void mayKillFocus();
 public:
@@ -132,6 +151,23 @@ public:
 	void setPositionNotifyChild(int n) { m_notify_child_on_position_change = 1; }
 
 	void notifyShowHide();
+
+	void setCornerRadius(int radius, int edges);
+	int getCornerRadiusEdges() {return m_cornerRadiusEdges;}
+	int getCornerRadius();
+
+	enum
+	{
+		RADIUS_TOP_LEFT = 1,
+		RADIUS_TOP_RIGHT = 2,
+		RADIUS_TOP = 3,
+		RADIUS_BOTTOM_LEFT = 4,
+		RADIUS_BOTTOM_RIGHT = 8,
+		RADIUS_BOTTOM = 12,
+		RADIUS_LEFT = 5,
+		RADIUS_RIGHT = 10,
+		RADIUS_ALL = 15,
+	};
 };
 
 extern eWidgetDesktop *getDesktop(int which);

--- a/lib/gui/ewidgetdesktop.cpp
+++ b/lib/gui/ewidgetdesktop.cpp
@@ -59,7 +59,7 @@ int eWidgetDesktop::movedWidget(eWidget *root)
 	return 0; /* native move ok */
 }
 
-void eWidgetDesktop::calcWidgetClipRegion(eWidget *widget, gRegion &parent_visible)
+void eWidgetDesktop::calcWidgetClipRegion(eWidget *widget, gRegion &parent_visible, bool parent)
 {
 		/* start with our clip region, clipped with the parent's */
 	if (widget->m_vis & eWidget::wVisShow)
@@ -68,7 +68,7 @@ void eWidgetDesktop::calcWidgetClipRegion(eWidget *widget, gRegion &parent_visib
 		widget->m_visible_region.moveBy(widget->position());
 		widget->m_visible_region &= parent_visible; // in parent space!
 
-		if (!widget->isTransparent())
+		if (!widget->isTransparent() && (widget->m_cornerRadius == 0 || parent))
 				/* remove everything this widget will contain from parent's visible list, unless widget is transparent. */
 			parent_visible -= widget->m_visible_region; // will remove child regions too!
 
@@ -87,7 +87,7 @@ void eWidgetDesktop::calcWidgetClipRegion(eWidget *widget, gRegion &parent_visib
 		if (i != widget->m_childs.end())
 		{
 			if (i->m_vis & eWidget::wVisShow)
-				calcWidgetClipRegion(*i, widget->m_visible_region);
+				calcWidgetClipRegion(*i, widget->m_visible_region, false);
 			else
 				clearVisibility(*i);
 		}

--- a/lib/gui/ewidgetdesktop.h
+++ b/lib/gui/ewidgetdesktop.h
@@ -78,7 +78,7 @@ public:
 	void setMargins(const eRect& value) { m_margins = value; }
 private:
 	ePtrList<eWidget> m_root;
-	void calcWidgetClipRegion(eWidget *widget, gRegion &parent_visible);
+	void calcWidgetClipRegion(eWidget *widget, gRegion &parent_visible, bool parent = true);
 	void paintBackground(eWidgetDesktopCompBuffer *comp);
 
 	eMainloop *m_mainloop;

--- a/lib/gui/ewindow.cpp
+++ b/lib/gui/ewindow.cpp
@@ -114,3 +114,9 @@ int eWindow::event(int event, void *data, void *data2)
 	return eWidget::event(event, data, data2);
 }
 
+void eWindow::setCornerRadius(int radius, int edges)
+{
+	/* set corner radius for child, too */
+	eWidget::setCornerRadius(radius, edges);
+	m_child->setCornerRadius(radius, edges);
+}

--- a/lib/gui/ewindow.h
+++ b/lib/gui/ewindow.h
@@ -21,6 +21,7 @@ public:
 	};
 
 	void setBackgroundColor(const gRGB &col);
+	void setCornerRadius(int radius, int edges);
 
 	void setFlag(int flags);
 	void clearFlag(int flags);

--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -1,7 +1,7 @@
 import errno
 import xml.etree.ElementTree
 
-from enigma import addFont, eLabel, ePixmap, ePoint, eRect, eSize, eWindow, eWindowStyleManager, eWindowStyleSkinned, getDesktop, gFont, getFontFaces, gRGB, BT_ALPHATEST, BT_ALPHABLEND
+from enigma import addFont, eLabel, ePixmap, ePoint, eRect, eSize, eWidget, eWindow, eWindowStyleManager, eWindowStyleSkinned, getDesktop, gFont, getFontFaces, gRGB, BT_ALPHATEST, BT_ALPHABLEND
 from os.path import basename, dirname, isfile
 
 from Components.config import ConfigSubsection, ConfigText, config
@@ -315,6 +315,26 @@ def parseValuePair(s, scale, object=None, desktop=None, size=None):
 def parsePosition(s, scale, object=None, desktop=None, size=None):
 	return ePoint(*parseValuePair(s, scale, object, desktop, size))
 
+def parseRadius(value):
+	data = [x.strip() for x in value.split(";")]
+	if len(data) == 2:
+		edges = [x.strip() for x in data[1].split(",")]
+		edgesMask = {
+			"topLeft": eWidget.RADIUS_TOP_LEFT,
+			"topRight": eWidget.RADIUS_TOP_RIGHT,
+			"top": eWidget.RADIUS_TOP,
+			"bottomLeft": eWidget.RADIUS_BOTTOM_LEFT,
+			"bottomRight": eWidget.RADIUS_BOTTOM_RIGHT,
+			"bottom": eWidget.RADIUS_BOTTOM,
+			"left": eWidget.RADIUS_LEFT,
+			"right": eWidget.RADIUS_RIGHT,
+		}
+		edgeValue = 0
+		for e in edges:
+			edgeValue += edgesMask.get(e, 0)
+		return int(data[0]), edgeValue
+	else:
+		return int(data[0]), eWidget.RADIUS_ALL
 
 def parseSize(s, scale, object=None, desktop=None):
 	return eSize(*[max(0, x) for x in parseValuePair(s, scale, object, desktop)])
@@ -498,6 +518,12 @@ class AttributeParser:
 
 	def secondfont(self, value):
 		self.guiObject.setSecondFont(parseFont(value, self.scaleTuple))
+		
+	def widgetBorderColor(self, value):
+		self.guiObject.setWidgetBorderColor(parseColor(value))
+
+	def widgetBorderWidth(self, value):
+		self.guiObject.setWidgetBorderWidth(parseScale(value))
 
 	def zPosition(self, value):
 		self.guiObject.setZPosition(int(value))
@@ -518,7 +544,7 @@ class AttributeParser:
 
 	def selectionPixmap(self, value):
 		self.guiObject.setSelectionPicture(loadPixmap(value, self.desktop))
-
+		
 	def selectionPixmapLarge(self, value):
 		self.guiObject.setSelectionPictureLarge(loadPixmap(value, self.desktop))
 
@@ -639,6 +665,10 @@ class AttributeParser:
 
 	def borderWidth(self, value):
 		self.guiObject.setBorderWidth(parseScale(value))
+		
+	def cornerRadius(self, value):
+		radius, edgeValue = parseRadius(value)
+		self.guiObject.setCornerRadius(radius, edgeValue)
 
 	def scrollbarSliderBorderWidth(self, value):
 		self.guiObject.setScrollbarSliderBorderWidth(parseScale(value))


### PR DESCRIPTION
*** Feature and code based on https://github.com/openatv/enigma2/commit/96719cad359d945ed69554b51362b5a2aa2f9348. Thanks to @jbleyel

This is for support of native corner rounding and borders for widgets. So to not be needed to use an images for the corners.

So a screen can be defined like that

`
<screen position="center,30" size="90,90" name="Mute" title="Mute" backgroundColor="transparent" zPosition="10" flags="wfNoBorder" cornerRadius="7">
    <eLabel position="0,0" size="90,90" backgroundColor="background" zPosition="-11" cornerRadius="6" widgetBorderWidth="2" widgetBorderColor="background5" />
    <ePixmap position="20,20" size="50,50" pixmap="icons/mute.svg" alphatest="blend" zPosition="12" />
  </screen>
`

Please wait the build check to complete.! ;)