### PR TITLE
[Render.Picon] Avoid possible BSoD

### DIFF
--- a/lib/python/Components/Renderer/Picon.py
+++ b/lib/python/Components/Renderer/Picon.py
@@ -73,6 +73,8 @@ class PiconLocator:
 				self.searchPaths.append(value)
 
 	def getPiconName(self, serviceRef):
+		if serviceRef is None:
+			return ""
 		# remove the path and name fields, and replace ":" by "_"
 		fields = GetWithAlternative(serviceRef).split(":", 10)[:10]
 		if not fields or len(fields) < 10:


### PR DESCRIPTION
Protect about NoneType serviceRef argument.

Reported on the forum:

I have a fairly common scenario (for me) and I get a crash once a week or so. I have 2x s2 and 1xT2 tuners. At a point in time there are no active recordings taking place and I am on a T2 channel watching live TV (e.g. BBC1 HD). Go into Movie List and play a file (say an hour or so long). In the meantime a recording starts on the T2 tuner on another channel (e.g. ITV HD).

When I come out of my recording and the system goes back to Live TV I get a crash and the box reboots. I would expect it to just give a warning that no T2 tuner is available and simple show a black screen until I change to a channel with a free tuner (e.g. one of the S2 tuners) or switch to the recording T2 channel - but it doesn't - it crashes.

https://world-of-satellite.com/threads/fairly-frequent-crash-when-no-free-tuner-and-coming-out-of-watching-a-recording.67378/