### PR TITLE
[TextBox] missing feature

### DIFF
--- a/lib/python/Screens/TextBox.py
+++ b/lib/python/Screens/TextBox.py
@@ -4,19 +4,20 @@ from Components.ScrollLabel import ScrollLabel
 
 
 class TextBox(Screen):
-	def __init__(self, session, text="", title=None, pigless=False):
+	def __init__(self, session, text="", title=None, pigless=False, label=None):
 		Screen.__init__(self, session)
 		if pigless:
 			self.skinName = ["TextBoxPigLess", "TextBox"]
 		self.text = text
-		self["text"] = ScrollLabel(self.text)
+		self.label = label if label else "text"
+		self[self.label] = ScrollLabel(self.text)
 
 		self["actions"] = ActionMap(["OkCancelActions", "DirectionActions"],
 				{
 					"cancel": self.close,
 					"ok": self.close,
-					"up": self["text"].pageUp,
-					"down": self["text"].pageDown,
+					"up": self[self.label].pageUp,
+					"down": self[self.label].pageDown,
 				}, -1)
 
 		if title:


### PR DESCRIPTION
Add possibility to specify widget name.
Feature is in other distros for a long time, e.g. OpenBlackHole, OpenViX. Prevent BSoD in PLi when using plugins that rely on this feature, e.g. https://github.com/DimitarCC/iptv-m3u-reader/blob/8560e189eb630bb39eecdb8a7620903d29740fb3/src/plugin.py#L1219