### PR TITLE
VideoHardware.py: Set HDMI(DVI) port as default.

### DIFF
--- a/lib/python/Plugins/SystemPlugins/Videomode/VideoHardware.py
+++ b/lib/python/Plugins/SystemPlugins/Videomode/VideoHardware.py
@@ -301,7 +301,7 @@ class VideoHardware:
 					else:
 						ratelist.append((rate, rate == "multi" and (mode == "2160p30" and "multi (25Hz/30Hz)" or "multi (50Hz/60Hz)") or rate))
 				config.av.videorate[mode] = ConfigSelection(choices=ratelist)
-		config.av.videoport = ConfigSelection(choices=lst)
+		config.av.videoport = ConfigSelection(default="DVI", choices=lst)
 
 	def setConfiguredMode(self):
 		port = config.av.videoport.value


### PR DESCRIPTION
Some TVs can't handle 1440x576i resolution(resolution with e.g. dm8000), which result in a black screen during language select screen after a fresh image install.

Set HDMI port as default to ensure resolution is set to 720p.

See also forum:
https://forums.openpli.org/topic/87666-openpli-py3/page-27#entry1476256