### PR TITLE
[ewidget] log rather than crash if a widget has no parent

### DIFF
--- a/lib/gui/ewidget.cpp
+++ b/lib/gui/ewidget.cpp
@@ -337,9 +337,13 @@ void eWidget::recalcClipRegionsWhenVisible()
 			t->m_desktop->recalcClipRegions(t);
 			break;
 		}
+		if (!t->m_parent)
+		{
+			eTraceNoNewLineStart("[eWidget] RecalcClipRegions for widget at (%d,%d)=>(%d,%d).", this->position().x(), this->position().y(), this->size().width(), this->size().height());
+			eTraceNoNewLine("Top level parent at (%d,%d)=>(%d,%d) has no desktop", t->position().x(), t->position().y(), t->size().width(), t->size().height());
+		}
 		t = t->m_parent;
-		ASSERT(t);
-	} while(1);
+	} while(t);
 }
 
 void eWidget::parentRemoved()


### PR DESCRIPTION
[eDVBRecordFileThread] wait: aio_return returned failure: Interrupted system call
[eDVBRecordFileThread] wait: aio_return returned failure: Interrupted system call
[eDVBChannel] getLength failed - can't seek relative to end! ../../git/lib/gui/ewidget.cpp:341 ASSERTION t FAILED!

Ater stop icam service SKY DE 19.2 and use timeshift.

-thanks @SimonCapewell

https://github.com/OpenViX/enigma2/commit/b36c06d71458402632ff9cc9759bdee822f961d8