### PR TITLE
[db/scan] create database for logical channel number (descriptor 0x83…

### DIFF
--- a/lib/dvb/db.h
+++ b/lib/dvb/db.h
@@ -7,7 +7,74 @@
 #include <lib/base/eptrlist.h>
 #include <set>
 #include <vector>
+#include <sstream>
 class ServiceDescriptionSection;
+
+struct LCNData
+{
+private:
+	bool FOUND;
+
+	std::vector<std::string> split_str(std::string s)
+	{
+		std::vector<std::string> tokens;
+		std::string token;
+		std::stringstream str(s);
+		while (getline(str, token, ':')) {
+			tokens.push_back(token);
+		}
+		return tokens;
+	}
+
+public:
+	int NS;
+	int ONID;
+	int TSID;
+	int SID;
+	int SIGNAL;
+	int LCN;
+	LCNData()
+	{
+		LCN = 0;
+		SIGNAL = -1;
+		FOUND = true;
+	}
+
+	eServiceReferenceDVB parse(const char *line)
+	{
+
+		if (sscanf(line, "%x:%x:%x:%x:%d:%d", &NS, &ONID, &TSID, &SID, &LCN, &SIGNAL) == 6)
+			return eServiceReferenceDVB(eDVBNamespace(NS), eTransportStreamID(TSID), eOriginalNetworkID(ONID), eServiceID(SID), 0);
+		else
+			return eServiceReferenceDVB();
+		
+	}
+
+	void Update(uint16_t lcn, uint32_t signal)
+	{
+		LCN = lcn;
+		SIGNAL = signal;
+		FOUND = true;
+	}
+
+	void write(FILE *lf, const eServiceReferenceDVB &key)
+	{
+		if (FOUND)
+		{
+			int sid = key.getServiceID().get();
+			int tsid = key.getTransportStreamID().get();
+			int onid = key.getOriginalNetworkID().get();
+			int ns = key.getDVBNamespace().get();
+			fprintf(lf, "%x:%x:%x:%x:%d:%d\n", ns, onid, tsid, sid, LCN, SIGNAL);
+		}
+	}
+
+	void resetFound()
+	{
+		FOUND = false;
+	}
+
+};
 
 class eIPTVDBItem
 {
@@ -65,6 +132,7 @@ class eDVBDB: public iDVBChannelList
 #endif
 private:
 	void loadServiceListV5(FILE * f);
+	std::map<eServiceReferenceDVB, LCNData> m_lcnmap;
 public:
 	std::vector<eIPTVDBItem> iptv_services;
 // iDVBChannelList
@@ -83,6 +151,7 @@ public:
 	PyObject *readTerrestrials(SWIG_PYOBJECT(ePyObject) ter_list, SWIG_PYOBJECT(ePyObject) tp_dict);
 	PyObject *readCables(SWIG_PYOBJECT(ePyObject) cab_list, SWIG_PYOBJECT(ePyObject) tp_dict);
 	PyObject *readATSC(SWIG_PYOBJECT(ePyObject) atsc_list, SWIG_PYOBJECT(ePyObject) tp_dict);
+	PyObject *getLcnDBData();
 #ifndef SWIG
 	RESULT removeFlags(unsigned int flagmask, eDVBChannelID chid, unsigned int orb_pos);
 	RESULT removeServices(eDVBChannelID chid, unsigned int orb_pos);
@@ -95,6 +164,7 @@ public:
 
 	RESULT addService(const eServiceReferenceDVB &referenc, eDVBService *service);
 	RESULT getService(const eServiceReferenceDVB &reference, ePtr<eDVBService> &service);
+	RESULT getLcnDBData(std::map<eServiceReferenceDVB, LCNData> &data);
 	RESULT flush();
 
 	RESULT startQuery(ePtr<iDVBChannelListQuery> &query, eDVBChannelQuery *q, const eServiceReference &source);
@@ -107,6 +177,9 @@ public:
 	eDVBDB();
 	virtual ~eDVBDB();
 	int renumberBouquet(eBouquet &bouquet, int startChannelNum = 1);
+	void addLcnToDB(int ns, int onid, int tsid, int sid, uint16_t lcn, uint32_t signal);
+	void resetLcnDB();
+	void readLcnDBFile();
 #endif
 	void setNumberingMode(bool numberingMode);
 	void setLoadUnlinkedUserbouquets(bool value) { m_load_unlinked_userbouquets=value; }
@@ -117,6 +190,7 @@ public:
 	void saveServicelist();
 	void saveIptvServicelist();
 	void saveServicelist(const char *file);
+	void saveLcnDB();
 	void reloadBouquets();
 	void parseServiceData(ePtr<eDVBService> s, std::string str);
 };


### PR DESCRIPTION
…) DVB-C/T/T2

Data is fully handled in C++ and is accessible from both C++ and python modules

Author: @DimitarCC

Includes https://github.com/openatv/enigma2/commit/b13920f04d1a344fc480fe655fbf30d35384f1a5 Includes some elements from https://github.com/openatv/enigma2/commit/be62b2da3a92e16429c695b5277e1ffa3a339990