### PR TITLE
HDMI-CEC - added option for IP test before Standby or Deep standby

### DIFF
--- a/lib/python/Components/HdmiCec.py
+++ b/lib/python/Components/HdmiCec.py
@@ -2,6 +2,7 @@ import struct
 import os
 import time
 from Components.config import config, ConfigSelection, ConfigYesNo, ConfigSubsection, ConfigText, ConfigCECAddress, ConfigLocations, ConfigDirectory, ConfigNothing, ConfigIP
+from Components.Console import Console
 from enigma import eHdmiCEC, eActionMap
 from Tools.StbHardware import getFPWasTimerWakeup
 import NavigationInstance

--- a/lib/python/Components/HdmiCec.py
+++ b/lib/python/Components/HdmiCec.py
@@ -1,7 +1,7 @@
 import struct
 import os
 import time
-from Components.config import config, ConfigSelection, ConfigYesNo, ConfigSubsection, ConfigText, ConfigCECAddress, ConfigLocations, ConfigDirectory, ConfigNothing
+from Components.config import config, ConfigSelection, ConfigYesNo, ConfigSubsection, ConfigText, ConfigCECAddress, ConfigLocations, ConfigDirectory, ConfigNothing, ConfigIP
 from enigma import eHdmiCEC, eActionMap
 from Tools.StbHardware import getFPWasTimerWakeup
 import NavigationInstance
@@ -102,6 +102,8 @@ config.hdmicec.bookmarks = ConfigLocations(default=[LOGPATH])
 config.hdmicec.log_path = ConfigDirectory(LOGPATH)
 config.hdmicec.next_boxes_detect = ConfigYesNo(default=False)
 config.hdmicec.sourceactive_zaptimers = ConfigYesNo(default=False)
+config.hdmicec.ethernet_pc_used = ConfigYesNo(default=False)
+config.hdmicec.pc_ip = ConfigIP(default = [192,168,3,7])
 
 
 class HdmiCec:
@@ -120,6 +122,9 @@ class HdmiCec:
 		self.repeat = eTimer()
 		self.repeat.timeout.get().append(self.wakeupMessages)
 		self.queue = []
+
+		self.delayEthernetPC = eTimer()
+		self.delayEthernetPC.timeout.get().append(self.ethernetPCActive)
 
 		self.delay = eTimer()
 		self.delay.timeout.get().append(self.sendStandbyMessages)
@@ -300,7 +305,19 @@ class HdmiCec:
 				self.sendMessage(5, "standby")
 
 	def secondBoxActive(self):
+		if config.hdmicec.ethernet_pc_used.value:
+			self.delayEthernetPC.start(100, True)
 		self.sendMessage(0, "getpowerstatus")
+
+	def ethernetPCActive(self):
+		def result(data, retval, extra):
+			if retval == 0:
+				self.useStandby = False
+				print("[HDMI-CEC] found PC corresponding from address %s" % ip)
+		if config.hdmicec.ethernet_pc_used.value:
+			ip = "%d.%d.%d.%d" % tuple(config.hdmicec.pc_ip.value)
+			cmd = "ping -c 1 -W 1 %s >/dev/null 2>&1" % ip
+			Console().ePopen(cmd, result)
 
 	def onLeaveStandby(self):
 		self.wakeupMessages()

--- a/lib/python/Plugins/SystemPlugins/HdmiCEC/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/HdmiCEC/plugin.py
@@ -62,6 +62,9 @@ class HdmiCECSetupScreen(ConfigListScreen, Screen):
 			self.list.append((_("Repeat leave standby messages"), config.hdmicec.repeat_wakeup_timer, _("The command to wake from standby will be sent multiple times.")))
 			self.list.append((_("Send 'sourceactive' before zap timers"), config.hdmicec.sourceactive_zaptimers, _("Command the TV to switch to the correct HDMI input when zap timers activate.")))
 			self.list.append((_("Detect next boxes before standby"), config.hdmicec.next_boxes_detect, _("Before sending the command to switch the TV to standby, the receiver tests if all the other devices plugged to TV are in standby. If they are not, the 'sourceinactive' command will be sent to the TV instead of the 'standby' command.")))
+			self.list.append((_("Detect PC before standby"), config.hdmicec.ethernet_pc_used, _("Before sending the command to switch the TV to standby, the receiver tests if PC connected to TV is in standby. If it is not, the 'sourceinactive' command will be sent to the TV instead of the 'standby' command.")))
+			if config.hdmicec.ethernet_pc_used.value:
+				self.list.append((8 * " " + _("IP"), config.hdmicec.pc_ip))
 			self.list.append((_("Debug to file"), config.hdmicec.debug, _("If enabled, a log will be kept of CEC protocol traffic ('hdmicec.log')")))
 			self.logpath_entry = (_("Select path for logfile"), config.hdmicec.log_path, _("Press OK to select the save location of the log file."))
 			if config.hdmicec.debug.value != "0":

--- a/lib/python/Screens/Standby.py
+++ b/lib/python/Screens/Standby.py
@@ -343,7 +343,7 @@ class TryQuitMainloop(MessageBox):
 				if not inStandby:
 					if os.path.exists("/usr/script/standby_enter.sh"):
 						Console().ePopen("/usr/script/standby_enter.sh")
-					if BoxInfo.getItem("HasHDMI-CEC") and config.hdmicec.enabled.value and ((config.hdmicec.control_tv_standby.value and config.hdmicec.next_boxes_detect.value) or config.hdmicec.handle_deepstandby_events.value != "no"):
+					if BoxInfo.getItem("HasHDMI-CEC") and config.hdmicec.enabled.value and ((config.hdmicec.control_tv_standby.value and (config.hdmicec.next_boxes_detect.value or config.hdmicec.ethernet_pc_used.value)) or config.hdmicec.handle_deepstandby_events.value != "no"):
 						if config.hdmicec.control_tv_standby.value and config.hdmicec.next_boxes_detect.value:
 							import Components.HdmiCec
 							Components.HdmiCec.hdmi_cec.secondBoxActive()


### PR DESCRIPTION
- when this option is enabled and the corresponding PC responds to the ping on the network,
 during the transition of the box to standby/deep standby, a 'sourceinactive' is sent instead of 'standby',
 preventing the TV from turning off.
- By default, this option is disabled.