### PR TITLE
Fix audio track display after selection when SoftDecoder is active

### DIFF
--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -2301,6 +2301,9 @@ RESULT eDVBServicePlay::selectTrack(unsigned int i)
 		if (i >= program.audioStreams.size())
 			return -2;
 
+		// Update m_current_audio_pid so getCurrentTrack() returns the correct index
+		m_current_audio_pid = program.audioStreams[i].pid;
+
 		// Update audio cache in eDVBService
 		updateAudioCache(program.audioStreams[i].pid, program.audioStreams[i].type);
 


### PR DESCRIPTION
When SoftDecoder handles audio track selection, m_current_audio_pid was not being updated, causing getCurrentTrack() to return the wrong index. The audio selection menu would show the old track as active instead of the newly selected one.

Fix by updating m_current_audio_pid before delegating to SoftDecoder.