### PR TITLE
Fix ServiceReference/eServiceReference mess

### DIFF
--- a/lib/python/ServiceReference.py
+++ b/lib/python/ServiceReference.py
@@ -1,62 +1,133 @@
 from enigma import eServiceReference, eServiceCenter, getBestPlayableServiceReference
 import NavigationInstance
 
-
-class ServiceReference(eServiceReference):
-	def __init__(self, ref, reftype=eServiceReference.idInvalid, flags=0, path=''):
-		if reftype != eServiceReference.idInvalid:
-			self.ref = eServiceReference(reftype, flags, path)
-		elif not isinstance(ref, eServiceReference):
-			self.ref = eServiceReference(ref or "")
-		else:
-			self.ref = ref
-		self.serviceHandler = eServiceCenter.getInstance()
-
-	def __str__(self):
-		return self.ref.toString()
-
-	def getServiceName(self):
-		info = self.info()
-		return info and info.getName(self.ref) or ""
-
-	def info(self):
-		return self.serviceHandler.info(self.ref)
-
-	def list(self):
-		return self.serviceHandler.list(self.ref)
-
-	def getType(self):
-		return self.ref.type
-
-	def getPath(self):
-		return self.ref.getPath()
-
-	def getFlags(self):
-		return self.ref.flags
-
-	def isRecordable(self):
-		ref = self.ref
-		return ref.flags & eServiceReference.isGroup or (ref.type == eServiceReference.idDVB or ref.type == eServiceReference.idDVB + 0x100 or ref.type == 0x2000 or ref.type == 0x1001)
+# Global helper functions
 
 
-def getPlayingref(ref):
+def getPlayingRef():
 	playingref = None
 	if NavigationInstance.instance:
 		playingref = NavigationInstance.instance.getCurrentlyPlayingServiceReference()
-	if not playingref:
-		playingref = eServiceReference()
-	return playingref
+	return playingref or eServiceReference()
 
 
-def isPlayableForCur(ref):
-	info = eServiceCenter.getInstance().info(ref)
-	return info and info.isPlayable(ref, getPlayingref(ref))
+def isPlayableForCur(serviceref):
+	info = eServiceCenter.getInstance().info(serviceref)
+	return info and info.isPlayable(serviceref, getPlayingRef())
 
 
-def resolveAlternate(ref):
+def resolveAlternate(serviceref):
 	nref = None
-	if ref.flags & eServiceReference.isGroup:
-		nref = getBestPlayableServiceReference(ref, getPlayingref(ref))
+	if serviceref.flags & eServiceReference.isGroup:
+		nref = getBestPlayableServiceReference(serviceref, getPlayingRef())
 		if not nref:
-			nref = getBestPlayableServiceReference(ref, eServiceReference(), True)
+			nref = getBestPlayableServiceReference(serviceref, eServiceReference(), True)
 	return nref
+
+# Extensions to eServiceReference
+
+
+@staticmethod
+def __fromDirectory(path):
+	ref = eServiceReference(eServiceReference.idFile,
+			eServiceReference.flagDirectory |
+			eServiceReference.shouldSort | eServiceReference.sort1, path)
+	ref.setData(0, 1)
+	return ref
+
+
+eServiceReference.fromDirectory = __fromDirectory
+
+eServiceReference.isPlayback = lambda serviceref: "0:0:0:0:0:0:0:0:0" in serviceref.toCompareString()
+
+# Apply ServiceReference method proxies to the eServiceReference object so the two classes can be used interchangeably
+# These are required for ServiceReference backwards compatibility
+eServiceReference.isRecordable = lambda serviceref: serviceref.flags & eServiceReference.isGroup or (serviceref.type == eServiceReference.idDVB or serviceref.type == eServiceReference.idDVB + 0x100 or serviceref.type == 0x2000 or serviceref.type == 0x1001 or serviceref.type == eServiceReference.idServiceMP3)
+
+
+def __repr(serviceref):
+	chnum = serviceref.getChannelNum()
+	chnum = ", ChannelNum=" + str(chnum) if chnum else ""
+	return "eServiceReference(Name=%s%s, String=%s)" % (serviceref.getServiceName(), chnum, serviceref.toString())
+
+
+eServiceReference.__repr__ = __repr
+
+
+def __toString(serviceref):
+	return serviceref.toString()
+
+
+eServiceReference.__str__ = __toString
+
+
+def __getServiceName(serviceref):
+	info = eServiceCenter.getInstance().info(serviceref)
+	return info and info.getName(serviceref) or ""
+
+
+eServiceReference.getServiceName = __getServiceName
+
+
+def __info(serviceref):
+	return eServiceCenter.getInstance().info(serviceref)
+
+
+eServiceReference.info = __info
+
+
+def __list(serviceref):
+	return eServiceCenter.getInstance().list(serviceref)
+
+
+eServiceReference.list = __list
+
+# ref is obsolete but kept for compatibility.
+# A ServiceReference *is* an eServiceReference now, so you no longer need to use .ref
+
+
+def __getRef(serviceref):
+	return serviceref
+
+
+def __setRef(self, serviceref):
+	eServiceReference.__init__(self, serviceref)
+
+
+eServiceReference.ref = property(__getRef, __setRef,)
+
+# getType is obsolete but kept for compatibility. Use "serviceref.type" instead
+
+
+def __getType(serviceref):
+	return serviceref.type
+
+
+eServiceReference.getType = __getType
+
+# getFlags is obsolete but kept for compatibility. Use "serviceref.flags" instead
+
+
+def __getFlags(serviceref):
+	return serviceref.flags
+
+
+eServiceReference.getFlags = __getFlags
+
+
+# Compatibility class that exposes eServiceReference as ServiceReference
+# Don't use this for new code. eServiceReference now supports everything in one single type
+class ServiceReference(eServiceReference):
+	def __new__(cls, ref, reftype=eServiceReference.idInvalid, flags=0, path=''):
+		# if trying to copy an eServiceReference object, turn it into a ServiceReference type and return it
+		if reftype == eServiceReference.idInvalid and isinstance(ref, eServiceReference):
+			new = ref
+			new.__class__ = ServiceReference
+			return new
+		return eServiceReference.__new__(cls)
+
+	def __init__(self, ref, reftype=eServiceReference.idInvalid, flags=0, path=''):
+		if reftype != eServiceReference.idInvalid:
+			eServiceReference.__init__(self, reftype, flags, path)
+		elif not isinstance(ref, eServiceReference):
+			eServiceReference.__init__(self, ref or "")


### PR DESCRIPTION
The ServiceReference class is a consistent cause of bugs and developer confusion. This commit extends the Python eServiceReference proxy with methods previously available on ServiceReference so we can just use eServiceReference everywhere in Python.

Author: @SimonCapewell