### PR TITLE
Add a rating-based sort mode to the yellow button in SingleEPG.

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -130,6 +130,7 @@
 		<item level="1" text="End time" indents="4" conditional="config.epg.filter.value" description="End of the time interval during which events must begin to be displayed. If the filter is active, use keys 3 and 6 to adjust the end time, and key 0 to save.">config.epg.filter_end</item>
 		<item level="1" text="Toggle Filter Order" indents="4" conditional="config.epg.filter.value" description="Using the 'Stop' button will cyclically switch displaying events starting: 'outside the interval', 'within the interval', and 'without filtering', instead of 'within the interval', 'outside the interval', and 'without filtering'.">config.epg.filter_reversal</item>
 		<item level="1" text="Keep sorting" indents="4" conditional="config.epg.filter.value" description="When switching the filter, the selected EPG sorting is preserved.">config.epg.filter_keepsorting</item>
+		<item level="1" text="Rating sort in SingleEPG" description="Enable sorting by rating under the yellow button in SingleEPG.">config.epg.ratingsort</item>
 	</setup>
 	<setup key="subtitlesetup" title="Subtitle settings">
 		<item level="0" text="Teletext subtitle color" description="Configure the color of the teletext subtitles.">config.subtitles.ttx_subtitle_colors</item>

--- a/lib/python/Components/EpgList.py
+++ b/lib/python/Components/EpgList.py
@@ -60,6 +60,7 @@ class EPGList(GUIComponent):
 		self.tw = applySkinFactor(90)
 		self.dy = 0
 		self.sidesMargin = 0
+		self.sorting = 0
 
 		if type == EPG_TYPE_SINGLE:
 			self.l.setBuildFunc(self.buildSingleEntry)
@@ -163,11 +164,22 @@ class EPGList(GUIComponent):
 				x += self.col[0]
 				self.datetime_rect = Rect(x, 0, self.gap(self.col[1]), height)
 				x += self.col[1]
