### PR TITLE
[Navigation.playServiceExtensions] update handling

### DIFF
--- a/lib/python/Navigation.py
+++ b/lib/python/Navigation.py
@@ -121,7 +121,7 @@ class Navigation:
 			adjust = adjust[0]
 		oldref = self.currentlyPlayingServiceOrGroup
 		current_service_source = None
-		is_handled = False
+		is_async_play = False
 		if InfoBarInstance:
 			current_service_source = InfoBarInstance.session.screen["CurrentService"]
 
@@ -195,8 +195,15 @@ class Navigation:
 				if BoxInfo.getItem("FCCactive") and "%3a//" in ref.toString() and not is_stream_relay:
 					self.pnav.stopService()
 
+				playref_str_orig = playref.toString()
 				for f in Navigation.playServiceExtensions:
-					playref, is_handled = f(self, playref, event, InfoBarInstance)
+					ret = f(self, playref, event, InfoBarInstance)
+					if isinstance(ret, (ServiceReference, eServiceReference)):
+						playref = ret
+					else:
+						playref, is_async_play = ret
+					if is_async_play or playref.toString() != playref_str_orig:
+						break
 
 				self.currentlyPlayingServiceOrGroup = ref
 				if startPlayingServiceOrGroup and startPlayingServiceOrGroup.flags & eServiceReference.isGroup and not ref.flags & eServiceReference.isGroup:
@@ -239,7 +246,7 @@ class Navigation:
 					self.retryServicePlayTimer = eTimer()
 					self.retryServicePlayTimer.callback.append(boundFunction(self.playService, ref, checkParentalControl, forceRestart, adjust))
 					self.retryServicePlayTimer.start(config.misc.softcam_streamrelay_delay.value, True)
-				elif not is_handled and self.pnav.playService(playref):
+				elif not is_async_play and self.pnav.playService(playref):
 						self.currentlyPlayingServiceReference = None
 						self.originalPlayingServiceReference = None
 						self.currentlyPlayingServiceOrGroup = None
@@ -253,7 +260,7 @@ class Navigation:
 					setPreferredTuner(int(config.usage.frontend_priority.value))
 				if self.currentlyPlayingServiceReference and self.currentlyPlayingServiceReference.toString() in streamrelay.data:
 					self.currentServiceIsStreamRelay = True
-				if InfoBarInstance and "%3a//" in playref.toString() and not is_handled:
+				if InfoBarInstance and "%3a//" in playref.toString() and not is_async_play:
 					self.originalPlayingServiceReference = None
 					InfoBarInstance.serviceStarted()
 				return 0


### PR DESCRIPTION
Break loop once a match is found. This is needed for when multiple plugins are using Navigation.playServiceExtensions.

Also, allow plugins that only return sref, and do not return is_async_play.