### PR TITLE
[AutoDiseqc] code reorganization

### DIFF
--- a/lib/python/Screens/AutoDiseqc.py
+++ b/lib/python/Screens/AutoDiseqc.py
@@ -10,7 +10,7 @@ from enigma import eDVBFrontendParametersSatellite, eDVBResourceManager, eTimer
 
 class AutoDiseqc(ConfigListScreen, Screen):
 	skin = """
-		<screen position="c-250,c-100" size="500,250" title=" ">
+		<screen position="c-250,c-100" size="500,250" title="Auto DiseqC">
 			<widget source="statusbar" render="Label" position="10,5" zPosition="10" size="e-10,60" halign="center" valign="center" font="Regular;22" transparent="1" shadowColor="black" shadowOffset="-1,-1" />
 			<widget source="tunerstatusbar" render="Label" position="10,60" zPosition="10" size="e-10,30" halign="center" valign="center" font="Regular;22" transparent="1" shadowColor="black" shadowOffset="-1,-1" />
 			<widget name="config" position="10,100" size="e-10,100" scrollbarMode="showOnDemand" />
@@ -22,49 +22,7 @@ class AutoDiseqc(ConfigListScreen, Screen):
 		"A", "B", "C", "D"
 	]
 
-	sat_frequencies = [
-		# Thor 0.8W Sky News
-		(
-			12418,
-			28000,
-			eDVBFrontendParametersSatellite.Polarisation_Vertical,
-			eDVBFrontendParametersSatellite.FEC_7_8,
-			eDVBFrontendParametersSatellite.Inversion_Off,
-			3592,
-			eDVBFrontendParametersSatellite.System_DVB_S,
-			eDVBFrontendParametersSatellite.Modulation_Auto,
-			eDVBFrontendParametersSatellite.RollOff_auto,
-			eDVBFrontendParametersSatellite.Pilot_Unknown,
-			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
-			eDVBFrontendParametersSatellite.PLS_Gold,
-			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
-			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
-			eDVBFrontendParametersSatellite.T2MI_Default_Pid,
-			20,
-			70,
-			"Thor 5/6/7 0.8w"),
-
-		# Eutelsat 9.0E CCTV Europe
-		(
-			11996,
-			27500,
-			eDVBFrontendParametersSatellite.Polarisation_Vertical,
-			eDVBFrontendParametersSatellite.FEC_3_4,
-			eDVBFrontendParametersSatellite.Inversion_Off,
-			90,
-			eDVBFrontendParametersSatellite.System_DVB_S,
-			eDVBFrontendParametersSatellite.Modulation_Auto,
-			eDVBFrontendParametersSatellite.RollOff_auto,
-			eDVBFrontendParametersSatellite.Pilot_Unknown,
-			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
-			eDVBFrontendParametersSatellite.PLS_Gold,
-			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
-			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
-			eDVBFrontendParametersSatellite.T2MI_Default_Pid,
-			6400,
-			156,
-			"Eutelsat 9B 9.0e"),
-
+	universal_central_sats_frequencies = [
 		# Hotbird 13.0E Rai 1
 		(
 			10992,
@@ -84,29 +42,8 @@ class AutoDiseqc(ConfigListScreen, Screen):
 			eDVBFrontendParametersSatellite.T2MI_Default_Pid,
 			12400,
 			318,
-			"Hotbird 13.0e"),
-
-		# Eutelsat 16.0E OTV
-		(
-			11345,
-			30000,
-			eDVBFrontendParametersSatellite.Polarisation_Horizontal,
-			eDVBFrontendParametersSatellite.FEC_3_4,
-			eDVBFrontendParametersSatellite.Inversion_Off,
-			160,
-			eDVBFrontendParametersSatellite.System_DVB_S,
-			eDVBFrontendParametersSatellite.Modulation_Auto,
-			eDVBFrontendParametersSatellite.RollOff_auto,
-			eDVBFrontendParametersSatellite.Pilot_Unknown,
-			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
-			eDVBFrontendParametersSatellite.PLS_Gold,
-			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
-			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
-			eDVBFrontendParametersSatellite.T2MI_Default_Pid,
-			24100,
-			366,
-			"Eutelsat 16A 16.0e"),
-
+			"Hotbird 13.0°E"
+		),
 		# Astra 19.2E ZDF
 		(
 			11954,
@@ -126,8 +63,8 @@ class AutoDiseqc(ConfigListScreen, Screen):
 			eDVBFrontendParametersSatellite.T2MI_Default_Pid,
 			1079,
 			1,
-			"Astra 1 19.2e"),
-
+			"Astra 1 19.2°E"
+		),
 		# Astra 23.5E Astra SES
 		(
 			12168,
@@ -147,8 +84,8 @@ class AutoDiseqc(ConfigListScreen, Screen):
 			eDVBFrontendParametersSatellite.T2MI_Default_Pid,
 			3224,
 			3,
-			"Astra 3 23.5e"),
-
+			"Astra 3 23.5°E"
+		),
 		# Astra 28.2E EPG background audio
 		(
 			11778,
@@ -168,8 +105,99 @@ class AutoDiseqc(ConfigListScreen, Screen):
 			eDVBFrontendParametersSatellite.T2MI_Default_Pid,
 			2004,
 			2,
-			"Astra 2 28.2e"),
+			"Astra 2 28.2°E"
+		),
+	]
 
+	universal_east_sats_frequencies = [
+		# Astra 4A 4.8 Home 3
+		(
+			11785,
+			27500,
+			eDVBFrontendParametersSatellite.Polarisation_Vertical,
+			eDVBFrontendParametersSatellite.FEC_5_6,
+			eDVBFrontendParametersSatellite.Inversion_Off,
+			48,
+			eDVBFrontendParametersSatellite.System_DVB_S2,
+			eDVBFrontendParametersSatellite.Modulation_8PSK,
+			eDVBFrontendParametersSatellite.RollOff_auto,
+			eDVBFrontendParametersSatellite.Pilot_Unknown,
+			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
+			eDVBFrontendParametersSatellite.PLS_Gold,
+			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
+			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
+			eDVBFrontendParametersSatellite.T2MI_Default_Pid,
+			201,
+			85,
+			"Astra 4A 4.8°E"
+		),
+		# Eutelsat 9.0E CCTV 4 Europe
+		(
+			11996,
+			27500,
+			eDVBFrontendParametersSatellite.Polarisation_Vertical,
+			eDVBFrontendParametersSatellite.FEC_3_4,
+			eDVBFrontendParametersSatellite.Inversion_Off,
+			90,
+			eDVBFrontendParametersSatellite.System_DVB_S,
+			eDVBFrontendParametersSatellite.Modulation_Auto,
+			eDVBFrontendParametersSatellite.RollOff_auto,
+			eDVBFrontendParametersSatellite.Pilot_Unknown,
+			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
+			eDVBFrontendParametersSatellite.PLS_Gold,
+			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
+			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
+			eDVBFrontendParametersSatellite.T2MI_Default_Pid,
+			1,
+			1,
+			"Eutelsat 9B 9.0°E"
+		),
+		# Eutelsat 16.0E CGTN
+		(
+			11595,
+			30000,
+			eDVBFrontendParametersSatellite.Polarisation_Horizontal,
+			eDVBFrontendParametersSatellite.FEC_3_4,
+			eDVBFrontendParametersSatellite.Inversion_Off,
+			160,
+			eDVBFrontendParametersSatellite.System_DVB_S2,
+			eDVBFrontendParametersSatellite.Modulation_8PSK,
+			eDVBFrontendParametersSatellite.RollOff_auto,
+			eDVBFrontendParametersSatellite.Pilot_Unknown,
+			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
+			eDVBFrontendParametersSatellite.PLS_Gold,
+			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
+			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
+			eDVBFrontendParametersSatellite.T2MI_Default_Pid,
+			2,
+			64,
+			"Eutelsat 16A 16.0°E"
+		),
+
+	]
+
+	universal_west_sats_frequencies = [
+		# Thor 0.8W Sky News
+		(
+			12418,
+			28000,
+			eDVBFrontendParametersSatellite.Polarisation_Vertical,
+			eDVBFrontendParametersSatellite.FEC_7_8,
+			eDVBFrontendParametersSatellite.Inversion_Off,
+			3592,
+			eDVBFrontendParametersSatellite.System_DVB_S,
+			eDVBFrontendParametersSatellite.Modulation_Auto,
+			eDVBFrontendParametersSatellite.RollOff_auto,
+			eDVBFrontendParametersSatellite.Pilot_Unknown,
+			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
+			eDVBFrontendParametersSatellite.PLS_Gold,
+			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
+			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
+			eDVBFrontendParametersSatellite.T2MI_Default_Pid,
+			20,
+			70,
+			"Thor 5/6/7 0.8°W"
+		),
 		# Eutelsat 5.0W Fransat
 		(
 			11054,
@@ -189,18 +217,18 @@ class AutoDiseqc(ConfigListScreen, Screen):
 			eDVBFrontendParametersSatellite.T2MI_Default_Pid,
 			20500,
 			1375,
-			"Eutelsat 5 West B 5.0w"),
-
-		# Hispasat 30.0W TSA
+			"Eutelsat 5 West B 5.0°W"
+		),
+		# Hispasat 30.0W TVI
 		(
-			10890,
-			27500,
-			eDVBFrontendParametersSatellite.Polarisation_Vertical,
-			eDVBFrontendParametersSatellite.FEC_3_4,
+			10770,
+			30000,
+			eDVBFrontendParametersSatellite.Polarisation_Horizontal,
+			eDVBFrontendParametersSatellite.FEC_5_6,
 			eDVBFrontendParametersSatellite.Inversion_Off,
 			3300,
-			eDVBFrontendParametersSatellite.System_DVB_S,
-			eDVBFrontendParametersSatellite.Modulation_Auto,
+			eDVBFrontendParametersSatellite.System_DVB_S2,
+			eDVBFrontendParametersSatellite.Modulation_8PSK,
 			eDVBFrontendParametersSatellite.RollOff_auto,
 			eDVBFrontendParametersSatellite.Pilot_Unknown,
 			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
@@ -208,12 +236,13 @@ class AutoDiseqc(ConfigListScreen, Screen):
 			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
 			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
 			eDVBFrontendParametersSatellite.T2MI_Default_Pid,
-			15,
-			2,
-			"Hispasat 30.0w"),
+			6,
+			6,
+			"Hispasat 30.0°W"
+		),
 	]
 
-	circular_sat_frequencies = [
+	circular_sats_frequencies = [
 		# Express AMU1 36.0E NTV Plus
 		(
 			11785,
@@ -233,7 +262,29 @@ class AutoDiseqc(ConfigListScreen, Screen):
 			eDVBFrontendParametersSatellite.T2MI_Default_Pid,
 			13,
 			112,
-			"Express AMU1 36.0e"),
+			"Express AMU1 36.0°E"
+		),
+		# Express AT1 56.0E NTV Plus Vostok
+		(
+			12054,
+			27500,
+			eDVBFrontendParametersSatellite.Polarisation_CircularRight,
+			eDVBFrontendParametersSatellite.FEC_3_4,
+			eDVBFrontendParametersSatellite.Inversion_Off,
+			560,
+			eDVBFrontendParametersSatellite.System_DVB_S2,
+			eDVBFrontendParametersSatellite.Modulation_8PSK,
+			eDVBFrontendParametersSatellite.RollOff_auto,
+			eDVBFrontendParametersSatellite.Pilot_Unknown,
+			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
+			eDVBFrontendParametersSatellite.PLS_Gold,
+			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
+			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
+			eDVBFrontendParametersSatellite.T2MI_Default_Pid,
+			566,
+			112,
+			"Express AT1 56.0°E"
+		),
 	]
 
 	SAT_TABLE_FREQUENCY = 0
@@ -255,15 +306,14 @@ class AutoDiseqc(ConfigListScreen, Screen):
 	SAT_TABLE_ONID = 16
 	SAT_TABLE_NAME = 17
 
-	def __init__(self, session, feid, nr_of_ports, simple_tone, simple_sat_change):
+	def __init__(self, session, feid, nr_of_ports, simple_tone, simple_sat_change, order="all"):
 		self.skin = AutoDiseqc.skin
 		Screen.__init__(self, session)
 
 		self["statusbar"] = StaticText(" ")
 		self["tunerstatusbar"] = StaticText(" ")
 
-		self.list = []
-		ConfigListScreen.__init__(self, self.list, session=self.session)
+		ConfigListScreen.__init__(self, [], session=session)
 
 		self["key_red"] = StaticText(_("Abort"))
 
@@ -274,26 +324,31 @@ class AutoDiseqc(ConfigListScreen, Screen):
 		self.simple_tone = simple_tone
 		self.simple_sat_change = simple_sat_change
 		self.found_sats = []
-		self.circular_setup = False
-		sat_found = False
-		for x in self.sat_frequencies:
-			if x[self.SAT_TABLE_ORBPOS] == 360:
-				sat_found = True
-		if self.nr_of_ports == 1:
-			if not sat_found:
-				self.sat_frequencies += self.circular_sat_frequencies
-		elif sat_found:
-			self.sat_frequencies.remove(x)
+		self.circular_setup = 0
+		if order == "all":
+			self.sat_frequencies = self.universal_central_sats_frequencies[:] + self.universal_east_sats_frequencies[:] + self.universal_west_sats_frequencies[:]
+			if nr_of_ports == 1:
+				self.sat_frequencies += self.circular_sats_frequencies[:]
+		elif order == "astra":
+			self.sat_frequencies = self.universal_central_sats_frequencies[:]
+		elif order == "east":
+			self.sat_frequencies = self.universal_central_sats_frequencies[:] + self.universal_east_sats_frequencies[:]
+			if nr_of_ports == 1:
+				self.sat_frequencies += self.circular_sats_frequencies[:]
+		elif order == "west":
+			self.sat_frequencies = self.universal_west_sats_frequencies[:]
+		elif order == "circular":
+			self.sat_frequencies = self.circular_sats_frequencies[:]
 
 		if not self.openFrontend():
 			self.oldref = self.session.nav.getCurrentlyPlayingServiceOrGroup()
 			self.session.nav.stopService()
 			if not self.openFrontend():
-				if self.session.pipshown:
-					if hasattr(self.session, 'infobar'):
-						if self.session.infobar.servicelist and self.session.infobar.servicelist.dopipzap:
+				if hasattr(self.session, "pipshown") and self.session.pipshown:
+					if hasattr(self.session, "infobar"):
+						if hasattr(self.session.infobar, "servicelist") and self.session.infobar.servicelist and self.session.infobar.servicelist.dopipzap:
 							self.session.infobar.servicelist.togglePipzap()
-					if hasattr(self.session, 'pip'):
+					if hasattr(self.session, "pip"):
 						del self.session.pip
 					self.session.pipshown = False
 				if not self.openFrontend():
@@ -321,6 +376,8 @@ class AutoDiseqc(ConfigListScreen, Screen):
 
 		self.statusTimer = eTimer()
 		self.statusTimer.callback.append(self.statusCallback)
+		self.waitCloseTimer = eTimer()
+		self.waitCloseTimer.callback.append(self.waitClose)
 		self.tunerStatusTimer = eTimer()
 		self.tunerStatusTimer.callback.append(self.tunerStatusCallback)
 		self.startStatusTimer()
@@ -331,7 +388,9 @@ class AutoDiseqc(ConfigListScreen, Screen):
 			self.raw_channel.receivedTsidOnid.get().remove(self.gotTsidOnid)
 
 	def keyCancel(self):
-		self.abort = True
+		if not self.abort:
+			self.abort = True
+			self["key_red"].setText(" ")
 
 	def keyOK(self):
 		return
@@ -375,7 +434,10 @@ class AutoDiseqc(ConfigListScreen, Screen):
 				config.Nims[self.feid].diseqcMode.value = "single"
 				if self.sat_frequencies[self.index][self.SAT_TABLE_ORBPOS] == 360 and not self.found_sats:
 					config.Nims[self.feid].simpleDiSEqCSetCircularLNB.value = True
-					self.circular_setup = True
+					self.circular_setup = 1
+				if self.sat_frequencies[self.index][self.SAT_TABLE_ORBPOS] == 560 and not self.found_sats:
+					config.Nims[self.feid].simpleDiSEqCSetCircularLNB.value = True
+					self.circular_setup = 2
 
 			config.Nims[self.feid].configMode.value = "simple"
 			config.Nims[self.feid].simpleDiSEqCSetVoltageTone = self.simple_tone
@@ -393,7 +455,7 @@ class AutoDiseqc(ConfigListScreen, Screen):
 				self.tunerStopScan(False)
 				return
 
-			if self.circular_setup:
+			if self.circular_setup == 1:
 				if self.raw_channel:
 					self.raw_channel.receivedTsidOnid.get().remove(self.gotTsidOnid)
 				del self.frontend
@@ -462,16 +524,21 @@ class AutoDiseqc(ConfigListScreen, Screen):
 			self.tunerStopScan(False)
 			return
 
+		title_name = _("Tuner status:")
 		if dict["tuner_state"] == "TUNING":
-			self["tunerstatusbar"].setText(_("Tuner status:") + " " + _("TUNING"))
+			self["tunerstatusbar"].setText(title_name + " " + _("TUNING"))
+		elif dict["tuner_state"] == "FAILED":
+			self["tunerstatusbar"].setText(title_name + " " + _("FAILED"))
+		elif dict["tuner_state"] == "LOSTLOCK":
+			self["tunerstatusbar"].setText(title_name + " " + _("LOSTLOCK"))
 		elif dict["tuner_state"] == "LOCKED":
-			self["tunerstatusbar"].setText(_("Tuner status:") + " " + _("ACQUIRING TSID/ONID"))
+			self["tunerstatusbar"].setText(title_name + " " + _("ACQUIRING TSID/ONID"))
 		elif dict["tuner_state"] == "IDLE":
-			self["tunerstatusbar"].setText(_("Tuner status:") + " " + _("IDLE"))
+			self["tunerstatusbar"].setText(title_name + " " + _("IDLE"))
 		elif dict["tuner_state"] == "UNKNOWN":
-			self["tunerstatusbar"].setText(_("Tuner status:") + " " + _("UNKNOWN"))
-		elif dict["tuner_state"] == "LOSTLOCK" or dict["tuner_state"] == "FAILED":
-			self["tunerstatusbar"].setText(_("Tuner status:") + " " + _("FAILED"))
+			self["tunerstatusbar"].setText(title_name + " " + _("UNKNOWN"))
+
+		if dict["tuner_state"] in ("LOSTLOCK", "FAILED"):
 			self.tunerStopScan(False)
 			return
 
@@ -491,11 +558,18 @@ class AutoDiseqc(ConfigListScreen, Screen):
 		else:
 			self.tunerStopScan(False)
 
+	def waitClose(self):
+		self.close(len(self.found_sats) > 0)
+
 	def tunerStopScan(self, result):
+		if self.waitCloseTimer.isActive():
+			return
+
 		if self.abort:
 			self.setupClear()
 			self.close(False)
 			return
+
 		if result:
 			self.found_sats.append((self.diseqc_ports[self.port_index], self.sat_frequencies[self.index][self.SAT_TABLE_ORBPOS], self.sat_frequencies[self.index][self.SAT_TABLE_NAME]))
 			self.index = 0
@@ -507,16 +581,19 @@ class AutoDiseqc(ConfigListScreen, Screen):
 				self.port_index += 1
 
 		if len(self.found_sats) > 0:
-			self.list = []
+			lst = []
 			for x in self.found_sats:
-				self.list.append((_("DiSEqC port %s: %s") % (x[0], x[2]), ConfigNothing()))
-			self["config"].list = self.list
+				lst.append((_("DiSEqC port %s: %s") % (x[0], x[2]), ConfigNothing()))
+			self["config"].list = lst
 			self["config"].setCurrentIndex(len(self.found_sats) - 1)
 
 		if self.nr_of_ports == self.port_index:
 			self.state = 99
 			self.setupSave()
-			self.close(len(self.found_sats) > 0)
+			if len(self.found_sats) > 0:
+				self.waitCloseTimer.start(4000, True)
+			else:
+				self.close(False)
 			return
 
 		for x in self.found_sats:

--- a/lib/python/Screens/Satconfig.py
+++ b/lib/python/Screens/Satconfig.py
@@ -375,9 +375,9 @@ class NimSetup(Setup, ServiceStopScreen):
 		self.saveAll(reopen=True)
 		return True
 
-	def autoDiseqcRun(self, ports):
+	def autoDiseqcRun(self, ports, order="all"):
 		self.stopService()
-		self.session.openWithCallback(self.autoDiseqcCallback, AutoDiseqc, self.slotid, ports, self.nimConfig.simpleDiSEqCSetVoltageTone, self.nimConfig.simpleDiSEqCOnlyOnSatChange)
+		self.session.openWithCallback(self.autoDiseqcCallback, AutoDiseqc, self.slotid, ports, self.nimConfig.simpleDiSEqCSetVoltageTone, self.nimConfig.simpleDiSEqCOnlyOnSatChange, order)
 
 	def autoDiseqcCallback(self, result):
 		from Screens.Wizard import Wizard
@@ -709,7 +709,15 @@ class NimSetup(Setup, ServiceStopScreen):
 
 	def key_yellow(self):
 		if self.nimConfig.configMode.value == "simple" and self.nimConfig.diseqcMode.value in ("single", "diseqc_a_b", "diseqc_a_b_c_d") and (not self.nim.isCombined() or self.nimConfig.configModeDVBS.value):
-			self.autoDiseqcRun(self.nimConfig.diseqcMode.value == "diseqc_a_b_c_d" and 4 or self.nimConfig.diseqcMode.value == "diseqc_a_b" and 2 or 1)
+			east_order = self.nimConfig.diseqcMode.value == "single" and ("13/19.2/23.5/28.2/4.8/9/16/36/56 - °E", "east") or ("13/19.2/23.5/28.2/4.8/9/16 - °E", "east")
+			menu = [(_("All"), "all"), ("13/19.2/23.5/28.2 - °E", "astra"), east_order, ("0.8/5/30 - °W", "west")]
+			if self.nimConfig.diseqcMode.value == "single":
+				menu.append(("36/56 - °E" + _(" (circular LNB)"), "circular"))
+			menu.append((_("No"), "no"))
+			def cb(choice):
+				if choice and choice[1] != "no":
+					self.autoDiseqcRun(self.nimConfig.diseqcMode.value == "diseqc_a_b_c_d" and 4 or self.nimConfig.diseqcMode.value == "diseqc_a_b" and 2 or 1, choice[1])
+			self.session.openWithCallback(cb, ChoiceBox, title=_("Select satellite list:"), list=menu)
 		elif self.configMode:
 			self.nimConfig.configMode.selectNext()
 			self["config"].invalidate(self.configMode)


### PR DESCRIPTION
-divide the satellites into several groups (west, east, central, circular)
-update data of many frequencies (old frequencies do not exist for a long time)
-add a 4 second pause at the last satellite found (before closing the window)
-minor code optimization (for red button/check status/circular lnb) 
-add two sat 4.8E/56E circular lnb
-[Satconfig] create a list(all,west, east, central, circular) to select the required satellites (yellow button)
green button (select all satellites - as before)