### PR TITLE
[InfoBarStreamRelay] sanity check play service

### DIFF
--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -179,7 +179,7 @@ class InfoBarStreamRelay:
 				self.__srefs.remove(servicestring)
 			else:
 				self.__srefs.append(servicestring)
-			if nav.getCurrentlyPlayingServiceReference() == service:
+			if nav.getCurrentlyPlayingServiceReference() and nav.getCurrentlyPlayingServiceReference() == service:
 				nav.restartService()
 			self.__saveToFile()
 


### PR DESCRIPTION
File "/usr/lib/enigma2/python/Screens/InfoBarGenerics.py", line 182, in toggle
if nav.getCurrentlyPlayingServiceReference() == service: 
ValueError: invalid null reference in method 'eServiceReference___eq__', argument 2 of type 'eServiceReference const &'