### PR TITLE
Fix Last Scanned bouquet with wrong serviceType after SDT/VCT update

### DIFF
--- a/lib/dvb/scan.cpp
+++ b/lib/dvb/scan.cpp
@@ -1794,6 +1794,21 @@ RESULT eDVBScan::processSDT(eDVBNamespace dvbnamespace, const ServiceDescription
 
 					/* Remove old entry with wrong serviceType */
 					m_new_services.erase(sit);
+
+					/* Update m_new_servicerefs: replace old serviceRef with correct SDT serviceType */
+					for (std::vector<eServiceReferenceDVB>::iterator srit = m_new_servicerefs.begin();
+						srit != m_new_servicerefs.end(); ++srit)
+					{
+						if (srit->getServiceID() == ref.getServiceID() &&
+							srit->getDVBNamespace() == ref.getDVBNamespace() &&
+							srit->getTransportStreamID() == ref.getTransportStreamID() &&
+							srit->getOriginalNetworkID() == ref.getOriginalNetworkID())
+						{
+							*srit = ref;  /* Update with correct serviceType */
+							break;
+						}
+					}
+
 					found_existing = true;
 					SCAN_eDebug("[eDVBScan] SID %04x: replacing PMT entry (type %d) with SDT entry (type %d)",
 						ref.getServiceID().get(), sit->first.getServiceType(), ref.getServiceType());
@@ -1954,6 +1969,21 @@ RESULT eDVBScan::processVCT(eDVBNamespace dvbnamespace, const VirtualChannelTabl
 
 					/* Remove old entry with wrong serviceType */
 					m_new_services.erase(sit);
+
+					/* Update m_new_servicerefs: replace old serviceRef with correct VCT serviceType */
+					for (std::vector<eServiceReferenceDVB>::iterator srit = m_new_servicerefs.begin();
+						srit != m_new_servicerefs.end(); ++srit)
+					{
+						if (srit->getServiceID() == ref.getServiceID() &&
+							srit->getDVBNamespace() == ref.getDVBNamespace() &&
+							srit->getTransportStreamID() == ref.getTransportStreamID() &&
+							srit->getOriginalNetworkID() == ref.getOriginalNetworkID())
+						{
+							*srit = ref;  /* Update with correct serviceType */
+							break;
+						}
+					}
+
 					found_existing = true;
 					SCAN_eDebug("[eDVBScan] SID %04x: replacing PMT entry (type %d) with VCT entry (type %d)",
 						ref.getServiceID().get(), sit->first.getServiceType(), ref.getServiceType());


### PR DESCRIPTION
OpenPLI uses a separate m_new_servicerefs vector to populate the Last Scanned bouquet, while OpenATV iterates over m_new_services directly.

When a service is first found via PMT (with guessed serviceType) and then updated by SDT/VCT (with authoritative serviceType), the old entry in m_new_services was replaced, but m_new_servicerefs still contained the old serviceReference with the wrong serviceType.

This caused:
- Incomplete Last Scanned bouquet (services with wrong serviceType don't match the entries in m_new_services/lamedb)
- Selecting a channel from Last Scanned switches to wrong channel (because the serviceReference doesn't match any service)

Fix by updating m_new_servicerefs when replacing a PMT entry with SDT/VCT data, ensuring both data structures stay in sync.