### PR TITLE
Font - preserve line-start flag across color escapes

### DIFF
--- a/lib/gdi/font.cpp
+++ b/lib/gdi/font.cpp
@@ -777,7 +777,6 @@ int eTextPara::renderString(const char *string, int rflags, int border)
 	{
 		int isprintable=1;
 		int flags = nextflags;
-		nextflags = 0;
 		unsigned long chr = *i;
 
 		if (!(rflags&RS_DIRECT))
@@ -884,6 +883,8 @@ nprint:				isprintable=0;
 		}
 		if (isprintable)
 		{
+			nextflags = 0;
+
 			if (activate_colorreset)
 				flags |= GS_COLORRESET;
 


### PR DESCRIPTION
- it appears that existing \c escape could already consume GS_ISFIRST when used immediately after a newline, and later added \C escape inherited same issue. Preserve pending flags until next printable glyph to keep wrapping and alignment correct.