### PR TITLE
[Directories.py] sanitizeFilename, fix blacklist

### DIFF
--- a/lib/python/Tools/Directories.py
+++ b/lib/python/Tools/Directories.py
@@ -571,7 +571,7 @@ def sanitizeFilename(filename):
 	and make sure we do not exceed Windows filename length limits.
 	Hence a less safe blacklist, rather than a whitelist.
 	"""
-	blacklist = ["\\", "/", ":", "*", "?", "\"", "<", ">", "|", "\0", "(", ")", " "]
+	blacklist = ["\\", "/", ":", "*", "?", "\"", "<", ">", "|", "\0"]
 	reserved = [
 		"CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5",
 		"COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5",


### PR DESCRIPTION
Original code comes from here: https://pypi.org/project/sanitize-filename/

But the blacklist has been modified which breaks valid filenames.

This commit returns to the original blacklist, allowing spaces and parenthesis.

The old code also breaks picon names where parenthesis and spaces especially are used. This affects the new UTF8 SNP algorithm where a 1:1 relationship is expected