### PR TITLE
SingleEPG - filter events with timespan with 'stop' button

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -651,6 +651,7 @@
 		<key id="KEY_TV2" mapto="preview" flags="m" />
 		<key id="KEY_REWIND" mapto="prevDay" flags="m" />
 		<key id="KEY_FASTFORWARD" mapto="nextDay" flags="m" />
+		<key id="KEY_STOP" mapto="filter" flags="m" />
 	</map>
 
 	<map context="GMEPGSelectActions">

--- a/data/setup.xml
+++ b/data/setup.xml
@@ -124,6 +124,10 @@
 		<item level="2" text="Location EPG Cache file" description="Define the location of the EPG Cache file.">config.misc.epgcache_filename</item>
 		<item level="2" text="Full description separator" description="Configure separator type used in full description for separate short and extended descriptions.">config.epg.fulldescription_separator</item>
 		<item level="2" text="Replace newlines in EPG" description="Select char for replacing newlines in EPG.">config.epg.replace_newlines</item>
+		<item level="1" text="Enable filtering in SingleEPG" description="Enable setting a time interval for filtering events in SingleEPG using the 'Stop' button.">config.epg.filter</item>
+		<item level="1" text="Start time" indents="4" conditional="config.epg.filter.value" description="Start of the time interval within which an events must start in order to be displayed.">config.epg.filter_start</item>
+		<item level="1" text="End time" indents="4" conditional="config.epg.filter.value" description="End of the time interval within which an events must start in order to be displayed.">config.epg.filter_end</item>
+		<item level="1" text="Toggle Filter Order" indents="4" conditional="config.epg.filter.value" description="Using the 'Stop' button will cyclically switch displaying events starting: 'outside the interval', 'within the interval', and 'without filtering', instead of 'within the interval', 'outside the interval', and 'without filtering'.">config.epg.filter_reversal</item>
 	</setup>
 	<setup key="subtitlesetup" title="Subtitle settings">
 		<item level="0" text="Teletext subtitle color" description="Configure the color of the teletext subtitles.">config.subtitles.ttx_subtitle_colors</item>

--- a/lib/python/Components/EpgList.py
+++ b/lib/python/Components/EpgList.py
@@ -321,11 +321,36 @@ class EPGList(GUIComponent):
 		#print((int(time()) - t)
 		self.selectionChanged()
 
-	def fillSingleEPG(self, service):
+	def filtering_epg(self, epg_list, filtering):
+		def dailySpan(start, end):
+			return list(filter(lambda event: (start <= event_time(event) < end), epg_list))
+		def overnightSpan(start, end):
+			return list(filter(lambda event: (start <= event_time(event) < 1440 or 0 <= event_time(event) < end), epg_list))
+		def event_time(event):
+			return localtime(event[2]).tm_hour * 60 + localtime(event[2]).tm_min
+
+		def minutes(t):
+			return t[0] * 60 + t[1]
+
+		start, end = minutes(config.epg.filter_start.value), minutes(config.epg.filter_end.value)
+		if filtering == 1:
+			if start < end:
+				return dailySpan(start, end)
+			else:
+				return overnightSpan(start, end)
+		elif filtering == 2:
+			if start < end:
+				return overnightSpan(end, start)
+			else:
+				return dailySpan(end, start)
+
+	def fillSingleEPG(self, service, filtering=0):
 		t = int(time())
 		epg_time = t - (int(config.epg.histminutes.value) * 60)
 		test = ['RIBDT', (service.ref.toString(), 0, epg_time, -1)]
 		self.list = self.queryEPG(test)
+		if filtering:
+			self.list = self.filtering_epg(self.list, filtering)
 		self.l.setList(self.list)
 		if t != epg_time:
 			idx = 0

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -505,6 +505,20 @@ def InitUsageConfig():
 	choicelist = [("no", _("no")), ("nothing", _("omit")), ("space", _("space")), ("dot", ". "), ("dash", " - "), ("asterisk", " * "), ("hashtag", " # ")]
 	config.epg.replace_newlines = ConfigSelection(default="no", choices=choicelist)
 
+	config.epg.filter = ConfigYesNo(default=False)
+	config.epg.filter_start = ConfigClock(default=time.mktime((1970, 1, 1, 6, 0, 0, 0, 0, 0)))
+	config.epg.filter_end = ConfigClock(default=time.mktime((1970, 1, 1, 20, 0, 0, 0, 0, 0)))
+	def validateEPGFilterTimes(configElement):
+		def minutes(t):
+			return t[0] * 60 + t[1]
+		start, end = minutes(config.epg.filter_start.value), minutes(config.epg.filter_end.value)
+		if start == end:
+			config.epg.filter_end.value = [(config.epg.filter_end.value[0] + 1) % 24, config.epg.filter_end.value[1]]
+			print("[UsageConfig] EPG filter - start and end times must be different.")
+	config.epg.filter_start.addNotifier(validateEPGFilterTimes)
+	config.epg.filter_end.addNotifier(validateEPGFilterTimes)
+	config.epg.filter_reversal = ConfigYesNo(default=False)
+
 	def correctInvalidEPGDataChange(configElement):
 		eServiceEvent.setUTF8CorrectMode(int(configElement.value))
 	config.epg.correct_invalid_epgdata = ConfigSelection(default="1", choices=[("0", _("Disabled")), ("1", _("Enabled")), ("2", _("Debug"))])

