### PR TITLE
Timesync - use 'chronyc selectdata' instead of 'tracking' in 'auto' mode

### DIFF
--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -867,7 +867,8 @@ def InitUsageConfig():
 			eDVBLocalTimeHandler.getInstance().setUseDVBTime(False)
 			print("[UsageConfig] NTP enabled, DVB time disabled")
 
-		eEPGCache.getInstance().timeUpdated()
+		if configElement.value != "auto":
+			eEPGCache.getInstance().timeUpdated()
 
 	config.ntp.timesync = ConfigSelection(default="auto", choices=[("auto", _("auto")), ("dvb", _("Transponder Time")), ("ntp", _("Internet (ntp)"))])
 	config.ntp.timesync.addNotifier(timesyncChanged)
@@ -1023,10 +1024,10 @@ class NtpHandler:
 
 	def isUsable(self):
 		try:
-			result = subprocess.check_output('chronyc tracking', shell=True, text=True)
+			result = subprocess.check_output(["chronyc", "selectdata"], text=True)
+			return "* " in result
 		except subprocess.CalledProcessError:
 			return False
-		return "Leap status     : Normal" in result
 
 	def reset(self):
 		self.retry = 0


### PR DESCRIPTION
'chronyc selectdata' is used because other chronyc commands (e.g. 'tracking' and 'sources') were found to break the startup callback sequence on H7S.