### PR TITLE
Allow runtime enabling/disabling of the HiSilicon framebuffer layer via a /etc/hifblayer flag file.

### DIFF
--- a/lib/gdi/fb.cpp
+++ b/lib/gdi/fb.cpp
@@ -185,7 +185,7 @@ int fbClass::SetMode(int nxRes, int nyRes, int nbpp)
 	memset(lfb, 0, stride*yRes);
 
 #ifdef HAVE_HIFBLAYER
-	if (m_available_total > (stride * yRes * 3))
+	if (access("/etc/hifblayer", F_OK) == 0 && m_available_total > (stride * yRes * 3))
 	{
 		HIFB_LAYER_INFO_S layerinfo;
 		if (ioctl(fbFd, FBIOGET_LAYER_INFO, &layerinfo) < 0)


### PR DESCRIPTION
The new implementation remains disabled by default until the tuxtxt-related issues are resolved.