### PR TITLE
[ChannelSelection] bouquet name

### DIFF
--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -1130,7 +1130,7 @@ class ChannelSelectionEdit:
 		serviceHandler = eServiceCenter.getInstance()
 		mutableBouquetList = serviceHandler.list(self.bouquet_root).startEdit()
 		if mutableBouquetList:
-			name = sanitizeFilename(bName)
+			name = sanitizeFilename(bName.replace(" ", ""))
 			while os.path.isfile((self.mode == MODE_TV and '/etc/enigma2/userbouquet.%s.tv' or '/etc/enigma2/userbouquet.%s.radio') % name):
 				name = name.rsplit('_', 1)
 				name = ('_').join((name[0], len(name) == 2 and name[1].isdigit() and str(int(name[1]) + 1) or '1'))


### PR DESCRIPTION
Output of sanitizeFilename gives valid utf8 filenames including spaces. This is correct behaviour. But enigma will not tolerate spaces in bouquet filenames (it truncates the filename on the space), so remove any spaces here rather than breaking santizeFilename by including this there.