### PR TITLE
[SoftCSA] Restore original recording buffer size to reduce LowMem pre…

### DIFF
--- a/lib/dvb/demux.cpp
+++ b/lib/dvb/demux.cpp
@@ -1121,7 +1121,7 @@ eDVBTSRecorder::eDVBTSRecorder(eDVBDemux *demux, int packetsize, bool streaming,
 		// sync_mode forced if AIO short writes were detected in a previous channel
 		// is_streaming_output=true when target is a socket (streaming encrypted channels)
 		m_thread = new eDVBRecordScrambledThread(packetsize,
-			256*188, s_aio_sync_fallback || sync_mode, is_streaming_output);
+			-1, s_aio_sync_fallback || sync_mode, is_streaming_output);
 	CONNECT(m_thread->m_event, eDVBTSRecorder::filepushEvent);
 }
 


### PR DESCRIPTION
…ssure

The ScrambledThread used a fixed buffer of 256*188 (47 KB) per slot, while the original FileThread default was packetsize*1024 (188 KB). This 4x reduction caused ~4x more write() syscalls, increasing kernel-side allocations (NFS RPC structs, socket buffers, slab objects) in the DMA/LowMem zone. On heavy recording setups (4+ simultaneous NFS recordings), this contributed to LowMem exhaustion and OOM kills.

Passing -1 restores the default buffer calculation. The descrambling code is unaffected as it iterates 188-byte packets regardless of buffer size.

(cherry picked from commit c9c058fef495eb472b3077ef4035ca02bb47740a) (cherry picked from commit e369fc0c64fa33e9dae334bea3e7253eafa0aedd)