### PR TITLE
[ChannelSelection] correctChannelNumber - sanity check ref

### DIFF
--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -2556,7 +2556,7 @@ class ChannelSelection(ChannelSelectionBase, ChannelSelectionEdit, ChannelSelect
 		selected_ref = self.getCurrentSelection()
 		if selected_ref and current_ref and selected_ref.getChannelNum() != current_ref.getChannelNum():
 			oldref = self.session.nav.currentlyPlayingServiceReference
-			if oldref and selected_ref == oldref or (oldref != current_ref and selected_ref == current_ref):
+			if oldref and (selected_ref == oldref or (oldref != current_ref and selected_ref == current_ref)):
 				self.session.nav.currentlyPlayingServiceOrGroup = selected_ref
 				self.session.nav.pnav.navEvent(iPlayableService.evStart)
 		if self.dopipzap:


### PR DESCRIPTION
Traceback (most recent call last):
  File
"/usr/lib/enigma2/python/Components/ActionMap.py", line 56, in action

File "/usr/lib/enigma2/python/Screens/ChannelSelection.py", line 2223, in channelSelected
  File
"/usr/lib/enigma2/python/Screens/ChannelSelection.py", line 2559, in correctChannelNumber
ValueError: invalid null reference in method
'eServiceReference___ne__', argument 2 of type 'eServiceReference const &'