### PR TITLE
[Pixmap]

### DIFF
--- a/lib/python/Components/Pixmap.py
+++ b/lib/python/Components/Pixmap.py
@@ -1,10 +1,10 @@
-from Components.ConditionalWidget import ConditionalWidget
-from Components.GUIComponent import GUIComponent
+from os import path
 
 from enigma import ePixmap, eTimer
 
-from Tools.Directories import resolveFilename, SCOPE_CURRENT_SKIN
-from os import path
+from Components.ConditionalWidget import ConditionalWidget
+from Components.GUIComponent import GUIComponent
+from Tools.Directories import resolveFilename, fileExists, SCOPE_GUISKIN, SCOPE_LCDSKIN
 from skin import loadPixmap
 
 
@@ -13,15 +13,48 @@ class Pixmap(GUIComponent):
 
 	def __init__(self):
 		GUIComponent.__init__(self)
+		self.xOffset, self.yOffset = 0, 0
 		self.pixmap = None
 
 	def getSize(self):
 		s = self.instance.size()
-		return (s.width(), s.height())
-	
+		return s.width(), s.height()
+
 	def setPixmap(self, pixmap):
 		self.pixmap = pixmap
 		self.instance.setPixmap(self.pixmap)
+
+	def applySkin(self, desktop, screen):
+		if self.skinAttributes is not None:
+			attribs = []
+			for (attrib, value) in self.skinAttributes:
+				if attrib == "offset":
+					self.xOffset, self.yOffset = map(int, value.split(','))
+				else:
+					attribs.append((attrib, value))
+			self.skinAttributes = attribs
+		return GUIComponent.applySkin(self, desktop, screen)
+
+	def move(self, x, y=None):
+		if y is None:
+			y = x.y()
+			x = x.x()
+		GUIComponent.move(self, x - self.xOffset, y - self.yOffset)
+
+	def setPosition(self, x, y):
+		self.move(x, y)
+
+	def getPosition(self):
+		x, y = GUIComponent.getPosition(self)
+		return x + self.xOffset, y + self.yOffset
+
+	def setOffset(self, x, y):
+		oldx, oldy = self.getPosition()
+		self.xOffset, self.yOffset = x, y
+		self.move(oldx, oldy)
+
+	def getOffset(self):
+		return self.xOffset, self.yOffset
 
 
 class PixmapConditional(ConditionalWidget, Pixmap):
@@ -36,14 +69,19 @@ class MovingPixmap(Pixmap):
 
 		self.moving = False
 
-		# TODO: get real values
-		self.x = 0.0
-		self.y = 0.0
+		# get actual values after skin applied
+		self.x = 0
+		self.y = 0
 
 		self.clearPath()
 
 		self.moveTimer = eTimer()
 		self.moveTimer.callback.append(self.doMove)
+
+	def applySkin(self, desktop, screen):
+		ret = Pixmap.applySkin(self, desktop, screen)
+		self.x, self.y = self.getPosition()
+		return ret
 
 	def clearPath(self, repeated=False):
 		if self.moving:
@@ -63,31 +101,38 @@ class MovingPixmap(Pixmap):
 
 	def startMoving(self):
 		if not self.moving:
-			self.time = self.path[self.currDest][2]
-			self.stepX = (self.path[self.currDest][0] - self.x) / float(self.time)
-			self.stepY = (self.path[self.currDest][1] - self.y) / float(self.time)
+			try:
+				self.time = self.path[self.currDest][2]
+				self.x, self.y = self.getPosition()
+				self.stepX = (self.path[self.currDest][0] - self.x) / float(self.time)
+				self.stepY = (self.path[self.currDest][1] - self.y) / float(self.time)
 
-			self.moving = True
-			self.moveTimer.start(100)
+				self.moving = True
+				self.moveTimer.start(100)
+			except:  # moving not possible... widget not there yet/any more... stop moving
+				self.stopMoving()
 
 	def stopMoving(self):
 		self.moving = False
 		self.moveTimer.stop()
 
 	def doMove(self):
-		self.x += self.stepX
-		self.y += self.stepY
 		self.time -= 1
+		if self.time == 0:
+			self.x, self.y = self.path[self.currDest][0:2]
+		else:
+			self.x += self.stepX
+			self.y += self.stepY
 		try:
 			self.move(int(self.x), int(self.y))
