### PR TITLE
ePositionGauge - add hidePointerOnZeroLength skin parameter

### DIFF
--- a/lib/gui/epositiongauge.cpp
+++ b/lib/gui/epositiongauge.cpp
@@ -13,6 +13,7 @@ ePositionGauge::ePositionGauge(eWidget *parent)
 	m_length = 0;
 	m_have_foreground_color = 0;
 	m_seek_position = 0;
+	m_hidePointerOnZeroLength = 0;
 }
 
 ePositionGauge::~ePositionGauge()
@@ -26,6 +27,15 @@ void ePositionGauge::setLength(const pts_t &len)
 	if (m_length == len)
 		return;
 	m_length = len;
+
+	if (m_hidePointerOnZeroLength)
+	{
+		if (m_length)
+			m_point_widget->show();
+		else
+			m_point_widget->hide();
+	}
+
 	updatePosition();
 	invalidate();
 }
@@ -188,6 +198,16 @@ int ePositionGauge::event(int event, void *data, void *data2)
 	default:
 		return eWidget::event(event, data, data2);
 	}
+}
+
+void ePositionGauge::setHidePointerOnZeroLength(int hide)
+{
+	m_hidePointerOnZeroLength = hide;
+
+	if (m_hidePointerOnZeroLength && !m_length)
+		m_point_widget->hide();
+	else
+		m_point_widget->show();
 }
 
 void ePositionGauge::updatePosition()

--- a/lib/gui/epositiongauge.h
+++ b/lib/gui/epositiongauge.h
@@ -26,6 +26,8 @@ public:
 	void enableSeekPointer(int enable);
 	void setSeekPosition(const pts_t &pos);
 
+	void setHidePointerOnZeroLength(int hide);
+
 #ifndef SWIG
 protected:
 	int event(int event, void *data=0, void *data2=0);
@@ -62,6 +64,8 @@ private:
 
 	int m_have_foreground_color;
 	gRGB m_foreground_color;
+
+	int m_hidePointerOnZeroLength;
 #endif
 };
 

--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -776,6 +776,9 @@ class AttributeParser:
 		ptr = loadPixmap(name, self.desktop)
 		self.guiObject.setPointer(1, ptr, pos)
 
+	def hidePointerOnZeroLength(self, value):
+		self.guiObject.setHidePointerOnZeroLength(int(parseBoolean("hidePointerOnZeroLength", value)))
+
 	def shadowOffset(self, value):
 		self.guiObject.setShadowOffset(parsePosition(value, self.scaleTuple))
 


### PR DESCRIPTION
- add hidePointerOnZeroLength skin parameter to hide pointer when playback length is zero.
- default behavior remains unchanged for backward compatibility.