### PR TITLE
ePositionGauge - update pointer position after resize

### DIFF
--- a/lib/gui/epositiongauge.cpp
+++ b/lib/gui/epositiongauge.cpp
@@ -181,6 +181,10 @@ int ePositionGauge::event(int event, void *data, void *data2)
 	}
 	case evtChangedPosition:
 		return 0;
+	case evtChangedSize:
+		eWidget::event(event, data, data2);
+		updatePosition();
+		return 0;
 	default:
 		return eWidget::event(event, data, data2);
 	}


### PR DESCRIPTION
- pointer position is calculated when pointer is set, before final widget size may be applied by skin. This can leave pointer vertically misaligned and partially clipped, e.g. only lower half being visible when no playback is active.

Recalculate the pointer position on evtChangedSize so it is correctly positioned once widget has its final size.