### PR TITLE
[FlashImage] - Vu+ Multiboot - if rejecting usb images then deselect all

### DIFF
--- a/lib/python/Screens/FlashImage.py
+++ b/lib/python/Screens/FlashImage.py
@@ -285,7 +285,7 @@ class FlashImage(Screen):
 			imagesList = getImagelist()
 			currentimageslot = getCurrentImage()
 			choices = []
-			slotdict = {k: v for k, v in BoxInfo.getItem("canMultiBoot").items() if not v['device'].startswith('/dev/sda')}
+			slotdict = {k: v for k, v in BoxInfo.getItem("canMultiBoot").items() if not v['device'].startswith('/dev/sd')}
 			for x in range(1, len(slotdict) + 1):
 				choices.append(((_("slot%s - %s (current image) with, backup") if x == currentimageslot else _("slot%s - %s, with backup")) % (x, imagesList[x]['imagename']), (x, "with backup")))
 			for x in range(1, len(slotdict) + 1):


### PR DESCRIPTION
OpenPli doesn,t directly support flashing to usb devices, however the current check assumes usb is mounted as /dev/sda which in Vu+ Multiboot is not necesarily true.
Flashing to slot 4+ will successfully add a new image to existing eMMC, which is not a good idea.
This change checks for any /dev/sdX device and rejects.
see following log....

[FlashImage][confirmation] currentimageslot:2 imageList;{1: {'imagename': 'Openvix 5.4 (2024-05-23)'}, 2: {'imagename': 'Openpli develop (2024-05-23)'}, 3: {'imagename': 'Openatv 7.3 (2024-03-01)'}, 4: {'imagename': 'Openbh 5.4 (2024-04-01)'}, 5: {'imagename': 'Openvix 6.5 (2024-04-17)'}, 6: {'imagename': 'Openvix 5.3 (2024-03-28)'}, 7: {'imagename': 'Openvix 6.5 (2024-03-29)'}}
[FlashImage][confirmation] Boxinfo:dict_items([(1, {'device': '/dev/mmcblk0p4', 'startupfile': 'STARTUP_1', 'rootsubdir': 'linuxrootfs1'}), (2, {'device': '/dev/mmcblk0p4', 'startupfile': 'STARTUP_2', 'rootsubdir': 'linuxrootfs2'}), (3, {'device': '/dev/mmcblk0p4', 'startupfile': 'STARTUP_3', 'rootsubdir': 'linuxrootfs3'}), (5, {'device': '/dev/sdb1', 'startupfile': 'STARTUP_5', 'rootsubdir': 'uno4kse/linuxrootfs5'}), (6, {'device': '/dev/sdb1', 'startupfile': 'STARTUP_6', 'rootsubdir': 'uno4kse/linuxrootfs6'}), (7, {'device': '/dev/sdb1', 'startupfile': 'STARTUP_7', 'rootsubdir': 'uno4kse/linuxrootfs7'}), (4, {'device': '/dev/sdb1', 'startupfile': 'STARTUP_4', 'rootsubdir': 'uno4kse/linuxrootfs4'})])
[FlashImage][confirmation] slotdict:{1: {'device': '/dev/mmcblk0p4', 'startupfile': 'STARTUP_1', 'rootsubdir': 'linuxrootfs1'}, 2: {'device': '/dev/mmcblk0p4', 'startupfile': 'STARTUP_2', 'rootsubdir': 'linuxrootfs2'}, 3: {'device': '/dev/mmcblk0p4', 'startupfile': 'STARTUP_3', 'rootsubdir': 'linuxrootfs3'}, 5: {'device': '/dev/sdb1', 'startupfile': 'STARTUP_5', 'rootsubdir': 'uno4kse/linuxrootfs5'}, 6: {'device': '/dev/sdb1', 'startupfile': 'STARTUP_6', 'rootsubdir': 'uno4kse/linuxrootfs6'}, 7: {'device': '/dev/sdb1', 'startupfile': 'STARTUP_7', 'rootsubdir': 'uno4kse/linuxrootfs7'}, 4: {'device': '/dev/sdb1', 'startupfile': 'STARTUP_4', 'rootsubdir': 'uno4kse/linuxrootfs4'}} 

[FlashImage][flashimage] slot:5
[Console] command: /usr/bin/ofgwrite -k -r -m5 '/media/hdd/downloaded_images/openpli-develop-vuuno4kse-20240524_usb.unzipped/vuplus/uno4kse'

Creating directory linuxrootfs5 recursively
Flash rootfs unpack
Delete rootfs: rm -r -f /oldroot_remount/linuxrootfs5/
Untar: tar xf /media/hdd/downloaded_images/openpli-develop-vuuno4kse-20240524_usb.unzipped/vuplus/uno4kse/rootfs.tar.bz2
Successfully flashed rootfs!
Flashing kernel ...
Successfully flashed kernel!
Successfully flashed image