### PR TITLE
Fix Last Scanned bouquet m_new_servicerefs synchronization

### DIFF
--- a/lib/dvb/scan.cpp
+++ b/lib/dvb/scan.cpp
@@ -1241,11 +1241,11 @@ void eDVBScan::channelDone()
 
 		if (!(m_flags & scanOnlyFree) || !m_pmt_in_progress->second.scrambled) {
 			SCAN_eDebug("[eDVBScan] add not scrambled!");
-			m_new_servicerefs.push_back(ref);
 			std::pair<std::map<eServiceReferenceDVB, ePtr<eDVBService> >::iterator, bool> i =
 				m_new_services.insert(std::pair<eServiceReferenceDVB, ePtr<eDVBService> >(ref, service));
 			if (i.second)
 			{
+				m_new_servicerefs.push_back(ref);
 				m_last_service = i.first;
 				m_event(evtNewService);
 			}
@@ -1794,6 +1794,21 @@ RESULT eDVBScan::processSDT(eDVBNamespace dvbnamespace, const ServiceDescription
 
 					/* Remove old entry with wrong serviceType */
 					m_new_services.erase(sit);
+
+					/* Update m_new_servicerefs: replace old serviceRef with correct SDT serviceType */
+					for (std::vector<eServiceReferenceDVB>::iterator srit = m_new_servicerefs.begin();
+						srit != m_new_servicerefs.end(); ++srit)
+					{
+						if (srit->getServiceID() == ref.getServiceID() &&
+							srit->getDVBNamespace() == ref.getDVBNamespace() &&
+							srit->getTransportStreamID() == ref.getTransportStreamID() &&
+							srit->getOriginalNetworkID() == ref.getOriginalNetworkID())
+						{
+							*srit = ref;  /* Update with correct serviceType */
+							break;
+						}
+					}
+
 					found_existing = true;
 					SCAN_eDebug("[eDVBScan] SID %04x: replacing PMT entry (type %d) with SDT entry (type %d)",
 						ref.getServiceID().get(), sit->first.getServiceType(), ref.getServiceType());
@@ -1805,8 +1820,10 @@ RESULT eDVBScan::processSDT(eDVBNamespace dvbnamespace, const ServiceDescription
 			std::pair<std::map<eServiceReferenceDVB, ePtr<eDVBService> >::iterator, bool> i =
 				m_new_services.insert(std::pair<eServiceReferenceDVB, ePtr<eDVBService> >(ref, service));
 
-			if (i.second && !found_existing)
+			if (i.second)
 			{
+				if (!found_existing)
+					m_new_servicerefs.push_back(ref);
 				m_last_service = i.first;
 				m_event(evtNewService);
 			}
@@ -1954,6 +1971,21 @@ RESULT eDVBScan::processVCT(eDVBNamespace dvbnamespace, const VirtualChannelTabl
 
 					/* Remove old entry with wrong serviceType */
 					m_new_services.erase(sit);
+
+					/* Update m_new_servicerefs: replace old serviceRef with correct VCT serviceType */
+					for (std::vector<eServiceReferenceDVB>::iterator srit = m_new_servicerefs.begin();
+						srit != m_new_servicerefs.end(); ++srit)
+					{
+						if (srit->getServiceID() == ref.getServiceID() &&
+							srit->getDVBNamespace() == ref.getDVBNamespace() &&
+							srit->getTransportStreamID() == ref.getTransportStreamID() &&
+							srit->getOriginalNetworkID() == ref.getOriginalNetworkID())
+						{
+							*srit = ref;  /* Update with correct serviceType */
+							break;
+						}
+					}
+
 					found_existing = true;
 					SCAN_eDebug("[eDVBScan] SID %04x: replacing PMT entry (type %d) with VCT entry (type %d)",
 						ref.getServiceID().get(), sit->first.getServiceType(), ref.getServiceType());
@@ -1965,8 +1997,10 @@ RESULT eDVBScan::processVCT(eDVBNamespace dvbnamespace, const VirtualChannelTabl
 			std::pair<std::map<eServiceReferenceDVB, ePtr<eDVBService> >::iterator, bool> i =
 				m_new_services.insert(std::pair<eServiceReferenceDVB, ePtr<eDVBService> >(ref, service));
 
-			if (i.second && !found_existing)
+			if (i.second)
 			{
+				if (!found_existing)
+					m_new_servicerefs.push_back(ref);
 				m_last_service = i.first;
 				m_event(evtNewService);
 			}


### PR DESCRIPTION
The m_new_servicerefs vector (used to preserve scan order in the Last Scanned bouquet) was getting out of sync with m_new_services in several ways:

1. In channelDone(): m_new_servicerefs.push_back() was called BEFORE checking if the insert succeeded. If the service already existed (from SDT), it would create a duplicate entry with wrong serviceType.

2. In processSDT()/processVCT(): When replacing a PMT entry with different serviceType, m_new_servicerefs was not updated.

3. In processSDT()/processVCT(): New services (not replacing existing) were not added to m_new_servicerefs at all.

This caused the serviceRefs in the Last Scanned bouquet to not match what's in lamedb, causing setCurrentSelection() to fail and fall back to the first channel.

Fix:
- channelDone(): Only add to m_new_servicerefs after successful insert
- processSDT()/processVCT(): Update m_new_servicerefs when replacing an existing entry (update serviceRef in place)
- processSDT()/processVCT(): Add new services to m_new_servicerefs
- Send evtNewService for all successful inserts (not just !found_existing) so the scan UI shows all services correctly