### PR TITLE
AutoDiseqc.py: Fix AutoDiseqc during setup wizard

### DIFF
--- a/lib/python/Screens/AutoDiseqc.py
+++ b/lib/python/Screens/AutoDiseqc.py
@@ -432,6 +432,8 @@ class AutoDiseqc(ConfigListScreen, Screen):
 					config.Nims[self.feid].simpleDiSEqCSetCircularLNB.value = True
 					self.circular_setup = 2
 
+			config.Nims[self.feid].configMode.value = "simple"
+
 			self.saveAndReloadNimConfig()
 			self.state += 1
 


### PR DESCRIPTION
AutoDiseqc status 'IDLE' on all satellites.
Nothing found.

Introduced with commit:
https://github.com/OpenPLi/enigma2/commit/5b75b401d3436044ea16b43eb3d6735989f03313