### PR TITLE
[python_pmt.i] Replace PyInt_FromLong() with PyLong_FromLong()

### DIFF
--- a/lib/python/python_pmt.i
+++ b/lib/python/python_pmt.i
@@ -21,7 +21,7 @@ PyObject *eDVBServicePMTHandler::getCaIds(bool pair)
 		}
 		else
 		{
-			PyList_SET_ITEM(ret, i, PyInt_FromLong(caids[i]));
+			PyList_SET_ITEM(ret, i, PyLong_FromLong(caids[i]));
 		}
 	}
 


### PR DESCRIPTION
PyInt_FromLong() is deprecated.
http://python3porting.com/cextensions.html