### PR TITLE
[config.py] fix BSoD

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -1004,7 +1004,6 @@ class ConfigMacText(ConfigElement, NumericalTextInput):
 		if session is not None:
 			from Screens.NumericalTextInputHelpDialog import NumericalTextInputHelpDialog
 			self.help_window = session.instantiateDialog(NumericalTextInputHelpDialog, self)
-			self.help_window.setAnimationMode(0)
 			self.help_window.show()
 
 	def onDeselect(self, session):
@@ -1379,7 +1378,6 @@ class ConfigText(ConfigElement, NumericalTextInput):
 		if session is not None:
 			from Screens.NumericalTextInputHelpDialog import NumericalTextInputHelpDialog
 			self.help_window = session.instantiateDialog(NumericalTextInputHelpDialog, self)
-			self.help_window.setAnimationMode(0)
 			self.help_window.show()
 
 	def onDeselect(self, session):


### PR DESCRIPTION
[Skin] Processing screen 'NumericalTextInputHelpDialog', position=(537, 675), size=(846 x 246) for module 'NumericalTextInputHelpDialog'. Traceback (most recent call last):
  File "/usr/lib/enigma2/python/Components/ConfigList.py", line 92, in selectionChanged
    self.current[1].onSelect(self.session)
  File "/usr/lib/enigma2/python/Components/config.py", line 1382, in onSelect
    self.help_window.setAnimationMode(0)
  File "/usr/lib/enigma2/python/Screens/Screen.py", line 206, in setAnimationMode
    self.instance.setAnimationMode(mode)
AttributeError: 'eWindow' object has no attribute 'setAnimationMode' [ePyObject] (CallObject(<bound method ConfigList.selectionChanged of <Components.ConfigList.ConfigList object at 0xaefd7b80>>,()) failed) [gRC] Warning: Main thread is busy, displaying spinner!