### PR TITLE
[ScanSetup] fix str py3

### DIFF
--- a/lib/python/Screens/ScanSetup.py
+++ b/lib/python/Screens/ScanSetup.py
@@ -410,6 +410,7 @@ class TerrestrialTransponderSearchSupport:
 				self.terrestrialTransponderSearch(freq, bandWidth)
 
 	def getTerrestrialTransponderData(self, str):
+		str = str.decode()
 		print("[getTerrestrialTransponderData] ", str)
 		if self.terrestrial_tunerName.startswith("Sundtek"):
 			str = self.remaining_data + str


### PR DESCRIPTION
File "/usr/lib/enigma2/python/Screens/ScanSetup.py", line 448, in getTerrestrialTransponderData
TypeError: can only concatenate str (not "bytes") to str