-		except: # moving not possible... widget not there any more... stop moving
+		except:  # moving not possible... widget not there any more... stop moving
 			self.stopMoving()
 
 		if self.time == 0:
 			self.currDest += 1
 			self.moveTimer.stop()
 			self.moving = False
-			if self.currDest >= len(self.path): # end of path
+			if self.currDest >= len(self.path):  # end of path
 				if self.repeated:
 					self.currDest = 0
 					self.moving = False
@@ -101,7 +146,7 @@ class MultiPixmap(Pixmap):
 	def __init__(self):
 		Pixmap.__init__(self)
 		self.pixmapfiles = []
-		self.pixmaps = {}
+		self.pixmaps = []
 
 	def applySkin(self, desktop, screen):
 		self.desktop = desktop
@@ -112,13 +157,12 @@ class MultiPixmap(Pixmap):
 			for (attrib, value) in self.skinAttributes:
 				if attrib == "pixmaps":
 					pixmaps = value.split(',')
-					for p in pixmaps:
-						self.pixmapfiles.append(resolveFilename(SCOPE_CURRENT_SKIN, p, path_prefix=skin_path_prefix))
-						#self.pixmaps.append(loadPixmap(resolveFilename(SCOPE_CURRENT_SKIN, p, path_prefix=skin_path_prefix), desktop))
-					if not pixmap:
-						pixmap = resolveFilename(SCOPE_CURRENT_SKIN, pixmaps[0], path_prefix=skin_path_prefix)
+					self.pixmapfiles = [pngfile for p in pixmaps if (pngfile := self.checkPaths(p.strip(), skin_path_prefix))]
+					if not pixmap and self.pixmapfiles:
+						pixmap = self.pixmapfiles[0]
 				elif attrib == "pixmap":
-					pixmap = resolveFilename(SCOPE_CURRENT_SKIN, value, path_prefix=skin_path_prefix)
+					if (pngfile := self.checkPaths(value, skin_path_prefix)):
+						pixmap = pngfile
 				else:
 					attribs.append((attrib, value))
 			if pixmap:
@@ -126,13 +170,16 @@ class MultiPixmap(Pixmap):
 			self.skinAttributes = attribs
 		return GUIComponent.applySkin(self, desktop, screen)
 
+	def checkPaths(self, value, skin_path_prefix):
+		return (fileExists(pngfile := resolveFilename(SCOPE_GUISKIN, value, path_prefix=skin_path_prefix)) or fileExists(pngfile := resolveFilename(SCOPE_LCDSKIN, value, path_prefix=skin_path_prefix))) and pngfile
+
 	def setPixmapNum(self, x):
 		if self.instance:
-			if len(self.pixmapfiles) > x:
-				if not self.pixmaps:
-					self.width = self.getSize()[0]
-				if x not in self.pixmaps:
-					self.pixmaps[x] = loadPixmap(self.pixmapfiles[x], self.desktop, self.width)
+			if not self.pixmaps and self.pixmapfiles:
+				width, height = self.getSize()
+				for file in self.pixmapfiles:
+					self.pixmaps.append(loadPixmap(file, self.desktop, width, height))
+			if len(self.pixmaps) > x:
 				self.instance.setPixmap(self.pixmaps[x])
 			else:
-				print("setPixmapNum(%d) failed! defined pixmaps:" % (x), self.pixmaps)
+				print("[MultiPixmap] setPixmapNum(%d) failed! defined pixmaps:" % x, self.pixmaps)


### PR DESCRIPTION
Add skinnable offsets to Pixmaps. The offset can be used to position the pixmap relative to an offset from the pixmap top left corner. Offsets need not be within the pixmap.

Remove the local x, y instance variables from MovablePixmap. Move the pixmap using a variant of the Bresenham line drawing algorithm so that the integer widget position can be used, but movement is pixel accurate.

Add a move() method for immediate positioning to MovablePixmap.

Help menu in main screen errors - simplify MovingPixmap Remove overcomplicated code to calculate intermediate points when moving a MovingPixmap.

Retain the calls to the pixmap offset support in Pixmap, protections against startMoving() being called before the widget instance is created, and ensure that the pixmap ends at the exact path segment endpoints rather than potentially being affected by float-to-int round down.