### PR TITLE
[scarthgap] python_console.i: Remove write console workaround

### DIFF
--- a/lib/python/python_console.i
+++ b/lib/python/python_console.i
@@ -187,15 +187,14 @@ static PyObject *
 eConsolePy_write(eConsolePy* self, PyObject *args)
 {
 	char *data;
+	int data_len;
 	int len = -1;
-	if (!PyArg_ParseTuple(args, "s|i", &data, &len))
+	if (!PyArg_ParseTuple(args, "s#|i", &data, &data_len, &len))
 	{
 		PyErr_SetString(PyExc_TypeError,
 			"1st arg must be a string, optionaly 2nd arg can be the string length");
 		return NULL;
 	}
-	int data_len = strlen(data);
-
 	if (len < 0)
 		len = data_len;
 	self->cont->write(data, len);


### PR DESCRIPTION
Revert commit (python_console.i file only)
https://github.com/OpenPLi/enigma2/commit/cef6469241ead8c4677d70081e560debfc786a09

Proper solution with patch OpenPLi core.
https://github.com/OpenPLi/openpli-oe-core/blob/scarthgap/meta-openpli/recipes-openpli/enigma2/enigma2/16-fix-write-console.patch