### PR TITLE
Scan - update progress after last scanned transponder

### DIFF
--- a/lib/dvb/scan.cpp
+++ b/lib/dvb/scan.cpp
@@ -216,6 +216,9 @@ void eDVBScan::stateChange(iDVBChannel *ch)
 			SCAN_eDebug("[eDVBScan] blindscan channel completed");
 			m_ch_blindscan.pop_front();
 		}
+
+		m_ch_current_active = false;
+		m_event(evtUpdate);
 		nextChannel();
 	}
 			/* unavailable will timeout, anyway. */
@@ -1354,6 +1357,7 @@ void eDVBScan::channelDone()
 		++i;
 	}
 
+	m_event(evtUpdate);
 	nextChannel();
 }
 


### PR DESCRIPTION
- emit a final evtUpdate before evtFinish so the UI receives the final progress state and the progress bar reaches 100% after the last transponder has been scanned.