### PR TITLE
servicedvbrecord - retry EIT file creation after initial failure

### DIFF
--- a/lib/service/servicedvbrecord.cpp
+++ b/lib/service/servicedvbrecord.cpp
@@ -17,8 +17,10 @@ DEFINE_REF(eDVBServiceRecord);
 
 eDVBServiceRecord::eDVBServiceRecord(const eServiceReferenceDVB &ref, bool isstreamclient): m_ref(ref)
 {
+	m_eitRetryTimer = eTimer::create(eApp);
 	CONNECT(m_service_handler.serviceEvent, eDVBServiceRecord::serviceEvent);
 	CONNECT(m_event_handler.m_eit_changed, eDVBServiceRecord::gotNewEvent);
+	CONNECT(m_eitRetryTimer->timeout, eDVBServiceRecord::retrySaveEit);
 	m_state = stateIdle;
 	m_want_record = 0;
 	m_record_ecm = false;
@@ -174,12 +176,39 @@ RESULT eDVBServiceRecord::prepare(const char *filename, time_t begTime, time_t e
 				std::string fname = filename;
 				fname.erase(fname.length()-2, 2);
 				fname += "eit";
-				eEPGCache::getInstance()->saveEventToFile(fname.c_str(), ref, eit_event_id, begTime, endTime);
+				int eitret = eEPGCache::getInstance()->saveEventToFile(fname.c_str(), ref, eit_event_id, begTime, endTime);
+
+				if (eitret)
+				{
+					m_eitFilename = fname;
+					m_eitRef = ref;
+					m_eitEventId = eit_event_id;
+					m_eitBegTime = begTime;
+					m_eitEndTime = endTime;
+					m_eitRetryTimer->stop();
+					m_eitRetryTimer->startLongTimer(30);
+				}
 			}
 		}
 		return ret;
 	}
 	return -1;
+}
+
+void eDVBServiceRecord::retrySaveEit()
+{
+	m_eitRetryTimer->stop();
+
+	if (m_eitFilename.empty())
+		return;
+	if (!access(m_eitFilename.c_str(), F_OK))
+	{
+		m_eitFilename.clear();
+		return;
+	}
+	eEPGCache::getInstance()->saveEventToFile(m_eitFilename.c_str(), m_eitRef, m_eitEventId, m_eitBegTime, m_eitEndTime);
+
+	m_eitFilename.clear();
 }
 
 RESULT eDVBServiceRecord::prepareStreaming(bool descramble, bool includeecm)
@@ -204,6 +233,8 @@ RESULT eDVBServiceRecord::start(bool simulate)
 
 RESULT eDVBServiceRecord::stop()
 {
+	m_eitRetryTimer->stop();
+
 	if (!m_simulate)
 		eDebug("[eDVBServiceRecord] stop recording!");
 

--- a/lib/service/servicedvbrecord.h
+++ b/lib/service/servicedvbrecord.h
@@ -95,6 +95,15 @@ private:
 			/* eit updates */
 	void gotNewEvent(int error);
 	void saveCutlist();
+			/* eit retry */
+	ePtr<eTimer> m_eitRetryTimer;
+	std::string m_eitFilename;
+	eServiceReferenceDVB m_eitRef;
+	int m_eitEventId;
+	time_t m_eitBegTime;
+	time_t m_eitEndTime;
+
+	void retrySaveEit();
 };
 
 #endif


### PR DESCRIPTION
- prepare() is called before the receiver tunes to the channel being recorded, so event may not yet exist in the EPG cache. 
- if the initial .eit creation fails for this reason, store the required parameters and retry once after 30 seconds.