### PR TITLE
enigma2.yml: Update to Ubuntu 22.04

### DIFF
--- a/.github/workflows/enigma2.yml
+++ b/.github/workflows/enigma2.yml
@@ -12,12 +12,20 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        gcc: [10]
+        python: ['3.9']
     env:
       CC: "gcc-10"
       CXX: "g++-10"
     steps:
     - uses: actions/checkout@v3
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
     - name: install python packages
       run: |
         pip3 install netifaces pyopenssl python-wifi service_identity twisted

--- a/configure.ac
+++ b/configure.ac
@@ -257,7 +257,7 @@ CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror \
 	-Wunsafe-loop-optimizations -Wpointer-arith \
 	-Wfloat-equal -Wlogical-op \
 	-Wno-error=cast-align=strict -Wno-error=ignored-qualifiers \
-	-Wno-error=cast-function-type \
+	-Wno-error=cast-function-type -Wno-error=deprecated-declarations \
 	-Wno-error=stringop-truncation -Wno-error=shadow -Wno-error=cast-qual \
 	-Wno-error=aggregate-return -Wno-error=missing-field-initializers \
 	-Wno-error=packed -Wno-error=vla -Wno-error=clobbered -Wno-error=unused-parameter \


### PR DESCRIPTION
Turn deprecated declaration errors into warnings (low level API OpenSSL).

Like:

../../git/lib/dvb_ci/dvbci_ccmgr.cpp:905:24: error: 'void AES_cbc_encrypt(const unsigned char*, unsigned char*, size_t, const AES_KEY*, unsigned char*, int)' is deprecated: Since OpenSSL 3.0 [-Werror=deprecated-declarations]
|   905 |         AES_cbc_encrypt(src, dst, len, &key, iv, encrypt);
|       |         ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~