### PR TITLE
[sec] not use rotor if saved lnb satellite position

### DIFF
--- a/lib/dvb/sec.cpp
+++ b/lib/dvb/sec.cpp
@@ -1123,6 +1123,12 @@ RESULT eDVBSatelliteEquipmentControl::prepare(iDVBFrontend &frontend, const eDVB
 			}
 			else if (m_not_linked_slot_mask & slot_id)
 			{
+				for (int idx=0; idx <= m_lnbidx; ++idx)
+				{
+					eDVBSatelliteLNBParameters &lnb = m_lnbs[idx];
+					if (lnb.m_slot_mask & slot_id)
+						lnb.old_orbital_position = -1;
+				}
 				lnb_param.old_orbital_position = sat.orbital_position;
 			}
 

--- a/lib/dvb/sec.cpp
+++ b/lib/dvb/sec.cpp
@@ -906,7 +906,7 @@ RESULT eDVBSatelliteEquipmentControl::prepare(iDVBFrontend &frontend, const eDVB
 			}
 
 			eDebugNoSimulate("[eDVBSatelliteEquipmentControl] RotorCmd %02x, lastRotorCmd %02lx", RotorCmd, lastRotorCmd);
-			if ( RotorCmd != -1 && RotorCmd != lastRotorCmd )
+			if (RotorCmd != -1 && ((RotorCmd != lastRotorCmd) || (lnb_param.old_orbital_position == -1 || (lnb_param.old_orbital_position != sat.orbital_position))))
 			{
 				int mrt = m_params[MOTOR_RUNNING_TIMEOUT]; // in seconds!
 				eSecCommand::pair compare;
@@ -1118,7 +1118,13 @@ RESULT eDVBSatelliteEquipmentControl::prepare(iDVBFrontend &frontend, const eDVB
 			frontend.setSecSequence(sec_sequence);
 
 			if (!rotor)
+			{
 				frontend.setData(eDVBFrontend::SAT_POSITION, sat.orbital_position);
+			}
+			else if (m_not_linked_slot_mask & slot_id)
+			{
+				lnb_param.old_orbital_position = sat.orbital_position;
+			}
 
 			return 0;
 		}
@@ -1293,6 +1299,7 @@ RESULT eDVBSatelliteEquipmentControl::addLNB()
 	lnb.m_slot_mask = 0;
 	lnb.m_prio = -1; // auto
 	lnb.m_advanced_satposdepends = -1;
+	lnb.old_orbital_position = -1;
 	m_lnbidx++;
 	m_lnbs.push_back(lnb);
 	m_curSat = (m_lnbs.end() - 1)->m_satellites.end();

--- a/lib/dvb/sec.h
+++ b/lib/dvb/sec.h
@@ -253,6 +253,7 @@ class eDVBSatelliteLNBParameters
 			m_increased_voltage = false;
 			m_prio = -1;
 			m_advanced_satposdepends = -1;
+			old_orbital_position = -1;
 #endif
 		}
 #ifdef SWIG


### PR DESCRIPTION
We're talking about commands for initializing/moving the motor.
I think they're unnecessary if we know for sure the motor is in the right position.
Currently, when the frontend is closed, the satellite position is reset to -1