### PR TITLE
ServiceInfoBar fixes

### DIFF
--- a/lib/python/Components/Addons/Makefile.am
+++ b/lib/python/Components/Addons/Makefile.am
@@ -5,4 +5,5 @@ install_PYTHON = \
 	Pager.py \
 	ButtonSequence.py \
 	ColorButtonsSequence.py \
-	ScreenHeader.py
+	ScreenHeader.py \
+	ServiceInfoBar.py

--- a/lib/python/Components/Addons/ServiceInfoBar.py
+++ b/lib/python/Components/Addons/ServiceInfoBar.py
@@ -190,8 +190,12 @@ class ServiceInfoBar(GUIAddon):
 				splittedRef = sRef.split(url.replace(":", "%3a"))
 				if len(splittedRef) > 1:
 					sRef = splittedRef[1].split(":")[0].replace("%3a", ":")
-				if hasActiveSubservicesForCurrentChannel(sRef):
-					return key
+				try:
+					if hasActiveSubservicesForCurrentChannel(sRef):
+						return key
+				except:
+					if hasActiveSubservicesForCurrentChannel(service):
+						return key
 			elif key == "stream" and not isRef:
 				if self.streamServer is None:
 					return None

--- a/lib/python/Components/Addons/ServiceInfoBar.py
+++ b/lib/python/Components/Addons/ServiceInfoBar.py
@@ -185,17 +185,8 @@ class ServiceInfoBar(GUIAddon):
 				if info.getInfoString(iServiceInformation.sHBBTVUrl) != "":
 					return key
 			elif key == "subservices" and not isRef:
-				sRef = info.getInfoString(iServiceInformation.sServiceref)
-				url = "http://%s:%s/" % (config.misc.softcam_streamrelay_url.getHTML(), config.misc.softcam_streamrelay_port.value)
-				splittedRef = sRef.split(url.replace(":", "%3a"))
-				if len(splittedRef) > 1:
-					sRef = splittedRef[1].split(":")[0].replace("%3a", ":")
-				try:
-					if hasActiveSubservicesForCurrentChannel(sRef):
-						return key
-				except:
-					if hasActiveSubservicesForCurrentChannel(service):
-						return key
+				if hasActiveSubservicesForCurrentChannel(service):
+					return key
 			elif key == "stream" and not isRef:
 				if self.streamServer is None:
 					return None

--- a/lib/python/Components/Converter/ServiceInfo.py
+++ b/lib/python/Components/Converter/ServiceInfo.py
@@ -47,6 +47,9 @@ def StdAudioDesc(description):
 		description = description.replace(orig, repl)
 	return description
 
+def getVideoHeight(info):
+	return info.getInfo(iServiceInformation.sVideoHeight)
+
 
 class ServiceInfo(Converter):
 	HAS_TELETEXT = 0


### PR DESCRIPTION
[Fixed] exception on PLi on subservices get
[Fixed] Missing global function in service info
[Fixed] missing entry in make file

All this is due to some general difference between OE-A and OpenPLi in subservices and video parameters get.