### PR TITLE
[ConfigList] sanity check use dummyConfigActions

### DIFF
--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -452,11 +452,16 @@ class ConfigListScreen:
 		self.keySave()
 
 	def dummyConfigActions(self, value):  # Temporary support for legacy code and plugins that hasn't yet been updated.
-		self["configActions"].setEnabled(value)
-		self["navigationActions"].setEnabled(value)
-		self["menuConfigActions"].setEnabled(value)
-		self["charConfigActions"].setEnabled(value)
-		self["editConfigActions"].setEnabled(value)
+		if "configActions" in self:
+			self["configActions"].setEnabled(value)
+		if "navigationActions" in self:
+			self["navigationActions"].setEnabled(value)
+		if "menuConfigActions" in self:
+			self["menuConfigActions"].setEnabled(value)
+		if "charConfigActions" in self:
+			self["charConfigActions"].setEnabled(value)
+		if "editConfigActions" in self:
+			self["editConfigActions"].setEnabled(value)
 
 	def dummyVKBActions(self, value):  # Temporary support for legacy code and plugins that hasn't yet been updated.
 		self["virtualKeyBoardActions"].setEnabled(value)


### PR DESCRIPTION
File
"/usr/lib/enigma2/python/Plugins/SystemPlugins/SatipClient/plugin.py", line 387, in DiscoveryStart
  File
"/usr/lib/enigma2/python/Components/ConfigList.py", line 457, in dummyConfigActions
KeyError: 'menuConfigActions'