### PR TITLE
Font - use \C to restore the original color

### DIFF
--- a/lib/gdi/font.cpp
+++ b/lib/gdi/font.cpp
@@ -769,6 +769,7 @@ int eTextPara::renderString(const char *string, int rflags, int border)
 
 	unsigned long newcolor = 0;
 	bool activate_newcolor = false;
+	bool activate_colorreset = false;
 	int nextflags = 0;
 
 	for (std::vector<unsigned long>::const_iterator i(uc_visual.begin());
@@ -818,16 +819,27 @@ int eTextPara::renderString(const char *string, int rflags, int border)
 							{
 								if ((i + 2 + codeidx) == uc_visual.end()) break;
 								color[codeidx] = (char)((*(i + 2 + codeidx)) & 0xff);
+								if (!isxdigit((unsigned char)color[codeidx]))
+									break;
 							}
+							isprintable = 0;
 							if (codeidx == 8)
 							{
 								newcolor = gRGB(color).argb();
 								activate_newcolor = true;
-								isprintable = 0;
 								i += 1 + codeidx;
+							}
+							else
+							{
+								isprintable = 1;
 							}
 							break;
 						}
+						case 'C':
+							isprintable = 0;
+							activate_colorreset = true;
+							i++;
+							break;
 						default:
 						;
 					}
@@ -867,6 +879,9 @@ nprint:				isprintable=0;
 		}
 		if (isprintable)
 		{
+			if (activate_colorreset)
+				flags |= GS_COLORRESET;
+
 			FT_UInt index = 0;
 
 				/* FIXME: our font doesn't seem to have a hyphen, so use hyphen-minus for it. */
@@ -896,6 +911,7 @@ nprint:				isprintable=0;
 				appendGlyph(current_font, current_face, index, flags, rflags, border, i == uc_visual.end() - 1, activate_newcolor, newcolor);
 
 			activate_newcolor = false;
+			activate_colorreset = false;
 		}
 	}
 	bboxValid=false;
@@ -971,10 +987,15 @@ void eTextPara::blit(gDC &dc, const ePoint &offset, const gRGB &cbackground, con
 			line_offs = *(line_offs_it++);
 			line_chars = *(line_chars_it++);
 		}
-		if (i->flags & GS_COLORCHANGE)
+		/* don't do colorchanges in borders */
+		if (!border)
 		{
-			/* don't do colorchanges in borders */
-			if (!border)
+			if (i->flags & GS_COLORRESET)
+			{
+				currentforeground = foreground;
+				setcolor = true;
+			}
+			else if (i->flags & GS_COLORCHANGE)
 			{
 				currentforeground = i->newcolor;
 				setcolor = true;

--- a/lib/gdi/font.h
+++ b/lib/gdi/font.h
@@ -98,6 +98,7 @@ public:
 #define GS_HYPHEN   32
 #define GS_COLORCHANGE 64
 #define GS_LF 128
+#define GS_COLORRESET 256
 #define GS_CANBREAK (GS_ISSPACE|GS_SOFTHYPHEN|GS_HYPHEN)
 
 struct pGlyph


### PR DESCRIPTION
- use \C to restore the default foreground color
- \c changes the color only when followed by 8 valid hexadecimal digits
- invalid \c sequences are rendered as normal text