### PR TITLE
SingleEPG - added 'Rating sort' under the instant record button.

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -661,6 +661,7 @@
 		<key id="KEY_4" mapto="startDown" flags="m" />
 		<key id="KEY_3" mapto="endUp" flags="m" />
 		<key id="KEY_6" mapto="endDown" flags="m" />
+		<key id="KEY_RECORD" mapto="ratingsort" flags="m" />
 	</map>
 
 	<map context="GMEPGSelectActions">

--- a/data/setup.xml
+++ b/data/setup.xml
@@ -130,6 +130,7 @@
 		<item level="1" text="End time" indents="4" conditional="config.epg.filter.value" description="End of the time interval during which events must begin to be displayed. If the filter is active, use keys 3 and 6 to adjust the end time, and key 0 to save.">config.epg.filter_end</item>
 		<item level="1" text="Toggle Filter Order" indents="4" conditional="config.epg.filter.value" description="Using the 'Stop' button will cyclically switch displaying events starting: 'outside the interval', 'within the interval', and 'without filtering', instead of 'within the interval', 'outside the interval', and 'without filtering'.">config.epg.filter_reversal</item>
 		<item level="1" text="Keep sorting" indents="4" conditional="config.epg.filter.value" description="When switching the filter, the selected EPG sorting is preserved.">config.epg.filter_keepsorting</item>
+		<item level="1" text="Enable rating sort in SingleEPG" description="Enable sorting events by parental rating in SingleEPG using the 'Rec' button. Rating can also be displayed in the skin.">config.epg.ratingsort</item>
 	</setup>
 	<setup key="subtitlesetup" title="Subtitle settings">
 		<item level="0" text="Teletext subtitle color" description="Configure the color of the teletext subtitles.">config.subtitles.ttx_subtitle_colors</item>

--- a/lib/python/Components/EpgList.py
+++ b/lib/python/Components/EpgList.py
@@ -1,6 +1,6 @@
 from Components.GUIComponent import GUIComponent
 
-from enigma import eEPGCache, eListbox, eListboxPythonMultiContent, gFont, RT_HALIGN_LEFT, RT_HALIGN_RIGHT, RT_HALIGN_CENTER, RT_VALIGN_CENTER
+from enigma import eEPGCache, eListbox, eListboxPythonMultiContent, gFont, RT_HALIGN_LEFT, RT_HALIGN_RIGHT, RT_HALIGN_CENTER, RT_VALIGN_CENTER, eServiceReference
 
 from Tools.Alternatives import CompareWithAlternatives
 from Tools.LoadPixmap import LoadPixmap
@@ -363,14 +363,31 @@ class EPGList(GUIComponent):
 			self.instance.moveSelectionTo(idx - 1)
 		self.selectionChanged()
 
+	def getEventRating(self, event):
+		try:
+			ref = event[0]
+			if isinstance(ref, str):
+				ref = eServiceReference(ref)
+			ev = self.epgcache.lookupEventId(ref, int(event[1]))
+			if ev:
+				p = ev.getParentalData()
+				if p:
+					return p.getRating() or 0
+		except Exception as e:
+			print("[EPG rating error]", event[4], type(event[0]), event[0], event[1], e)
+		return 0
+
 	def sortSingleEPG(self, type):
 		list = self.list
 		if list:
 			event_id = self.getSelectedEventId()
-			if type == 1:
+			if type & 0x10:
+				list.sort(key=lambda x: (self.getEventRating(x), x[2]))
+			elif type & 0x20:
+				list.sort(key=lambda x: (-self.getEventRating(x), x[2]))
+			elif type & 0x01:
 				list.sort(key=lambda x: (x[4] and x[4].lower(), x[2]))
 			else:
-				assert (type == 0)
 				list.sort(key=lambda x: x[2])
 			self.l.invalidate()
 			self.moveToEventId(event_id)

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -520,6 +520,7 @@ def InitUsageConfig():
 	config.epg.filter_end.addNotifier(validateEPGFilterTimes)
 	config.epg.filter_reversal = ConfigYesNo(default=False)
 	config.epg.filter_keepsorting = ConfigYesNo(default=False)
+	config.epg.ratingsort = ConfigSelection(default="0", choices=[("0", _("No")), ("1", _("Yes")), ("2", _("Yes and display rating"))])
 
 	def correctInvalidEPGDataChange(configElement):
 		eServiceEvent.setUTF8CorrectMode(int(configElement.value))

--- a/lib/python/Screens/EpgSelection.py
+++ b/lib/python/Screens/EpgSelection.py
@@ -49,6 +49,7 @@ class EPGSelection(Screen, HelpableScreen):
 		self.saved_title = None
 		self["Service"] = ServiceEvent()
 		self["Event"] = Event()
+		self["Rating"] = Event()
 		self.filtering = 0
 		if isinstance(service, str) and eventid is not None:
 			self.type = EPG_TYPE_SIMILAR
