### PR TITLE
[sec] prepareTurnOffSatCR - use original lnb position

### DIFF
--- a/lib/dvb/sec.cpp
+++ b/lib/dvb/sec.cpp
@@ -1141,6 +1141,7 @@ RESULT eDVBSatelliteEquipmentControl::prepare(iDVBFrontend &frontend, const eDVB
 void eDVBSatelliteEquipmentControl::prepareTurnOffSatCR(iDVBFrontend &frontend)
 {
 	eSecCommandList sec_sequence;
+	eDVBSatelliteLNBParameters &lnb_param = m_lnbs[m_lnbidx];
 	long userband, diction;
 
 	frontend.getData(eDVBFrontend::SATCR, userband);
@@ -1174,7 +1175,7 @@ void eDVBSatelliteEquipmentControl::prepareTurnOffSatCR(iDVBFrontend &frontend)
 			unsigned int ub = userband & 0x07;
 			unsigned int encoded_frequency_T = 0;
 			unsigned int mode = 0;
-			unsigned int position = 0;
+			unsigned int position = (lnb_param.SatCR_position - 1) & 0x01;
 			unsigned int bank = (position << 2) | (mode << 0);
 
 			eDVBDiseqcCommand diseqc;
@@ -1206,7 +1207,7 @@ void eDVBSatelliteEquipmentControl::prepareTurnOffSatCR(iDVBFrontend &frontend)
 			unsigned int ub = userband & 0x1f;
 			unsigned int encoded_frequency_T = 0;
 			unsigned int mode = 0;
-			unsigned int position = 0;
+			unsigned int position = (lnb_param.SatCR_position - 1) & 0x3f;
 
 			eDVBDiseqcCommand diseqc;
 			memset(diseqc.data, 0, MAX_DISEQC_LENGTH);


### PR DESCRIPTION
more info:

https://forums.openpli.org/topic/102012-unicable-reset-negeert-positie-parameter/