### PR TITLE
SingleEPG - filter events with timespan with 'Stop' button

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -651,6 +651,7 @@
 		<key id="KEY_TV2" mapto="preview" flags="m" />
 		<key id="KEY_REWIND" mapto="prevDay" flags="m" />
 		<key id="KEY_FASTFORWARD" mapto="nextDay" flags="m" />
+		<key id="KEY_STOP" mapto="filter" flags="m" />
 	</map>
 
 	<map context="GMEPGSelectActions">

--- a/data/setup.xml
+++ b/data/setup.xml
@@ -124,6 +124,11 @@
 		<item level="2" text="Location EPG Cache file" description="Define the location of the EPG Cache file.">config.misc.epgcache_filename</item>
 		<item level="2" text="Full description separator" description="Configure separator type used in full description for separate short and extended descriptions.">config.epg.fulldescription_separator</item>
 		<item level="2" text="Replace newlines in EPG" description="Select char for replacing newlines in EPG.">config.epg.replace_newlines</item>
+		<item level="1" text="Enable filtering in SingleEPG" description="Enable setting a time interval for filtering events in SingleEPG using the 'Stop' button.">config.epg.filter</item>
+		<item level="1" text="Start time" indents="4" conditional="config.epg.filter.value" description="Start of the time interval within which an events must start in order to be displayed.">config.epg.filter_start</item>
+		<item level="1" text="End time" indents="4" conditional="config.epg.filter.value" description="End of the time interval within which an events must start in order to be displayed.">config.epg.filter_end</item>
+		<item level="1" text="Toggle Filter Order" indents="4" conditional="config.epg.filter.value" description="Using the 'Stop' button will cyclically switch displaying events starting: 'outside the interval', 'within the interval', and 'without filtering', instead of 'within the interval', 'outside the interval', and 'without filtering'.">config.epg.filter_reversal</item>
+		<item level="1" text="Keep sorting" indents="4" conditional="config.epg.filter.value" description="When switching the filter, the selected EPG sorting is preserved.">config.epg.filter_keepsorting</item>
 	</setup>
 	<setup key="subtitlesetup" title="Subtitle settings">
 		<item level="0" text="Teletext subtitle color" description="Configure the color of the teletext subtitles.">config.subtitles.ttx_subtitle_colors</item>

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -505,6 +505,21 @@ def InitUsageConfig():
 	choicelist = [("no", _("no")), ("nothing", _("omit")), ("space", _("space")), ("dot", ". "), ("dash", " - "), ("asterisk", " * "), ("hashtag", " # ")]
 	config.epg.replace_newlines = ConfigSelection(default="no", choices=choicelist)
 
+	config.epg.filter = ConfigYesNo(default=False)
+	config.epg.filter_start = ConfigClock(default=time.mktime((1970, 1, 1, 6, 0, 0, 0, 0, 0)))
+	config.epg.filter_end = ConfigClock(default=time.mktime((1970, 1, 1, 20, 0, 0, 0, 0, 0)))
+	def validateEPGFilterTimes(configElement):
+		def minutes(t):
+			return t[0] * 60 + t[1]
+		start, end = minutes(config.epg.filter_start.value), minutes(config.epg.filter_end.value)
+		if start == end:
+			config.epg.filter_end.value = [(config.epg.filter_end.value[0] + 1) % 24, config.epg.filter_end.value[1]]
+			print("[UsageConfig] EPG filter - start and end times must be different.")
+	config.epg.filter_start.addNotifier(validateEPGFilterTimes)
+	config.epg.filter_end.addNotifier(validateEPGFilterTimes)
+	config.epg.filter_reversal = ConfigYesNo(default=False)
+	config.epg.filter_keepsorting = ConfigYesNo(default=False)
+
 	def correctInvalidEPGDataChange(configElement):
 		eServiceEvent.setUTF8CorrectMode(int(configElement.value))
 	config.epg.correct_invalid_epgdata = ConfigSelection(default="1", choices=[("0", _("Disabled")), ("1", _("Enabled")), ("2", _("Debug"))])


### PR DESCRIPTION
-when browsing through TV programs, it's often easier to search the EPG, for example, only from 20:00 to 01:00. Some channels alternate (e.g., one channel broadcasts from 20:00 to 06:00, and another from 6:00 to 20:00). Therefore, the user can set a time interval, and when viewing the SingleEpg using the Stop button, they can choose to display only events within that interval or, conversely, events outside of it. 
-user can set, if is keep epg sorting or no too.