--- a/lib/python/Screens/EpgSelection.py
+++ b/lib/python/Screens/EpgSelection.py
@@ -70,6 +70,7 @@ class EPGSelection(Screen):
 			self.currentService = ServiceReference(service)
 			self.zapFunc = zapFunc
 			self.sort_type = 0
+			self.filtering = 0
 			self.setSortDescription()
 		else:
 			self.setTitle(_("Multi EPG"))
@@ -110,6 +111,7 @@ class EPGSelection(Screen):
 				"nextService": self.nextService, # just used in single epg yet
 				"prevService": self.prevService, # just used in single epg yet
 				"preview": self.eventPreview,
+				"filter": self.stopButtonPressed,
 			})
 		self["actions"].csel = self
 		if parent and hasattr(parent, "fallbackTimer"):
@@ -120,6 +122,7 @@ class EPGSelection(Screen):
 
 	def nextBouquet(self):
 		if self.type == EPG_TYPE_SINGLE:
+			self.resetFiltering()
 			self.resetSortStatus()
 			self.session.openWithCallback(self.channelSelectionCallback, ChannelSelection.SimpleChannelSelection, _("Select channel"), True, True, self.currentService.ref, self.parent and self.parent.epg_bouquet)
 		if self.bouquetChangeCB:
@@ -127,6 +130,7 @@ class EPGSelection(Screen):
 
 	def prevBouquet(self):
 		if self.type == EPG_TYPE_SINGLE:
+			self.resetFiltering()
 			self.resetSortStatus()
 			self.session.openWithCallback(self.channelSelectionCallback, ChannelSelection.SimpleChannelSelection, _("Select channel"), True, True, self.currentService.ref, self.parent and self.parent.epg_bouquet)
 		if self.bouquetChangeCB:
@@ -134,11 +138,13 @@ class EPGSelection(Screen):
 
 	def nextService(self):
 		if self.serviceChangeCB:
+			self.resetFiltering()
 			self.resetSortStatus()
 			self.serviceChangeCB(1, self)
 
 	def prevService(self):
 		if self.serviceChangeCB:
+			self.resetFiltering()
 			self.resetSortStatus()
 			self.serviceChangeCB(-1, self)
 
@@ -219,14 +225,17 @@ class EPGSelection(Screen):
 		elif self.type == EPG_TYPE_SINGLE:
 			service = self.currentService
 			self["Service"].newService(service.ref)
-			if not self.saved_title:
-				self.saved_title = self.instance.getTitle()
-			self.setTitle(self.saved_title + ' - ' + service.getServiceName())
+			self.serviceToTitle(service)
 			li.fillSingleEPG(service)
 		elif self.type == EPG_TYPE_PARTIAL:
 			li.fill_partial_list(self.eventid)
 		else:
 			li.fillSimilarList(self.currentService, self.eventid)
+
+	def serviceToTitle(self, service):
+		if not self.saved_title:
+			self.saved_title = self.instance.getTitle()
+		self.setTitle(self.saved_title + ' - ' + service.getServiceName())
 
 	def eventViewCallback(self, setEvent, setService, val):
 		l = self["list"]
@@ -275,6 +284,24 @@ class EPGSelection(Screen):
 				self.session.open(EPGSelection, ref)
 		else:
 			self.infoKeyPressed()
+
+	def stopButtonPressed(self):
+		if config.epg.filter.value:
+			if self.type == EPG_TYPE_SINGLE:
+				self.resetSortStatus()
+				self.serviceToTitle(self.currentService)
+				title = self.instance.getTitle()
+				begin, end = config.epg.filter_start.value, config.epg.filter_end.value
+				if config.epg.filter_reversal.value:
+					self.filtering = self.filtering - 1 if self.filtering else 2
+				else:
+					self.filtering = (self.filtering + 1) % 3
+				title += '' if self.filtering == 0 else ('   (%02d:%02d - %02d:%02d)' % ((*begin, *end) if self.filtering == 1 else (*end, *begin)))
+				self.setTitle(title)
+				self["list"].fillSingleEPG(self.currentService, self.filtering)
+
+	def resetFiltering(self):
+		self.filtering = 0
 
 	def yellowButtonPressed(self):
 		if self.type == EPG_TYPE_MULTI:


### PR DESCRIPTION
- when browsing through TV programs, it's often easier to search the EPG, for example, only from 20:00 to 01:00. Some channels alternate (e.g., one channel broadcasts from 20:00 to 06:00, and another from 6:00 to 20:00). Therefore, the user can set a time interval, and when viewing the SingleEpg using the Stop button, they can choose to display only events within that interval or, conversely, events outside of it.