### PR TITLE
[InfoBar] remove  reset the Video Decoder GigaBlue

### DIFF
--- a/lib/python/Screens/InfoBar.py
+++ b/lib/python/Screens/InfoBar.py
@@ -260,8 +260,6 @@ class MoviePlayer(InfoBarBase, InfoBarShowHide, InfoBarMenu, InfoBarSeek, InfoBa
 			self.session.openWithCallback(self.leavePlayerConfirmed, ChoiceBox, title=_("Stop playing this movie?"), list=list)
 		else:
 			self.leavePlayerConfirmed([True, how])
-			#This does reset the Video Decoder as needed for GigaBlue boxes.
-			config.usage.QuadpipMode.changed()
 
 	def leavePlayer(self):
 		resumePointsInstance.setResumePoint(self.session)


### PR DESCRIPTION
This causes problems with playing the following video. more info:

https://forums.openpli.org/topic/104200-gigablue-uhd-quad-4k-player-problem/