### PR TITLE
[Videomode] force set 10 bit for gbquad4kpro

### DIFF
--- a/lib/python/Components/SystemInfo.py
+++ b/lib/python/Components/SystemInfo.py
@@ -255,6 +255,7 @@ def setBoxInfoItems():
 	BoxInfo.setItem("HasHiSi", pathExists("/proc/hisi"))
 	BoxInfo.setItem("FCCactive", False)
 	BoxInfo.setItem("Autoresolution_proc_videomode", model in ("gbue4k", "gbquad4k") and "/proc/stb/video/videomode_50hz" or "/proc/stb/video/videomode")
+	BoxInfo.setItem("ForceSet10bitMode2160p", model == "gbquad4kpro")
 
 
 setBoxInfoItems()

--- a/lib/python/Plugins/SystemPlugins/Videomode/VideoHardware.py
+++ b/lib/python/Plugins/SystemPlugins/Videomode/VideoHardware.py
@@ -228,6 +228,10 @@ class VideoHardware:
 			except IOError:
 				print("[VideoHardware] cannot open /proc/stb/video/videomode_24hz")
 
+		if BoxInfo.getItem("ForceSet10bitMode2160p") and mode.startswith("2160p"):  # Hack for GB QUAD 4K Pro
+			config.av.hdmicolordepth.value = "10bit"
+			config.av.hdmicolordepth.save()
+
 		self.updateAspect(None)
 
 	def saveMode(self, port, mode, rate):


### PR DESCRIPTION
-when use mode 2160p config.av.hdmicolordepth.value -->auto no image