### PR TITLE
AVSwitch: allow importing iAVSwitch

### DIFF
--- a/lib/python/Components/AVSwitch.py
+++ b/lib/python/Components/AVSwitch.py
@@ -3,6 +3,7 @@ from enigma import eAVSwitch, eDVBVolumecontrol, getDesktop
 from Components.SystemInfo import BoxInfo
 import os
 
+iAVSwitch = None # will be initialized later, allows to import name 'iAVSwitch' from 'Components.AVSwitch'
 
 class AVSwitch:
 	def setInput(self, input):


### PR DESCRIPTION
This commit allows to import name 'iAVSwitch' from 'Components.AVSwitch'

Plugin IPTVPlayer was failing with the following error: Plugin  Extensions/IPTVPlayer failed to load: cannot import name 'iAVSwitch' from 'Components.AVSwitch' (/usr/lib/enigma2/python/Components/AVSwitch.py) ImportError: cannot import name 'iAVSwitch' from 'Components.AVSwitch' (/usr/lib/enigma2/python/Components/AVSwitch.py)

Declaring the iAVSwitch prior calling InitAVSwitch fixes the error.