### PR TITLE
[InfoBarSubserviceSelection] hide "Quick zap" if not current service …

### DIFF
--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -3090,15 +3090,18 @@ class InfoBarSubserviceSelection:
 					selection = 0
 				self.bouquets = self.servicelist and self.servicelist.getBouquetList()
 				tlist = None
+				quickzap = ("--", "")
+				if serviceRef.toString() in [x[1] for x in subservices]:
+					quickzap = (_("Quick zap"), "quickzap", subservices)
 				if self.bouquets and len(self.bouquets):
 					keys = ["red", "blue", "", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
 					call_func_title = _("Add to favourites")
 					if config.usage.multibouquet.value:
 						call_func_title = _("Add to bouquet")
-						tlist = [(_("Quick zap"), "quickzap", subservices), (call_func_title, "CALLFUNC", self.addSubserviceToBouquetCallback), ("--", "")] + subservices
+						tlist = [quickzap, (call_func_title, "CALLFUNC", self.addSubserviceToBouquetCallback), ("--", "")] + subservices
 					selection += 3
 				else:
-					tlist = [(_("Quick zap"), "quickzap", subservices), ("--", "")] + subservices
+					tlist = [quickzap, ("--", "")] + subservices
 					keys = ["red", "", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
 					selection += 2
 				if tlist:


### PR DESCRIPTION
…in subservices list

- Example: Sky Sport 1 19.2E --> event name "Sendepause"
Traceback (most recent call last):
File "/usr/lib/enigma2/python/Components/ActionMap.py", line 76, in action
File "/usr/lib/enigma2/python/Components/ActionMap.py", line 56, in action
File "/usr/lib/enigma2/python/Screens/SubservicesQuickzap.py", line 61, in nextSubservice
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'