### PR TITLE
[Picon] Allow unicode filenames

### DIFF
--- a/lib/python/Components/Renderer/Picon.py
+++ b/lib/python/Components/Renderer/Picon.py
@@ -94,17 +94,13 @@ def getPiconName(serviceRef):
 		fields[2] = '1'
 		pngname = findPicon('_'.join(fields))
 	if not pngname: # picon by channel name
-		name = sanitizeFilename(ServiceReference(serviceRef).getServiceName())
-		name = re.sub('[^a-z0-9]', '', name.replace('&', 'and').replace('+', 'plus').replace('*', 'star').lower())
-		if name:
-			pngname = findPicon(name)
-			if not pngname:
-				name = re.sub("(fhd|uhd|hd|sd|4k)$", "", name)
-				if name:
-					pngname = findPicon(name)
-			if not pngname and len(name) > 6:
-				series = re.sub(r's[0-9]*e[0-9]*$', '', name)
-				pngname = findPicon(series)
+			utf8_name = sanitizeFilename(eServiceReference(serviceRef).getServiceName()).lower()
+			name = sub("[^a-z0-9]", "", utf8_name.replace("&", "and").replace("+", "plus").replace("*", "star"))
+			if name:
+				pngname = self.findPicon(name) or self.findPicon(sub("(fhd|uhd|hd|sd|4k)$", "", name).strip()) or self.findPicon(utf8_name)
+				if not pngname and len(name) > 6:
+					series = sub(r"s[0-9]*e[0-9]*$", "", name)
+					pngname = self.findPicon(series)
 	return pngname
 
 


### PR DESCRIPTION
Continues work from @nautilus7 in https://github.com/OpenPLi/enigma2/commit/2e7479e22eb2694fa1071f2429aad5721c663e1f

The filename will be identical to the channel name in lowercase including any spaces or special chars. Only characters prevented by sanitizeFilename will be omitted. For more info on sanitizeFilename see https://pypi.org/project/sanitize-filename/

Legacy code has been kept for compatibility with current picons.