### PR TITLE
[CI] fix crash when CI module is deactivated in the menu

### DIFF
--- a/lib/dvb_ci/dvbci.cpp
+++ b/lib/dvb_ci/dvbci.cpp
@@ -1266,6 +1266,15 @@ eDVBCISlot::eDVBCISlot(eMainloop *context, int nr):
 	m_context = context;
 	m_ciplus_routing_tunernum = -1;
 	state = stateDisabled;
+	application_manager = 0;
+	mmi_session = 0;
+	ca_manager = 0;
+	cc_manager = 0;
+	use_count = 0;
+	linked_next = 0;
+	user_mapped = false;
+	plugged = false;
+	m_ci_version = versionUnknown;
 	snprintf(configStr, 255, "config.ci.%d.enabled", slotid);
 	bool enabled = eConfigManager::getConfigBoolValue(configStr, true);
 	if (enabled)
@@ -1287,15 +1296,7 @@ void eDVBCISlot::openDevice()
 {
 	char filename[128];
 
-	application_manager = 0;
-	mmi_session = 0;
-	ca_manager = 0;
-	cc_manager = 0;
-	use_count = 0;
-	linked_next = 0;
-	user_mapped = false;
 	plugged = true;
-	m_ci_version = versionUnknown;
 
 	sprintf(filename, "/dev/ci%d", slotid);
 


### PR DESCRIPTION
-Initialize all pointers and variables in the constructor to avoid crash.

thanks @betacentauri