@@ -119,6 +120,7 @@ class EPGSelection(Screen, HelpableScreen):
 			})
 		self["EPGFilterActions"] = HelpableActionMap(self, ["EPGFilterActions"],
 			{
+				"ratingsort": (self.instantRecButtonPressed, _("Sort EPG by rating")),
 				"filter": (self.stopButtonPressed, _("EPG filter switching")),
 				"startDown": (self.filterStartDown, _("Start time") + " -"),
 				"startUp": (self.filterStartUp, _("Start time") + " +"),
@@ -313,7 +315,7 @@ class EPGSelection(Screen, HelpableScreen):
 
 	def fillFilteredSingleEPG(self, timespan):
 		self.serviceToTitle(self.currentService)
-		self.setTitle(self.instance.getTitle() + timespan)
+		self.setSingleEpgTitle()
 		self["list"].fillSingleEPG(self.currentService, self.sort_type, self.filtering)
 
 	def resetFiltering(self):
@@ -357,16 +359,31 @@ class EPGSelection(Screen, HelpableScreen):
 	def filterEndUp(self):
 		self.filtering and self.filterShiftTimespan('end', 1)
 
+	def instantRecButtonPressed(self):
+		if config.epg.ratingsort.value != "0":
+			rating = self.sort_type & 0x30
+			normal = self.sort_type & 0x01
+			if rating == 0x00:
+				rating = 0x10
+			elif rating == 0x10:
+				rating = 0x20
+			else:
+				rating = 0x00
+			self.sort_type = normal | rating
+			self.updateRatingEvent()
+			self["list"].sortSingleEPG(self.sort_type)
+			self.setSingleEpgTitle()
+
 	def yellowButtonPressed(self):
 		if self.type == EPG_TYPE_MULTI:
 			self["list"].updateMultiEPG(-1)
 		elif self.type == EPG_TYPE_SINGLE:
-			if self.sort_type == 0:
-				self.sort_type = 1
-			else:
-				self.sort_type = 0
+			self.sort_type &= ~0x30 # remove rating flag
+			self.sort_type ^= 0x01
+			self.updateRatingEvent()
 			self["list"].sortSingleEPG(self.sort_type)
 			self.setSortDescription()
+			self.setSingleEpgTitle()
 		elif self.type == EPG_TYPE_SIMILAR:
 			cur = self["list"].getCurrent()
 			cur_event = cur and cur[0]
@@ -375,16 +392,42 @@ class EPGSelection(Screen, HelpableScreen):
 				self.session.open(EPGSelection, None, None, event)
 
 	def setSortDescription(self):
-		if self.sort_type == 1:
+		if self.sort_type & 0x01:
 			# TRANSLATORS: This must fit into the header button in the EPG-List
 			self["key_yellow"].setText(_("Sort time"))
 		else:
 			# TRANSLATORS: This must fit into the header button in the EPG-List
 			self["key_yellow"].setText(_("Sort A-Z"))
 
+	def setSingleEpgTitle(self):
+		text = self.saved_title + ' - ' + self.currentService.getServiceName()
+		if self.filtering:
+			text += "   " + self.getTimespanText()
+		if self.sort_type & 0x10:
+			text += " - " + _("rating 0-18")
+		elif self.sort_type & 0x20:
+			text += " - " + _("rating 18-0")
+		self.setTitle(text)
+
 	def resetSortStatus(self):
 		self.sort_type = 0
 		self.setSortDescription()
+		self.setSingleEpgTitle()
+
+	def updateRatingEvent(self):
+		cur = self["list"].getCurrent()
+		event = cur and cur[0]
+		if self.type == EPG_TYPE_SINGLE and config.epg.ratingsort.value == "2" and self.sort_type & 0x30:
+			self["Rating"].newEvent(event)
+		else:
+			self["Rating"].newEvent(None)
+
+	def showRating(self):
+		self["Rating"].setVisible(
+			self.type == EPG_TYPE_SINGLE and
+			config.epg.ratingsort.value == "2" and
+			bool(self.sort_type & 0x30)
+		)
 
 	def blueButtonPressed(self):
 		if self.type == EPG_TYPE_MULTI:
@@ -645,6 +688,7 @@ class EPGSelection(Screen, HelpableScreen):
 			return
 		event = cur[0]
 		self["Event"].newEvent(event)
+		self.updateRatingEvent()
 		if self.type == EPG_TYPE_MULTI:
 			count = self["list"].getCurrentChangeCount()
 			if self.ask_time != -1:


### PR DESCRIPTION
It is configurable in EPG Setup as: No / Yes / Yes and display rating

When rating sort is activated with "Yes and display rating", the parental rating can also be displayed in the EPGSelection skin screen using:

<widget source="Rating" render="Label" position="30,565" size="720,30" transparent="1" zPosition="1" foregroundColor="blue" font="Regular;26" halign="left">
	<convert type="EventName">Rating</convert>
</widget>