-				self.descr_rect = Rect(x, 0, width - x, height)
+				if self.sorting == 2:
+					rating_w = 60
+					self.descr_rect = Rect(x, 0, width - x - rating_w, height)
+					self.rating_rect = Rect(width - rating_w, 0, rating_w, height)
+				else:
+					self.descr_rect = Rect(x, 0, width - x, height)
 			else:
 				self.weekday_rect = Rect(0, 0, width // 20 * 2 - 10, height)
 				self.datetime_rect = Rect(width // 20 * 2, 0, width // 20 * 5 - 15, height)
-				self.descr_rect = Rect(width // 20 * 7, 0, width // 20 * 13, height)
+				if self.sorting == 2:
+					descr_x = width // 20 * 7
+					rating_w = 60
+					self.descr_rect = Rect(descr_x, 0, width - descr_x - rating_w, height)
+					self.rating_rect = Rect(width - rating_w, 0, rating_w, height)
+				else:
+					self.descr_rect = Rect(width // 20 * 7, 0, width // 20 * 13, height)
 		elif self.type == EPG_TYPE_MULTI:
 			if self.skinColumns:
 				x = 0
@@ -227,6 +239,14 @@ class EPGList(GUIComponent):
 			(eListboxPythonMultiContent.TYPE_TEXT, r1.x + self.sidesMargin, r1.y, r1.w, r1.h, 0, RT_HALIGN_RIGHT | RT_VALIGN_CENTER, self.days[t[6]]),
 			(eListboxPythonMultiContent.TYPE_TEXT, r2.x + self.sidesMargin, r2.y, r2.w, r1.h, 0, RT_HALIGN_RIGHT | RT_VALIGN_CENTER, "%02d.%02d, %02d:%02d" % (t[2], t[1], t[3], t[4]))
 		]
+		if self.sorting == 2:
+			r = self.getEventRating((service, eventId, beginTime, duration, EventName))
+			if r:
+				rating = str(r + 3)
+			else:
+				rating = "-"
+			r4 = self.rating_rect
+			res.append((eListboxPythonMultiContent.TYPE_TEXT, r4.x, r4.y, r4.w, r4.h, 0, RT_HALIGN_CENTER | RT_VALIGN_CENTER, rating))
 		if clock_types:
 			for i in range(len(clock_types)):
 				clockIcon = (clock_types[i] == 65 and self.catchUpIcon) or self.clocks[clock_types[i]]
@@ -360,6 +380,7 @@ class EPGList(GUIComponent):
 				return dailySpan(end, start)
 
 	def fillSingleEPG(self, service, sorting=0, filtering=0):
+		self.sorting = sorting
 		t = int(time())
 		epg_time = t - (int(config.epg.histminutes.value) * 60)
 		test = ['RIBDT', (service.ref.toString(), 0, epg_time, -1)]
@@ -378,15 +399,32 @@ class EPGList(GUIComponent):
 			self.instance.moveSelectionTo(idx - 1)
 		self.selectionChanged()
 
+	def getEventRating(self, event):
+		try:
+			ref = event[0]
+			if isinstance(ref, str):
+				ref = eServiceReference(ref)
+			ev = self.epgcache.lookupEventId(ref, int(event[1]))
+			if ev:
+				p = ev.getParentalData()
+				if p:
+					return p.getRating() or 0
+		except Exception as e:
+			print("[EPG rating error]", event[4], type(event[0]), event[0], event[1], e)
+		return 0
+
 	def sortSingleEPG(self, type):
+		self.sorting = type
 		list = self.list
 		if list:
 			event_id = self.getSelectedEventId()
 			if type == 1:
 				list.sort(key=lambda x: (x[4] and x[4].lower(), x[2]))
+			elif type == 2:
+				list.sort(key=lambda x: (self.getEventRating(x), x[2]))
 			else:
-				assert (type == 0)
 				list.sort(key=lambda x: x[2])
+			self.recalcEntrySize()
 			self.l.invalidate()
 			self.moveToEventId(event_id)
 

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -520,6 +520,7 @@ def InitUsageConfig():
 	config.epg.filter_end.addNotifier(validateEPGFilterTimes)
 	config.epg.filter_reversal = ConfigYesNo(default=False)
 	config.epg.filter_keepsorting = ConfigYesNo(default=False)
+	config.epg.ratingsort = ConfigYesNo(default=False)
 
 	def correctInvalidEPGDataChange(configElement):
 		eServiceEvent.setUTF8CorrectMode(int(configElement.value))

--- a/lib/python/Screens/EpgSelection.py
+++ b/lib/python/Screens/EpgSelection.py
@@ -319,7 +319,7 @@ class EPGSelection(Screen, HelpableScreen):
 
 	def fillFilteredSingleEPG(self, timespan):
 		self.serviceToTitle(self.currentService)
-		self.setTitle(self.instance.getTitle() + timespan)
+		self.setSingleEpgTitle()
 		self["list"].fillSingleEPG(self.currentService, self.sort_type, self.filtering)
 
 	def resetFiltering(self):
@@ -367,10 +367,10 @@ class EPGSelection(Screen, HelpableScreen):
 		if self.type == EPG_TYPE_MULTI:
 			self["list"].updateMultiEPG(-1)
 		elif self.type == EPG_TYPE_SINGLE:
-			if self.sort_type == 0:
-				self.sort_type = 1
+			if config.epg.ratingsort.value:
+				self.sort_type = (self.sort_type + 1) % 3
 			else:
-				self.sort_type = 0
+				self.sort_type = (self.sort_type + 1) % 2
 			self["list"].sortSingleEPG(self.sort_type)
 			self.setSortDescription()
 		elif self.type == EPG_TYPE_SIMILAR:
@@ -381,12 +381,22 @@ class EPGSelection(Screen, HelpableScreen):
 				self.session.open(EPGSelection, None, None, event)
 
 	def setSortDescription(self):
-		if self.sort_type == 1:
-			# TRANSLATORS: This must fit into the header button in the EPG-List
-			self["key_yellow"].setText(_("Sort time"))
-		else:
-			# TRANSLATORS: This must fit into the header button in the EPG-List
+		# TRANSLATORS: This must fit into the header button in the EPG-List
+		if self.sort_type == 0:
 			self["key_yellow"].setText(_("Sort A-Z"))
+		elif self.sort_type == 1:
+			if config.epg.ratingsort.value:
+				self["key_yellow"].setText(_("Sort rating"))
+			else:
+				self["key_yellow"].setText(_("Sort time"))
+		else:
+			self["key_yellow"].setText(_("Sort time"))
+
+	def setSingleEpgTitle(self):
+		text = self.saved_title + ' - ' + self.currentService.getServiceName()
+		if self.filtering:
+			text += "   " + self.getTimespanText()
+		self.setTitle(text)
 
 	def resetSortStatus(self):
 		self.sort_type = 0


### PR DESCRIPTION
- the feature is disabled by default in the EPG settings. Users whose provider does not broadcast parental rating information can simply leave it disabled, so the yellow button behaviour remains unchanged.