### PR TITLE
DVB subtitles - added color filters

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -135,7 +135,7 @@
 		<item level="0" text="Show background behind subtitles" description="Configure if behind the subtitles a background is shown.">config.subtitles.showbackground</item>
 		<item level="2" text="Subtitle font size" description="Configure the font size of the subtitles.">config.subtitles.subtitle_fontsize</item>
 		<item level="2" text="Subtitle delay when timing lacks" description="Configure the subtitle delay when timing information is not available.">config.subtitles.subtitle_noPTSrecordingdelay</item>
-		<item level="0" text="Yellow DVB subtitles" description="When enabled, graphical DVB subtitles will be displayed in yellow, instead of the original color.">config.subtitles.dvb_subtitles_yellow</item>
+		<item level="0" text="DVB subtitles color filter" description="A color filter can be used for better readability of DVB subtitles.">config.subtitles.dvb_subtitles_color</item>
 		<item level="2" text="Use original DVB subtitle position" description="When enabled, graphical DVB subtitles will be displayed at their original position.">config.subtitles.dvb_subtitles_original_position</item>
 		<item level="2" text="Center DVB subtitles" description="When enabled, graphical DVB subtitles will be centered horizontally.">config.subtitles.dvb_subtitles_centered</item>
 		<item level="2" text="Subtitle delay when timing is bad" description="Configure an additional delay to improve subtitle synchronisation.">config.subtitles.subtitle_bad_timing_delay</item>

--- a/lib/dvb/subtitle.cpp
+++ b/lib/dvb/subtitle.cpp
@@ -1043,7 +1043,7 @@ void eDVBSubtitleParser::subtitle_redraw(int page_id)
 			}
 
 			int bcktrans = eConfigManager::getConfigIntValue("config.subtitles.dvb_subtitles_backtrans");
-			bool yellow = eConfigManager::getConfigBoolValue("config.subtitles.dvb_subtitles_yellow");
+			int color = eConfigManager::getConfigIntValue("config.subtitles.dvb_subtitles_color");
 
 			for (int i=0; i<clut_size; ++i)
 			{
@@ -1057,9 +1057,36 @@ void eDVBSubtitleParser::subtitle_redraw(int page_id)
 						y -= 16;
 						cr -= 128;
 						cb -= 128;
-						palette[i].r = MAX(MIN(((298 * y            + 460 * cr) / 256), 255), 0);
-						palette[i].g = MAX(MIN(((298 * y -  55 * cb - 137 * cr) / 256), 255), 0);
-						palette[i].b = yellow?0:MAX(MIN(((298 * y + 543 * cb  ) / 256), 255), 0);
+						if (color == 1) // yellow
+						{
+							palette[i].r = MAX(MIN(((298 * y            + 460 * cr) / 256), 255), 0);
+							palette[i].g = MAX(MIN(((298 * y -  55 * cb - 137 * cr) / 256), 255), 0);
+							palette[i].b = 0;
+						}
+						else if (color == 2) // green
+						{
+							palette[i].r = 0;
+							palette[i].g = MAX(MIN(((298 * y) / 256), 255), 0);
+							palette[i].b = 0;
+						}
+						else if (color == 3) // magenta
+						{
+							palette[i].r = MAX(MIN(((298 * y + 460 * cr) / 256), 255), 0);
+							palette[i].g = 0;
+							palette[i].b = MAX(MIN(((298 * y + 543 * cb) / 256), 255), 0);
+						}
+						else if (color == 4) // cyan
+						{
+							palette[i].r = 0;
+							palette[i].g = MAX(MIN(((298 * y + 543 * cb) / 256), 255), 0);
+							palette[i].b = MAX(MIN(((298 * y + 543 * cb) / 256), 255), 0);
+						}
+						else // original
+						{
+							palette[i].r = MAX(MIN(((298 * y            + 460 * cr) / 256), 255), 0);
+							palette[i].g = MAX(MIN(((298 * y -  55 * cb - 137 * cr) / 256), 255), 0);
+							palette[i].b = MAX(MIN(((298 * y + 543 * cb) / 256), 255), 0);
+						}
 						if (bcktrans)
 						{
 							if (palette[i].r || palette[i].g || palette[i].b)

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -649,7 +649,7 @@ def InitUsageConfig():
 			subtitle_delay_choicelist.append((str(i), _("%2.1f sec") % (i / 90000.)))
 	config.subtitles.subtitle_noPTSrecordingdelay = ConfigSelection(default="315000", choices=subtitle_delay_choicelist)
 
-	config.subtitles.dvb_subtitles_yellow = ConfigYesNo(default=False)
+	config.subtitles.dvb_subtitles_color = ConfigSelection(default="0", choices=[("0", _("Off")), ("1", _("Yellow")), ("2", _("Green")), ("3", _("Magenta")), ("4", _("Cyan"))])
 	config.subtitles.dvb_subtitles_original_position = ConfigSelection(default="0", choices=[("0", _("Original")), ("1", _("Fixed")), ("2", _("Relative"))])
 	config.subtitles.dvb_subtitles_centered = ConfigYesNo(default=False)
 	config.subtitles.subtitle_bad_timing_delay = ConfigSelection(default="0", choices=subtitle_delay_choicelist)

--- a/lib/python/Screens/AudioSelection.py
+++ b/lib/python/Screens/AudioSelection.py
@@ -466,7 +466,7 @@ class QuickSubtitlesConfigMenu(ConfigListScreen, Screen):
 		sub = self.infobar.selected_subtitle
 		if sub[0] == 0:  # dvb
 			menu = [
-				getConfigMenuItem("config.subtitles.dvb_subtitles_yellow"),
+				getConfigMenuItem("config.subtitles.dvb_subtitles_color"),
 				getConfigMenuItem("config.subtitles.dvb_subtitles_backtrans"),
 				getConfigMenuItem("config.subtitles.dvb_subtitles_original_position"),
 				(_("Center DVB subtitles"), self.center_dvb_subs),


### PR DESCRIPTION
- Replacement of the original option 'Yellow DVB Subtitles'. Additional colors have been added. It is essentially a color filter applied to the broadcasted DVB subtitles, so the resulting color depends on the original color of the broadcasted DVB subtitles.
- Added yellow, green, magenta and cyan color filters.